### PR TITLE
fix: fix when array property was displayed as json property

### DIFF
--- a/lib/commands/smapi/cli-customization-processor.js
+++ b/lib/commands/smapi/cli-customization-processor.js
@@ -99,8 +99,13 @@ class CliCustomizationProcessor {
         return definitions.get(schema);
     }
 
-    _shouldParseAsJson(property) {
-        return property.type === 'object' || (property.type === 'array' && '$ref' in property.items);
+    _shouldParseAsJson(property, definitions) {
+        if (property.type === 'object') return true;
+        if (property.type === 'array' && '$ref' in property.items) {
+            const schema = this._getDefinitionSchema(property.items.$ref, definitions);
+            if (schema.type === 'object') return true;
+        }
+        return false;
     }
 
     _appendSecondLevelProperty(customizationMetadata, parentName, rootName, secondLevelDefinition, required, definitions) {
@@ -120,7 +125,7 @@ class CliCustomizationProcessor {
                 enumOptions = schema.enum;
                 description = schema.description || description;
             }
-            const json = this._shouldParseAsJson(property);
+            const json = this._shouldParseAsJson(property, definitions);
             const bodyPath = `${parentName}${BODY_PATH_DELIMITER}${key}`;
             customizedParameter = { name: `${parentName} ${key}`, description, rootName, required, bodyPath, enum: enumOptions, json, type };
             this._addCustomizedParameter(customizationMetadata, customizedParameter);
@@ -145,7 +150,7 @@ class CliCustomizationProcessor {
                 this._appendSecondLevelProperty(customizationMetadata, key, rootName, secondLevelDefinition, isRequired, definitions);
             } else {
                 const { description, type } = property;
-                const json = this._shouldParseAsJson(property);
+                const json = this._shouldParseAsJson(property, definitions);
                 // required inherited from parent param
                 const customizedParameter = { name: key, description, rootName, required: param.required, bodyPath: key, json, type };
                 this._addCustomizedParameter(customizationMetadata, customizedParameter);

--- a/test/unit/commands/smapi/cli-customization-processor-test.js
+++ b/test/unit/commands/smapi/cli-customization-processor-test.js
@@ -35,7 +35,8 @@ describe('Smapi test - CliCustomizationProcessor class', () => {
     const nestedPropertyName = 'nestedProperty';
     const nestedEnumPropertyName = 'nestedEnumProperty';
     const bodyProperty = { type: 'number' };
-    const bodyPropertyWithArray = { type: 'array', items: { $ref: 'test' } };
+    const bodyPropertyWithSimpleArray = { type: 'array', items: { $ref: '#/definitions/SomeEnumType' } };
+    const bodyPropertyWithComplexArray = { type: 'array', items: { $ref: '#/definitions/SomeSimpleObjectType' } };
     const bodyPropertyWithDescription = { description: 'property description', type: 'boolean' };
     const nestedProperty = { $ref: 'SomeObjectType' };
     const nestedEnumProperty = { $ref: 'SomeEnumTypeWithDescription' };
@@ -57,12 +58,15 @@ describe('Smapi test - CliCustomizationProcessor class', () => {
             ['SomeEnumType', { enum: enumValues }],
             ['SomeEnumTypeWithDescription', { enum: enumValues, description: enumDescription }],
             ['SomeTypeWithDescription', { enum: enumValues, description: refObjectDescription }],
+            ['SomeSimpleObjectType', { type: 'object', properties: {} }],
             ['SomeObjectType', { description: parentDescription,
                 properties: { propertyOne: bodyProperty,
                     propertyTwo: bodyPropertyWithDescription,
                     propertyThree: { $ref: 'SomeEnumType' },
                     propertyFour: { $ref: 'SomeEnumTypeWithDescription' },
-                    propertyFive: bodyPropertyWithArray } }],
+                    propertyFive: bodyPropertyWithSimpleArray,
+                    propertySix: bodyPropertyWithComplexArray,
+                    propertySeven: { type: 'object', properties: { } } } }],
             ['SomeNestedType', { required: [nestedPropertyName],
                 properties: { nestedProperty } }],
             ['SomeTooManyPropertiesType', { properties: { ...objectWithTooManyProperties } }],


### PR DESCRIPTION
fix when array property was displayed as json property

happened when array property is enum.

example:

`ask smapi set-subscription-for-development-events -h`

events should be [MULTIPLE] and not [JSON]