### PR TITLE
fix: add logic to handle the param which isArray and isJson for smapi commands

### DIFF
--- a/lib/commands/smapi/cli-customization-processor.js
+++ b/lib/commands/smapi/cli-customization-processor.js
@@ -82,7 +82,7 @@ class CliCustomizationProcessor {
     }
 
     _addCustomizedParameter(customizationMetadata, customizedParameter) {
-        const isArray = customizedParameter.type === 'array';
+        const isArray = customizedParameter.type === 'array' && !customizedParameter.json; // the array of object is treated as json type
         const isNumber = ['number', 'integer'].includes(customizedParameter.type);
         const isBoolean = customizedParameter.type === 'boolean';
         const flags = { isArray, isNumber, isBoolean };


### PR DESCRIPTION
Currently json and isArray can be applied together on a param like the example shown below:
```
$ ask smapi complete-catalog-upload -h
Usage: ask smapi complete-catalog-upload [options]

Completes an upload. To be called after the file is uploaded to the backend data store using presigned url(s).

Options:
  -c,--catalog-id <catalog-id>  [REQUIRED] Unique identifier of the catalog
  --upload-id <upload-id>       [REQUIRED] Unique identifier of the upload
  --part-e-tags <part-e-tags>   [REQUIRED] List of (eTag, part number) pairs for each part of the file uploaded.
                                [MULTIPLE]: Values can be separated by comma.
                                [JSON]
  -p, --profile <profile>       The ASK CLI profile to use. When you don't include this option, ASK CLI uses the default profile.
  --debug                       When you include this option, ASK CLI shows debug messages in the output of the command.
  -h, --help                    output usage information
```

The part-e-tags option is a JSON not MULTIPLE. This commit fixes it.