### PR TITLE
fix: rename smapi commands version parameter since it was conflicting…

### DIFF
--- a/lib/commands/smapi/customizations/parameters.json
+++ b/lib/commands/smapi/customizations/parameters.json
@@ -5,6 +5,9 @@
     "vendorId": {
         "skip": true
     },
+    "version": {
+        "name": "vers"
+    },
     "createSkillRequest": {
         "skipUnwrap": true,
         "name": "manifest"


### PR DESCRIPTION
fixing a bug

Before

ask smapi get-interaction-model-catalog-values -c cat --version 20

having --version would simply call global version command which would return 2.0.1, which is ask cli version

After:
rename all version parameters for smapi to be named vers to avoid naming conflict.

`ask smapi get-interaction-model-catalog-values -c cat --vers 20`

this would call actual smapi.

