### PR TITLE
fix: parse to correct data type for nested body parameter

### DIFF
--- a/lib/commands/smapi/cli-customization-processor.js
+++ b/lib/commands/smapi/cli-customization-processor.js
@@ -62,7 +62,7 @@ class CliCustomizationProcessor {
 
     _processNonBodyParameter(parameter, parentOperation, definitions) {
         let customizedParameter = { ...parameter };
-        const isArray = parameter.type === 'array';
+        const { type } = parameter;
         let enumOptions = parameter.enum;
         let { description } = parameter;
         if (parameter.items && parameter.items.$ref) {
@@ -71,7 +71,7 @@ class CliCustomizationProcessor {
             enumOptions = enumValue.enumOptions;
             description = enumValue.description;
         }
-        customizedParameter = { ...customizedParameter, description, isArray, enum: enumOptions };
+        customizedParameter = { ...customizedParameter, description, type, enum: enumOptions };
         this._addCustomizedParameter(parentOperation.customizationMetadata, customizedParameter);
     }
 
@@ -82,6 +82,15 @@ class CliCustomizationProcessor {
     }
 
     _addCustomizedParameter(customizationMetadata, customizedParameter) {
+        const isArray = customizedParameter.type === 'array';
+        const isNumber = ['number', 'integer'].includes(customizedParameter.type);
+        const isBoolean = customizedParameter.type === 'boolean';
+        const flags = { isArray, isNumber, isBoolean };
+        Object.keys(flags).forEach(key => {
+            if (flags[key]) {
+                customizedParameter[key] = true;
+            }
+        });
         customizationMetadata.flatParamsMap.set(camelCase(customizedParameter.name), customizedParameter);
     }
 
@@ -101,6 +110,7 @@ class CliCustomizationProcessor {
         Object.keys(secondLevelDefinition.properties || []).forEach(key => {
             const property = secondLevelDefinition.properties[key];
             let enumOptions = null;
+            const { type } = property;
             let description = property.description || parentDescription;
             if (property.$ref) {
                 const schema = this._getDefinitionSchema(property.$ref, definitions);
@@ -112,12 +122,13 @@ class CliCustomizationProcessor {
             }
             const json = this._shouldParseAsJson(property);
             const bodyPath = `${parentName}${BODY_PATH_DELIMITER}${key}`;
-            customizedParameter = { name: `${parentName} ${key}`, description, rootName, required, bodyPath, enum: enumOptions, json };
+            customizedParameter = { name: `${parentName} ${key}`, description, rootName, required, bodyPath, enum: enumOptions, json, type };
             this._addCustomizedParameter(customizationMetadata, customizedParameter);
         });
         if (secondLevelDefinition.enum) {
+            const { type } = secondLevelDefinition;
             const { description, enumOptions } = this._mapEnum(parentDescription, secondLevelDefinition);
-            customizedParameter = { name: parentName, description, rootName, required, bodyPath: parentName, enum: enumOptions };
+            customizedParameter = { name: parentName, description, rootName, required, bodyPath: parentName, enum: enumOptions, type };
             this._addCustomizedParameter(customizationMetadata, customizedParameter);
         }
     }
@@ -133,10 +144,10 @@ class CliCustomizationProcessor {
                 const isRequired = required.includes(key);
                 this._appendSecondLevelProperty(customizationMetadata, key, rootName, secondLevelDefinition, isRequired, definitions);
             } else {
-                const { description } = property;
+                const { description, type } = property;
                 const json = this._shouldParseAsJson(property);
                 // required inherited from parent param
-                const customizedParameter = { name: key, description, rootName, required: param.required, bodyPath: key, json };
+                const customizedParameter = { name: key, description, rootName, required: param.required, bodyPath: key, json, type };
                 this._addCustomizedParameter(customizationMetadata, customizedParameter);
             }
         });

--- a/lib/commands/smapi/smapi-command-handler.js
+++ b/lib/commands/smapi/smapi-command-handler.js
@@ -36,7 +36,10 @@ const _mapToParams = (optionsValues, flatParamsMap, commanderToApiCustomizationM
         const apiName = commanderToApiCustomizationMap.get(key) || key;
         const param = flatParamsMap.get(apiName);
         if (param) {
-            const value = param.isArray ? optionsValues[key].split(ARRAY_SPLIT_DELIMITER) : optionsValues[key];
+            let value = optionsValues[key];
+            value = param.isArray ? value.split(ARRAY_SPLIT_DELIMITER) : value;
+            value = param.isNumber ? Number(value) : value;
+            value = param.isBoolean ? Boolean(value) : value;
             if (param.rootName) {
                 if (!res[param.rootName]) {
                     res[param.rootName] = {};

--- a/lib/commands/smapi/smapi-command-handler.js
+++ b/lib/commands/smapi/smapi-command-handler.js
@@ -1,6 +1,7 @@
 const { StandardSmapiClientBuilder } = require('ask-smapi-sdk');
 const os = require('os');
 const path = require('path');
+const R = require('ramda');
 
 const AppConfig = require('@src/model/app-config');
 const AuthorizationController = require('@src/controllers/authorization-controller');
@@ -47,7 +48,7 @@ const _mapToParams = (optionsValues, flatParamsMap, commanderToApiCustomizationM
                 let mergeObject = {};
                 mergeObject[param.bodyPath] = value;
                 mergeObject = unflatten(mergeObject, BODY_PATH_DELIMITER);
-                Object.assign(res[param.rootName], mergeObject);
+                res[param.rootName] = R.mergeDeepRight(res[param.rootName], mergeObject);
             } else if (param.json) {
                 res[param.name] = JSON.parse(value);
             } else {

--- a/test/unit/commands/smapi/cli-customization-processor-test.js
+++ b/test/unit/commands/smapi/cli-customization-processor-test.js
@@ -34,9 +34,9 @@ describe('Smapi test - CliCustomizationProcessor class', () => {
     const bodyPropertyTwoName = 'propertyTwo';
     const nestedPropertyName = 'nestedProperty';
     const nestedEnumPropertyName = 'nestedEnumProperty';
-    const bodyProperty = {};
+    const bodyProperty = { type: 'number' };
     const bodyPropertyWithArray = { type: 'array', items: { $ref: 'test' } };
-    const bodyPropertyWithDescription = { description: 'property description' };
+    const bodyPropertyWithDescription = { description: 'property description', type: 'boolean' };
     const nestedProperty = { $ref: 'SomeObjectType' };
     const nestedEnumProperty = { $ref: 'SomeEnumTypeWithDescription' };
     let processor;
@@ -97,7 +97,7 @@ describe('Smapi test - CliCustomizationProcessor class', () => {
             const key = camelCase(parameter.name);
             const { flatParamsMap } = parentOperation.customizationMetadata;
 
-            const expected = { ...parameter, enum: undefined, isArray: false };
+            const expected = { ...parameter, enum: undefined };
             expect(flatParamsMap.get(key)).eql(expected);
         });
 
@@ -162,7 +162,8 @@ describe('Smapi test - CliCustomizationProcessor class', () => {
                 rootName,
                 bodyPath: bodyPropertyTwoName,
                 name: bodyPropertyTwoName,
-                json: false };
+                json: false,
+                isBoolean: true };
             expect(flatParamsMap.get(bodyPropertyTwoName)).eql(expected);
         });
 
@@ -206,14 +207,22 @@ describe('Smapi test - CliCustomizationProcessor class', () => {
             const { flatParamsMap } = parentOperation.customizationMetadata;
             let { name, bodyPath, key } = mapExpectedParams(nestedPropertyName, bodyPropertyOneName);
 
-            let expected = { description: parentDescription, name, rootName, bodyPath, required: true, enum: null, json: false };
+            let expected = { description: parentDescription,
+                name,
+                rootName,
+                bodyPath,
+                required: true,
+                enum: null,
+                json: false,
+                isNumber: true,
+                type: 'number' };
             expect(flatParamsMap.get(key)).eql(expected);
 
             const expectedParams = mapExpectedParams(nestedPropertyName, bodyPropertyTwoName);
             name = expectedParams.name;
             bodyPath = expectedParams.bodyPath;
             key = expectedParams.key;
-            expected = { ...bodyPropertyWithDescription, name, rootName, bodyPath, required: true, enum: null, json: false };
+            expected = { ...bodyPropertyWithDescription, name, rootName, bodyPath, required: true, enum: null, json: false, isBoolean: true };
 
             expect(flatParamsMap.get(key)).eql(expected);
         });
@@ -244,7 +253,7 @@ describe('Smapi test - CliCustomizationProcessor class', () => {
             const name = nestedEnumPropertyName;
             const bodyPath = nestedEnumPropertyName;
 
-            const expected = { ...bodyProperty, name, rootName, bodyPath, required: false, enum: enumValues, description: enumDescription };
+            const expected = { ...bodyProperty, name, rootName, bodyPath, required: false, enum: enumValues, description: enumDescription, type: undefined };
             expect(flatParamsMap.get(nestedEnumPropertyName)).eql(expected);
         });
     });

--- a/test/unit/commands/smapi/smapi-command-handler-test.js
+++ b/test/unit/commands/smapi/smapi-command-handler-test.js
@@ -14,35 +14,28 @@ const smapiCommandHandler = require('@src/commands/smapi/smapi-command-handler')
 describe('Smapi test - smapiCommandHandler function', () => {
     const apiOperationName = 'someApiOperation';
     const skillId = 'some skill id';
-    const inputContent = 'hello';
-    const deviceLocale = 'en-US';
+    const someNumber = '20';
+    const someBoolean = 'true';
     const jsonValue = { test: 'test' };
     const arrayValue = ['test', 'test1', 'test2'];
     const arrayValueStr = arrayValue.join(ARRAY_SPLIT_DELIMITER);
 
-    const params = [
-        { name: 'skillId', in: 'path' },
-        { name: 'someNonPopulatedProperty', in: 'query' },
-        { name: 'simulationsApiRequest', in: 'body' },
-        { name: 'someJson', in: 'body' },
-        { name: 'someArray', in: 'query' }
-    ];
     const flatParamsMap = new Map([
         ['skillId', { name: 'skillId' }],
         ['someJson', { name: 'someJson', json: true }],
         ['someArray', { name: 'someArray', isArray: true }],
-        ['inputContent', { rootName: 'simulationsApiRequest', bodyPath: 'input>>>content' }],
-        ['deviceLocale', { rootName: 'simulationsApiRequest', bodyPath: 'device>>>locale' }],
+        ['someNumber', { rootName: 'simulationsApiRequest', bodyPath: 'input>>>someNumber', isNumber: true }],
+        ['someBoolean', { rootName: 'simulationsApiRequest', bodyPath: 'device>>>someBoolean', isBoolean: true }],
         ['sessionMode', { rootName: 'simulationsApiRequest', bodyPath: 'session>>>mode' }]]);
 
     const commanderToApiCustomizationMap = new Map();
     const cmdObj = {
         opts() {
-            return { skillId, inputContent, deviceLocale, someJson: JSON.stringify(jsonValue), someArray: arrayValueStr };
+            return { skillId, someNumber, someBoolean, someJson: JSON.stringify(jsonValue), someArray: arrayValueStr };
         }
     };
 
-    const clientStub = {};
+    const clientStub = { apiConfiguration: { apiEndpoint: null } };
     beforeEach(() => {
         sinon.stub(AuthorizationController.prototype, '_getAuthClientInstance').returns(
             { config: {} }
@@ -65,7 +58,8 @@ describe('Smapi test - smapiCommandHandler function', () => {
     it('| should send smapi command with correct parameter mapping', async () => {
         await smapiCommandHandler(apiOperationName, flatParamsMap, commanderToApiCustomizationMap, cmdObj);
 
-        const expectedParams = [jsonValue, skillId, null, arrayValue, { input: { content: inputContent }, device: { locale: deviceLocale } }];
+        const expectedParams = [jsonValue, skillId, null, arrayValue,
+            { input: { someNumber: Number(someNumber) }, device: { someBoolean: Boolean(someBoolean) } }];
         const calledParams = clientStub[apiOperationName].args[0];
 
         expect(calledParams).eql(expectedParams);

--- a/test/unit/commands/smapi/smapi-command-handler-test.js
+++ b/test/unit/commands/smapi/smapi-command-handler-test.js
@@ -25,7 +25,7 @@ describe('Smapi test - smapiCommandHandler function', () => {
         ['someJson', { name: 'someJson', json: true }],
         ['someArray', { name: 'someArray', isArray: true }],
         ['someNumber', { rootName: 'simulationsApiRequest', bodyPath: 'input>>>someNumber', isNumber: true }],
-        ['someBoolean', { rootName: 'simulationsApiRequest', bodyPath: 'device>>>someBoolean', isBoolean: true }],
+        ['someBoolean', { rootName: 'simulationsApiRequest', bodyPath: 'input>>>someBoolean', isBoolean: true }],
         ['sessionMode', { rootName: 'simulationsApiRequest', bodyPath: 'session>>>mode' }]]);
 
     const commanderToApiCustomizationMap = new Map();
@@ -59,7 +59,7 @@ describe('Smapi test - smapiCommandHandler function', () => {
         await smapiCommandHandler(apiOperationName, flatParamsMap, commanderToApiCustomizationMap, cmdObj);
 
         const expectedParams = [jsonValue, skillId, null, arrayValue,
-            { input: { someNumber: Number(someNumber) }, device: { someBoolean: Boolean(someBoolean) } }];
+            { input: { someNumber: Number(someNumber), someBoolean: Boolean(someBoolean) } }];
         const calledParams = clientStub[apiOperationName].args[0];
 
         expect(calledParams).eql(expectedParams);

--- a/test/unit/commands/smapi/smapi-commander-test.js
+++ b/test/unit/commands/smapi/smapi-commander-test.js
@@ -3,7 +3,7 @@ const sinon = require('sinon');
 const { makeSmapiCommander } = require('@src/commands/smapi/smapi-commander');
 
 
-describe('Smapi test - makeSmapiCommander function', () => {
+describe.skip('Smapi test - makeSmapiCommander function', () => {
     beforeEach(() => {
         sinon.stub(process, 'exit');
         sinon.stub(console, 'error');

--- a/test/unit/commands/smapi/smapi-commander-test.js
+++ b/test/unit/commands/smapi/smapi-commander-test.js
@@ -3,7 +3,7 @@ const sinon = require('sinon');
 const { makeSmapiCommander } = require('@src/commands/smapi/smapi-commander');
 
 
-describe.skip('Smapi test - makeSmapiCommander function', () => {
+describe('Smapi test - makeSmapiCommander function', () => {
     beforeEach(() => {
         sinon.stub(process, 'exit');
         sinon.stub(console, 'error');


### PR DESCRIPTION
The following commands were failing. 

ask smapi create-content-upload -c amzn1.ask-catalog.cat.c98f84ac-6730-4043-8fa7-19c93447f214 --number-of-upload-parts 1
ask smapi generate-catalog-upload-url -c amzn1.ask-catalog.cat.c98f84ac-6730-4043-8fa7-19c93447f214 --number-of-upload-parts 1

with error: class java.lang.String can not be converted to an Integer

--number-of-upload-parts had to be converted to number before sending to smapi.

this command was failing

ask smapi generate-credentials-for-alexa-hosted-skill -s amzn1.ask.skill.e9ac9d7f-5c4f-4c3b-8e41-1b347f625d95 --repository-url https://git-codecommit.us-east-1.amazonaws.com/v1/repos/e9ac9d7f-5c4f-4c3b-8e41-1b347f625d95 --repository-type GIT

url and type were overwriting each other instead of merging to the same object.


this PR fixes this issues.