### PR TITLE
fix: add additional debug output to smapi commands

### DIFF
--- a/bin/ask-smapi.js
+++ b/bin/ask-smapi.js
@@ -11,10 +11,7 @@ if (!process.argv.slice(2).length) {
     commander.outputHelp();
 } else {
     commander.parseAsync(process.argv)
-        .then(response => {
-            const message = response[0] ? jsonView.toString(response[0]) : 'Command executed successfully!';
-            Messenger.getInstance().info(message);
-        })
+        .then(result => Messenger.getInstance().info(result))
         .catch(err => {
             Messenger.getInstance().error(jsonView.toString(err.response));
             process.exit(1);

--- a/lib/commands/smapi/smapi-command-handler.js
+++ b/lib/commands/smapi/smapi-command-handler.js
@@ -60,6 +60,8 @@ const _mapToParams = (optionsValues, flatParamsMap, commanderToApiCustomizationM
     return res;
 };
 
+const _sdkFunctionName = (swaggerApiOperationName) => `call${swaggerApiOperationName.charAt(0).toUpperCase() + swaggerApiOperationName.slice(1)}`;
+
 /**
  * Handles smapi command request
  * @param {string} swaggerApiOperationName Swagger operation name.
@@ -99,11 +101,26 @@ const smapiCommandHandler = (swaggerApiOperationName, flatParamsMap, commanderTo
     if (inputOpts.debug) {
         Messenger.getInstance().info(`Operation: ${swaggerApiOperationName}`);
         Messenger.getInstance().info('Payload:');
-        Messenger.getInstance().info(jsonView.toString(paramsObject));
+        Messenger.getInstance().info(`${jsonView.toString(paramsObject)}\n`);
     }
-    const params = getParamNames(client[swaggerApiOperationName]);
+
+    const functionName = _sdkFunctionName(swaggerApiOperationName);
+    const params = getParamNames(client[functionName]);
     const args = _mapToArgs(params, paramsObject);
-    return client[swaggerApiOperationName](...args);
+
+    return client[functionName](...args)
+        .then(response => {
+            const { body, headers, statusCode } = response;
+            let result = '';
+            if (inputOpts.debug) {
+                Messenger.getInstance().info(`Status code: ${statusCode}`);
+                Messenger.getInstance().info(`Response headers: ${jsonView.toString(headers)}`);
+                Messenger.getInstance().info(`Response body: ${jsonView.toString(body)}`);
+            } else {
+                result = body && Object.keys(body).length ? jsonView.toString(body) : 'Command executed successfully!';
+            }
+            return result;
+        });
 };
 
 module.exports = smapiCommandHandler;


### PR DESCRIPTION
Add additional debug output to smapi command. Added response headers, body and status code.
Example:
`ask smapi create-export-request-for-skill -s amzn1.ask.skill.e9ac9d7f-5c4f-4c3b-8e41-1b347f625d95 -g development --debug`

```
Operation: createExportRequestForSkillV1
Payload:
{
  "skillId": "amzn1.ask.skill.e9ac9d7f-5c4f-4c3b-8e41-1b347f625d95",
  "stage": "development"
}

Status code: 202
Response headers: [
  {
    "key": "content-type",
    "value": "application/json"
  },
  {
    "key": "content-length",
    "value": "2"
  },
  {
    "key": "connection",
    "value": "close"
  },
  {
    "key": "server",
    "value": "Server"
  },
  {
    "key": "date",
    "value": "Tue, 28 Apr 2020 04:06:54 GMT"
  },
  {
    "key": "x-amzn-requestid",
    "value": "36c7742a-4577-47b3-b2ee-31f9e8ff9843"
  },
  {
    "key": "x-amz-date",
    "value": "Tue, 28 Apr 2020 04:06:54 GMT"
  },
  {
    "key": "location",
    "value": "/v1/skills/exports/amzn1.ask-package.export.6ea17097-89d5-48cd-8a3d-9add465afac7"
  },
  {
    "key": "x-amz-rid",
    "value": "AH885JWWQD2NYM0P4611"
  },
  {
    "key": "vary",
    "value": "Accept-Encoding,X-Amzn-CDN-Cache,X-Amzn-AX-Treatment,User-Agent"
  },
  {
    "key": "x-cache",
    "value": "Miss from cloudfront"
  },
  {
    "key": "via",
    "value": "1.1 768a2670e63a97b7ac4065216c345a7a.cloudfront.net (CloudFront)"
  },
  {
    "key": "x-amz-cf-pop",
    "value": "HIO50-C1"
  },
  {
    "key": "x-amz-cf-id",
    "value": "PiYlcnrbz2gp2Ds5XXsenxklCBNKL9XxEAj8kdiPikvUFsfssfZqNQ=="
  }
]
Response body: {}
```
