### PR TITLE
feat: add option to read json from file path

### DIFF
--- a/lib/commands/smapi/smapi-command-handler.js
+++ b/lib/commands/smapi/smapi-command-handler.js
@@ -1,6 +1,7 @@
 const { CustomSmapiClientBuilder } = require('ask-smapi-sdk');
 const os = require('os');
 const path = require('path');
+const fs = require('fs-extra');
 const R = require('ramda');
 
 const AppConfig = require('@src/model/app-config');
@@ -32,6 +33,18 @@ const _mapToArgs = (params, paramsObject) => {
     return res;
 };
 
+const _loadJson = (value) => {
+    const filePrefix = 'file:';
+    let json;
+    if (value.startsWith(filePrefix)) {
+        const filePath = value.split(filePrefix).pop();
+        json = fs.readJSONSync(filePath);
+    } else {
+        json = JSON.parse(value);
+    }
+    return json;
+};
+
 const _mapToParams = (optionsValues, flatParamsMap, commanderToApiCustomizationMap) => {
     const res = {};
     Object.keys(optionsValues).forEach(key => {
@@ -51,7 +64,7 @@ const _mapToParams = (optionsValues, flatParamsMap, commanderToApiCustomizationM
                 mergeObject = unflatten(mergeObject, BODY_PATH_DELIMITER);
                 res[param.rootName] = R.mergeDeepRight(res[param.rootName], mergeObject);
             } else if (param.json) {
-                res[param.name] = JSON.parse(value);
+                res[param.name] = _loadJson(value);
             } else {
                 res[param.name] = value;
             }

--- a/lib/commands/smapi/smapi-commander.js
+++ b/lib/commands/smapi/smapi-commander.js
@@ -20,7 +20,9 @@ const defaultOptions = [{
     description: optionModel.debug.description
 }];
 const requiredTemplate = { true: '[REQUIRED]', false: '[OPTIONAL]' };
-const jsonTemplate = { true: '[JSON]\n', false: '' };
+const jsonTemplate = { true: '[JSON]: Json string or a file. To pass as a file, prefix the file path with "file:". '
++ 'For example: --manifest file:/folder/file.json.\n',
+false: '' };
 
 const _makeEnumTemplate = (param) => (param.enum ? `[ENUM]: ${param.enum.join()}.\n` : '');
 const _makeArrayTemplate = (param) => (param.isArray ? '[MULTIPLE]: Values can be separated by comma.\n' : '');


### PR DESCRIPTION
Added option to read json from file path.

Examples:

```
ask smapi create-skill-for-vendor --manifest "$(cat skill-manifest.json)"
ask smapi create-skill-for-vendor --manifest file:skill-manifest.json
ask smapi create-skill-for-vendor --manifest file:/some-path/skill-manifest.json
```


