### PR TITLE
feat: can use specific s3 bucket to deploy the alexa backend by using cfn-deployer

### DIFF
--- a/lib/builtins/deploy-delegates/cfn-deployer/helper.js
+++ b/lib/builtins/deploy-delegates/cfn-deployer/helper.js
@@ -1,5 +1,6 @@
 const R = require('ramda');
 const fs = require('fs');
+const path = require('path');
 
 const CloudformationClient = require('@src/clients/aws-client/cloudformation-client');
 const S3Client = require('@src/clients/aws-client/s3-client');
@@ -17,6 +18,7 @@ module.exports = {
     getAwsInformation,
     uploadArtifacts,
     deployStack,
+    getS3BucketKey,
 };
 
 function getS3BucketName(awsProfile, awsRegion, userConfig, deployState) {
@@ -24,6 +26,12 @@ function getS3BucketName(awsProfile, awsRegion, userConfig, deployState) {
     if (currentBucketName) return currentBucketName;
     if (userConfig.deploymentBucket) return userConfig.deploymentBucket;
     return S3Client.generateBucketName(awsProfile, awsRegion);
+}
+
+function getS3BucketKey(userConfig, code) {
+    if (userConfig.deploymentBucketKey) return userConfig.deploymentBucketKey;
+    const bucketKey = `endpoint/${path.basename(code.codeBuild)}`;
+    return bucketKey;
 }
 
 function getAwsInformation(awsProfile, alexaRegion, userConfig, deployState) {
@@ -41,13 +49,13 @@ function getAwsInformation(awsProfile, alexaRegion, userConfig, deployState) {
 
     const bucketName = getS3BucketName(awsProfile, awsRegion, userConfig, deployState);
     const bucketObjectVersion = R.view(R.lensPath(['s3', 'objectVersion']), deployState);
-
     return { awsRegion, templatePath, bucketName, bucketObjectVersion };
 }
 
 
 function uploadArtifacts(reporter, options, callback) {
     const { awsProfile, awsRegion, bucketName, bucketKey, bucketObjectVersion, artifactFilePath, isCodeModified } = options;
+
     if (isCodeModified === false) {
         reporter.updateStatus('No change on the code and skip the code s3 upload process.');
         return process.nextTick(() => {

--- a/lib/builtins/deploy-delegates/cfn-deployer/helper.js
+++ b/lib/builtins/deploy-delegates/cfn-deployer/helper.js
@@ -19,6 +19,13 @@ module.exports = {
     deployStack,
 };
 
+function getS3BucketName(awsProfile, awsRegion, userConfig, deployState) {
+    const currentBucketName = R.view(R.lensPath(['s3', 'bucket']), deployState);
+    if (currentBucketName) return currentBucketName;
+    if (userConfig.deploymentBucket) return userConfig.deploymentBucket;
+    return S3Client.generateBucketName(awsProfile, awsRegion);
+}
+
 function getAwsInformation(awsProfile, alexaRegion, userConfig, deployState) {
     let awsRegion = alexaRegion === 'default' ? userConfig.awsRegion
         : R.view(R.lensPath(['regionalOverrides', alexaRegion, 'awsRegion']), userConfig);
@@ -32,7 +39,7 @@ function getAwsInformation(awsProfile, alexaRegion, userConfig, deployState) {
         throw 'The template path in userConfig must be provided.';
     }
 
-    const bucketName = R.view(R.lensPath(['s3', 'bucket']), deployState) || S3Client.generateBucketName(awsProfile, awsRegion);
+    const bucketName = getS3BucketName(awsProfile, awsRegion, userConfig, deployState);
     const bucketObjectVersion = R.view(R.lensPath(['s3', 'objectVersion']), deployState);
 
     return { awsRegion, templatePath, bucketName, bucketObjectVersion };

--- a/lib/builtins/deploy-delegates/cfn-deployer/index.js
+++ b/lib/builtins/deploy-delegates/cfn-deployer/index.js
@@ -58,7 +58,8 @@ function invoke(reporter, options, callback) {
     try {
         const { awsRegion, templatePath, bucketName, bucketObjectVersion } = helper
             .getAwsInformation(awsProfile, alexaRegion, userConfig, currentRegionDeployState);
-        const bucketKey = `endpoint/${path.basename(code.codeBuild)}`;
+        const bucketKey = helper.getS3BucketKey(userConfig, code);
+
         uploadArtifactsConfig = {
             awsProfile,
             awsRegion,

--- a/test/unit/builtins/cfn-deployer/helper-test.js
+++ b/test/unit/builtins/cfn-deployer/helper-test.js
@@ -1,9 +1,4 @@
-/*
-====== start
-{"awsProfile":"hide-dev","alexaRegion":"default","userConfig":{"runtime":"nodejs10.x","handler":"index.handler","templatePath":"./infrastructure/cfn-deployer/skill-stack.yaml","awsRegion":"us-east-1"},"deployState":{}}
-{"awsRegion":"us-east-1","templatePath":"./infrastructure/cfn-deployer/skill-stack.yaml","bucketName":"ask-withrouter-hide-dev-useast1-1587380830650"}
-====== end
-*/
+
 const { expect } = require('chai');
 const helpers = require('@src/builtins/deploy-delegates/cfn-deployer/helper')
 

--- a/test/unit/builtins/cfn-deployer/helper-test.js
+++ b/test/unit/builtins/cfn-deployer/helper-test.js
@@ -1,0 +1,39 @@
+/*
+====== start
+{"awsProfile":"hide-dev","alexaRegion":"default","userConfig":{"runtime":"nodejs10.x","handler":"index.handler","templatePath":"./infrastructure/cfn-deployer/skill-stack.yaml","awsRegion":"us-east-1"},"deployState":{}}
+{"awsRegion":"us-east-1","templatePath":"./infrastructure/cfn-deployer/skill-stack.yaml","bucketName":"ask-withrouter-hide-dev-useast1-1587380830650"}
+====== end
+*/
+const { expect } = require('chai');
+const helpers = require('@src/builtins/deploy-delegates/cfn-deployer/helper')
+
+describe('Builtins test - cfn-deployer helper.js test', () => {
+    describe('# test class method: getAwsInformation', () => {
+        it('| return basic aws resource informations', () => {
+            const result = helpers.getAwsInformation("default", "default", {
+                runtime: "nodejs10.x",
+                handler: "index.handler",
+                templatePath: "./infrastructure/cfn-deployer/skill-stack.yaml",
+                awsRegion: "us-east-1",
+            })
+            expect(result.awsRegion).equal('us-east-1')
+            expect(result.bucketObjectVersion).equal(undefined)              
+            expect(result.templatePath).equal("./infrastructure/cfn-deployer/skill-stack.yaml")
+            expect(result.bucketName).match(/^ask/)
+            expect(result.bucketName).match(/default/)
+        })
+        it('| return custom S3 bucket name when given userconfig props', () => {
+            const result = helpers.getAwsInformation("default", "default", {
+                runtime: "nodejs10.x",
+                handler: "index.handler",
+                templatePath: "./infrastructure/cfn-deployer/skill-stack.yaml",
+                awsRegion: "us-east-1",
+                deploymentBucket: "example-bucket-name"
+            })
+            expect(result.awsRegion).equal('us-east-1')
+            expect(result.bucketObjectVersion).equal(undefined)              
+            expect(result.templatePath).equal("./infrastructure/cfn-deployer/skill-stack.yaml")
+            expect(result.bucketName).equal("example-bucket-name")
+        })
+    })
+})

--- a/test/unit/run-test.js
+++ b/test/unit/run-test.js
@@ -10,6 +10,7 @@ require('module-alias/register');
     // builtins
     '@test/unit/builtins/lambda-deployer/index-test.js',
     '@test/unit/builtins/lambda-deployer/helper-test.js',
+    '@test/unit/builtins/cfn-deployer/helper-test.js',
     // commands
     '@test/unit/commands/option-validator-test',
     '@test/unit/commands/abstract-command-test',


### PR DESCRIPTION
## Expect

Using AWS CloudFormation, we want to use own specific S3 bucket to deploy our stack.

### Example - Serverless Framework
https://serverless.com/framework/docs/providers/aws/guide/serverless.yml/

```
provider:
  name: aws
  runtime: nodejs12.x
  deploymentBucket:
    name: com.serverless.${self:provider.region}.deploys # Deployment bucket name. Default is generated by the framework
```

## Actual

We can not use a specific s3 bucket.
The CLI use only already created bucket or create a new one.

## Description of changes:

On `ask-resources.json`, we want to set own specific S3 bucket name.

```json
{
  "askcliResourcesVersion": "2020-03-31",
  "profiles": {
    "default": {
      "skillMetadata": {
        "src": "./skill-package"
      },
      "code": {
        "default": {
          "src": "./lambda"
        }
      },
      "skillInfrastructure": {
        "userConfig": {
          "runtime": "nodejs10.x",
          "handler": "index.handler",
          "templatePath": "./infrastructure/cfn-deployer/skill-stack.yaml",
          "awsRegion": "us-east-1",
          "deploymentBucket": "example-bucket-name"
        },
        "type": "@ask-cli/cfn-deployer"
      }
    }
  }
}
```

The Pull Request is the patch for the feature and try to add a simple unit test for the function.

Best Regards.
