### PR TITLE
fix: add missing subscriptions lwa scope

### DIFF
--- a/lib/utils/constants.js
+++ b/lib/utils/constants.js
@@ -380,11 +380,13 @@ const SCOPES_MODELS_READWRITE = 'alexa::ask:models:readwrite';
 const SCOPES_SKILLS_TEST = 'alexa::ask:skills:test';
 const SCOPES_CATALOG_READ = 'alexa::ask:catalogs:read';
 const SCOPES_CATALOG_READWRITE = 'alexa::ask:catalogs:readwrite';
+const SCOPES_SUBSCRIPTIONS = 'alexa::ask:subscriptions';
 
 module.exports.LWA = {
     S3_RESPONSE_PARSER_URL: 'https://ask-cli-static-content.s3-us-west-2.amazonaws.com/html/ask-cli-no-browser.html',
     DEFAULT_STATE: 'Ask-SkillModel-ReadWrite',
-    DEFAULT_SCOPES: `${SCOPES_SKILLS_READWRITE} ${SCOPES_MODELS_READWRITE} ${SCOPES_SKILLS_TEST} ${SCOPES_CATALOG_READ} ${SCOPES_CATALOG_READWRITE}`,
+    DEFAULT_SCOPES: `${SCOPES_SKILLS_READWRITE} ${SCOPES_MODELS_READWRITE} ${SCOPES_SKILLS_TEST} ${SCOPES_CATALOG_READ}`
+        + ` ${SCOPES_CATALOG_READWRITE} ${SCOPES_SUBSCRIPTIONS}`,
     SIGNIN_URL: 'https://www.amazon.com/ap/signin',
     // Below are the details for the ask-cli's default LWA client which is used internally if another client is not provided by the users.
     // Use of this client outside of the CLI is unauthorized and unsupported by Amazon.


### PR DESCRIPTION
adding missing subscriptions lwa scope.

discovered during writing integration tests.

can be reproduces by

`ask smapi list-subscribers-for-development-events`
should give
[Error]: {
  "message": "User has not consented to this operation."
}

after running 

ask configure this error should disappear.