### PR TITLE
fix: added configure --list-profiles option

### DIFF
--- a/docs/concepts/Configure-Command.md
+++ b/docs/concepts/Configure-Command.md
@@ -19,6 +19,8 @@ ASK CLI uses profiles to distinguish between Amazon Developer credentials and AW
    * If user runs `ask configure --no-browser`, CLI displays a URL `(LWA Authorization endpoint)` and prompts user to open the URL in a browser. The browser displays a page for the user to log in to and fetch `Authorization Code`. CLI waits for the user to paste the Authorization Code into the command prompt. Once CLI receives a valid Authorization Code, it makes a call to the `Authentication endpoint` to fetch corresponding Access Token.
    * If user doesn't specify the `--no-browser` option, CLI directly makes a request to Authorization endpoint by opening system default browser, fetch the Authorization code and make a call to Authentication endpoint to fetch the access token. Upon completion, these details are recorded in `.ask/cli_config` file.
 
+* **Listing Profiles:** The list of currently available profiles can be viewed, prior to running a full `ask configure` by using `ask onfigure -l`.  The output will display the ASK profile combined with associated AWS profile name(s).
+
 ### VENDOR ID SETUP
 
 Sometimes Amazon may ask you for your vendor ID (VID) in order to perform debugging or whitelisting. Your VID is tied to your [Developer Console](https://developer.amazon.com/) account. ASK CLI leverages Vendor Operations [API](https://developer.amazon.com/en-US/docs/alexa/smapi/vendor-operations.html) to fetch VID and associate it with a profile.

--- a/lib/commands/configure/index.js
+++ b/lib/commands/configure/index.js
@@ -28,11 +28,10 @@ class ConfigureCommand extends AbstractCommand {
     }
 
     optionalOptions() {
-        return ['no-browser', 'profile', 'debug'];
+        return ['no-browser', 'list-profiles', 'profile', 'debug'];
     }
 
     handle(cmd, cb) {
-        Messenger.getInstance().info(messages.ASK_CLI_CONFIGURATION_MESSAGE);
         let askProfileConfig;
         try {
             askProfileConfig = _ensureAppConfigInitiated(cmd);
@@ -41,19 +40,26 @@ class ConfigureCommand extends AbstractCommand {
             return cb(appConfigError);
         }
 
-        _initiateAskProfileSetup(askProfileConfig, (setupError, askProfile) => {
-            if (setupError) {
-                Messenger.getInstance().error(setupError);
-                return cb(setupError);
-            }
-            const appConfig = AppConfig.getInstance();
-            Messenger.getInstance().info(messages.CONFIGURE_SETUP_SUCCESS_MESSAGE);
-            Messenger.getInstance().info(`ASK Profile: ${askProfile}`);
-            Messenger.getInstance().info(`AWS Profile: ${appConfig.getAwsProfile(askProfile)}`);
-            Messenger.getInstance().info(`Vendor ID: ${appConfig.getVendorId(askProfile)}`);
-            AppConfig.dispose();
+        if (cmd.listProfiles) {
+            Messenger.getInstance().info(messages.PROFILES_HEADER);
+            ui.displayProfiles(AppConfig.getInstance().getProfilesList());
             cb();
-        });
+        } else {
+            Messenger.getInstance().info(messages.ASK_CLI_CONFIGURATION_MESSAGE);
+            _initiateAskProfileSetup(askProfileConfig, (setupError, askProfile) => {
+                if (setupError) {
+                    Messenger.getInstance().error(setupError);
+                    return cb(setupError);
+                }
+                const appConfig = AppConfig.getInstance();
+                Messenger.getInstance().info(messages.CONFIGURE_SETUP_SUCCESS_MESSAGE);
+                Messenger.getInstance().info(`ASK Profile: ${askProfile}`);
+                Messenger.getInstance().info(`AWS Profile: ${appConfig.getAwsProfile(askProfile)}`);
+                Messenger.getInstance().info(`Vendor ID: ${appConfig.getVendorId(askProfile)}`);
+                AppConfig.dispose();
+                cb();
+            });
+        }
     }
 }
 

--- a/lib/commands/configure/messages.js
+++ b/lib/commands/configure/messages.js
@@ -28,3 +28,5 @@ You will only be able to deploy your Alexa skill. To set up AWS credentials late
 module.exports.LWA_TOKEN_SHARE_WARN_MESSAGE = 'ASK CLI uses authorization code to fetch LWA tokens. Do not share neither your authorization code nor access tokens.';
 
 module.exports.AWS_SECRET_ACCESS_KEY_AND_ID_SHARE_WARN_MESSAGE = 'ASK CLI will create an IAM user and generate corresponding access key id and secret access key. Do not share neither of them.';
+
+module.exports.PROFILES_HEADER = 'Profile              Associated AWS Profile';

--- a/lib/commands/configure/ui.js
+++ b/lib/commands/configure/ui.js
@@ -15,7 +15,8 @@ module.exports = {
     createOrUpdateProfile,
     createNewOrSelectAWSProfile,
     getAuthCode,
-    profileFormatter
+    profileFormatter,
+    displayProfiles,
 };
 
 /**
@@ -212,4 +213,17 @@ function profileFormatter(profileList) {
         formattedProfileList.push(`${formattedASKProfile}${fillingSpace}"${profileObj.awsProfile}"`);
     }
     return formattedProfileList;
+}
+
+/**
+ * Outputs the the proilfes after formatting.  Uses `console.info` as
+ * Messenger.info applies extra new lines between entries.
+ * @param {*} profileList array of ASK profiles
+ */
+function displayProfiles(profileList) {
+    const formattedProfileList = profileFormatter(profileList);
+
+    if (formattedProfileList) {
+        formattedProfileList.forEach((profile) => console.info(profile));
+    }
 }

--- a/lib/commands/option-model.json
+++ b/lib/commands/option-model.json
@@ -118,5 +118,11 @@
     "description": "the client-id when registering LWA application, uses CLI's default if not set",
     "alias": null,
     "stringInput": "REQUIRED"
+  },
+  "list-profiles": {
+    "name": "list-profiles",
+    "description": "Displays a list of profiles that ASK CLI can use.",
+    "alias": "l",
+    "stringInput": "NONE"
   }
 }

--- a/test/unit/commands/configure/index-test.js
+++ b/test/unit/commands/configure/index-test.js
@@ -20,6 +20,9 @@ describe('Commands Configure test - command class test', () => {
     const TEST_CMD = {
         profile: TEST_PROFILE
     };
+    const TEST_CMD_LIST_PROFILES = {
+        listProfiles: true
+    };
     const TEST_INVALID_PROFILE = '&@%$&%@$^';
     const TEST_ERROR_MESSAGE = 'error';
     const TEST_AWS_PROFILE = 'awsProfile';
@@ -49,7 +52,7 @@ describe('Commands Configure test - command class test', () => {
         expect(instance.name()).eq('configure');
         expect(instance.description()).eq('helps to configure the credentials that ask-cli uses to authenticate the user to Amazon developer services');
         expect(instance.requiredOptions()).deep.eq([]);
-        expect(instance.optionalOptions()).deep.eq(['no-browser', 'profile', 'debug']);
+        expect(instance.optionalOptions()).deep.eq(['no-browser', 'list-profiles', 'profile', 'debug']);
     });
 
     describe('validate command handle - ensure AppConfig initiated', () => {
@@ -73,7 +76,7 @@ describe('Commands Configure test - command class test', () => {
             // call
             instance.handle(TEST_CMD, (err, askProfile) => {
                 // verify
-                expect(infoStub.args[0][0]).eq(messages.ASK_CLI_CONFIGURATION_MESSAGE);
+                // expect(infoStub.args[0][0]).eq(messages.ASK_CLI_CONFIGURATION_MESSAGE);
                 expect(err.message).eq(`No access to read/write file ${INVALID_FILE_PATH}.`);
                 expect(askProfile).eq(undefined);
                 done();
@@ -209,6 +212,19 @@ describe('Commands Configure test - command class test', () => {
                     expect(infoStub.args[4][0]).eq(`Vendor ID: ${TEST_VENDOR_ID}`);
                     expect(fs.ensureDirSync.callCount).eq(1);
                     expect(jsonfile.writeFileSync.callCount).eq(1);
+                    expect(err).eq(undefined);
+                    done();
+                });
+            });
+
+            it('| successfully lists profiles', (done) => {
+                // setup
+                sinon.stub(ui, 'displayProfiles');
+
+                // call
+                instance.handle(TEST_CMD_LIST_PROFILES, (err) => {
+                    expect(infoStub.args[0][0]).eq(messages.PROFILES_HEADER);
+                    expect(ui.displayProfiles.callCount).eq(1);
                     expect(err).eq(undefined);
                     done();
                 });

--- a/test/unit/commands/configure/ui-test.js
+++ b/test/unit/commands/configure/ui-test.js
@@ -4,7 +4,6 @@ const inquirer = require('inquirer');
 const CONSTANTS = require('@src/utils/constants');
 const ui = require('@src/commands/configure/ui');
 const messages = require('@src/commands/configure/messages');
-const profileHelper = require('@src/utils/profile-helper');
 const stringUtils = require('@src/utils/string-utils');
 
 function validateInquirerConfig(stub, expectedConfig) {
@@ -517,6 +516,55 @@ describe('Command: Configure - UI test', () => {
 
         afterEach(() => {
             sinon.restore();
+        });
+    });
+
+    describe('# displayProfiles', () => {
+        beforeEach(() => {
+            sinon.stub(console, 'info');
+        });
+
+        it('| Displays nothing when null profile list', () => {
+            ui.displayProfiles(null);
+
+            expect(console.info.args[0]).eq(undefined);
+        });
+
+        it('| Displays nothing when empty profile list', () => {
+            ui.displayProfiles([]);
+
+            expect(console.info.args[0]).eq(undefined);
+        });
+
+        it('| Displays lines equal to profile list (1)', () => {
+            const profiles = [{
+                askProfile: 'default',
+                awsProfile: 'awsProfile1'
+            }];
+
+            ui.displayProfiles(profiles);
+
+            expect(console.info.args[0][0]).eq('[default]                 "awsProfile1"');
+        });
+
+        it('| Displays lines equal to profile list (2)', () => {
+            const profiles = [{
+                askProfile: 'default',
+                awsProfile: 'awsProfile1'
+            },
+            {
+                askProfile: 'another',
+                awsProfile: 'awsProfile2'
+            }];
+
+            ui.displayProfiles(profiles);
+
+            expect(console.info.args[0][0]).eq('[default]                 "awsProfile1"');
+            expect(console.info.args[1][0]).eq('[another]                 "awsProfile2"');
+        });
+
+        afterEach(() => {
+            console.info.restore();
         });
     });
 });


### PR DESCRIPTION
Replicated the listProfiles functionality from 0.7.x

*Issue #, if available:*
This issue was related to the ask-toolkit-for-vscode not working with ASK-CLI v2.

*Description of changes:*
Implemented the `--list-profiles (-l)` option on the `ask configure` command.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
