### PR TITLE
fix: standardize keys for smapi auto gen logic to prevent mismatch du…

### DIFF
--- a/lib/commands/smapi/cli-customization-processor.js
+++ b/lib/commands/smapi/cli-customization-processor.js
@@ -1,5 +1,5 @@
 
-const { kebabCase, camelCase } = require('@src/utils/string-utils');
+const { kebabCase, standardize } = require('@src/utils/string-utils');
 const CliError = require('@src/exceptions/cli-error');
 const { customizationMap } = require('@src/commands/smapi/customizations/parameters-map');
 
@@ -91,7 +91,7 @@ class CliCustomizationProcessor {
                 customizedParameter[key] = true;
             }
         });
-        customizationMetadata.flatParamsMap.set(camelCase(customizedParameter.name), customizedParameter);
+        customizationMetadata.flatParamsMap.set(standardize(customizedParameter.name), customizedParameter);
     }
 
     _getDefinitionSchema(ref, definitions) {

--- a/lib/commands/smapi/smapi-command-handler.js
+++ b/lib/commands/smapi/smapi-command-handler.js
@@ -12,7 +12,7 @@ const jsonView = require('@src/view/json-view');
 const Messenger = require('@src/view/messenger');
 const profileHelper = require('@src/utils/profile-helper');
 const unflatten = require('@src/utils/unflatten');
-const { getParamNames } = require('@src/utils/string-utils');
+const { getParamNames, standardize } = require('@src/utils/string-utils');
 
 const BeforeSendProcessor = require('./before-send-processor');
 const { BODY_PATH_DELIMITER, ARRAY_SPLIT_DELIMITER } = require('./cli-customization-processor');
@@ -24,7 +24,7 @@ const _mapToArgs = (params, paramsObject) => {
     params.forEach(param => {
         let value = null;
         Object.keys(paramsObject).forEach(k => {
-            if (k.toLowerCase() === param.toLowerCase()) {
+            if (standardize(k) === standardize(param)) {
                 value = paramsObject[k];
             }
         });
@@ -49,7 +49,7 @@ const _mapToParams = (optionsValues, flatParamsMap, commanderToApiCustomizationM
     const res = {};
     Object.keys(optionsValues).forEach(key => {
         const apiName = commanderToApiCustomizationMap.get(key) || key;
-        const param = flatParamsMap.get(apiName);
+        const param = flatParamsMap.get(standardize(apiName));
         if (param) {
             let value = optionsValues[key];
             value = param.isArray ? value.split(ARRAY_SPLIT_DELIMITER) : value;

--- a/lib/utils/string-utils.js
+++ b/lib/utils/string-utils.js
@@ -5,6 +5,7 @@ module.exports = {
     getParamNames,
     camelCase,
     kebabCase,
+    standardize,
     isNonEmptyString,
     isNonBlankString,
     isLambdaFunctionName,
@@ -37,6 +38,9 @@ function kebabCase(str) {
         .join('-');
 }
 
+function standardize(str) {
+    return camelCase(str).toLowerCase();
+}
 function isNonEmptyString(str) {
     return R.is(String, str) && !R.isEmpty(str);
 }

--- a/test/unit/commands/smapi/cli-customization-processor-test.js
+++ b/test/unit/commands/smapi/cli-customization-processor-test.js
@@ -1,6 +1,6 @@
 const { expect } = require('chai');
 const sinon = require('sinon');
-const { camelCase } = require('@src/utils/string-utils');
+const { camelCase, standardize } = require('@src/utils/string-utils');
 const CliError = require('@src/exceptions/cli-error');
 const { customizationMap } = require('@src/commands/smapi/customizations/parameters-map');
 const { CliCustomizationProcessor, BODY_PATH_DELIMITER, MAX_NESTED_PROPERTIES } = require('@src/commands/smapi/cli-customization-processor');
@@ -102,7 +102,7 @@ describe('Smapi test - CliCustomizationProcessor class', () => {
             const { flatParamsMap } = parentOperation.customizationMetadata;
 
             const expected = { ...parameter, enum: undefined };
-            expect(flatParamsMap.get(key)).eql(expected);
+            expect(flatParamsMap.get(standardize(key))).eql(expected);
         });
 
         it('| should skip processing of parameter', () => {
@@ -126,7 +126,7 @@ describe('Smapi test - CliCustomizationProcessor class', () => {
             const { flatParamsMap } = parentOperation.customizationMetadata;
 
             const expected = { ...parameter, enum: undefined, isArray: true };
-            expect(flatParamsMap.get(key)).eql(expected);
+            expect(flatParamsMap.get(standardize(key))).eql(expected);
         });
 
         it('| should add reference enum of non body paramter', () => {
@@ -138,7 +138,7 @@ describe('Smapi test - CliCustomizationProcessor class', () => {
             const { flatParamsMap } = parentOperation.customizationMetadata;
 
             const expected = { ...parameter, enum: enumValues, isArray: true };
-            expect(flatParamsMap.get(key)).eql(expected);
+            expect(flatParamsMap.get(standardize(key))).eql(expected);
         });
 
         it('| should add reference items of non body paramter and use reference item description if not defined', () => {
@@ -150,7 +150,7 @@ describe('Smapi test - CliCustomizationProcessor class', () => {
             const { flatParamsMap } = parentOperation.customizationMetadata;
 
             const expected = { ...parameter, enum: enumValues, description: refObjectDescription, isArray: true };
-            expect(flatParamsMap.get(key)).eql(expected);
+            expect(flatParamsMap.get(standardize(key))).eql(expected);
         });
 
         it('| should add body parameter', () => {
@@ -168,7 +168,7 @@ describe('Smapi test - CliCustomizationProcessor class', () => {
                 name: bodyPropertyTwoName,
                 json: false,
                 isBoolean: true };
-            expect(flatParamsMap.get(bodyPropertyTwoName)).eql(expected);
+            expect(flatParamsMap.get(standardize(bodyPropertyTwoName))).eql(expected);
         });
 
         it('| should add customized body parameter', () => {
@@ -182,7 +182,7 @@ describe('Smapi test - CliCustomizationProcessor class', () => {
             const { flatParamsMap } = parentOperation.customizationMetadata;
             const { name, required, description } = parameter;
             const expected = { name, required, description, json: true };
-            expect(flatParamsMap.get(parameter.name)).eql(expected);
+            expect(flatParamsMap.get(standardize(parameter.name))).eql(expected);
         });
 
         it('| should add customized body parameter with custom properties', () => {
@@ -199,7 +199,7 @@ describe('Smapi test - CliCustomizationProcessor class', () => {
             const { flatParamsMap } = parentOperation.customizationMetadata;
 
             const expected = { name, required, description };
-            expect(flatParamsMap.get(name)).eql(expected);
+            expect(flatParamsMap.get(standardize(name))).eql(expected);
         });
 
         it('| should add one level deep body parameter', () => {
@@ -220,7 +220,7 @@ describe('Smapi test - CliCustomizationProcessor class', () => {
                 json: false,
                 isNumber: true,
                 type: 'number' };
-            expect(flatParamsMap.get(key)).eql(expected);
+            expect(flatParamsMap.get(standardize(key))).eql(expected);
 
             const expectedParams = mapExpectedParams(nestedPropertyName, bodyPropertyTwoName);
             name = expectedParams.name;
@@ -228,7 +228,7 @@ describe('Smapi test - CliCustomizationProcessor class', () => {
             key = expectedParams.key;
             expected = { ...bodyPropertyWithDescription, name, rootName, bodyPath, required: true, enum: null, json: false, isBoolean: true };
 
-            expect(flatParamsMap.get(key)).eql(expected);
+            expect(flatParamsMap.get(standardize(key))).eql(expected);
         });
 
         it('| should fail since the body parameter is nested too deep', () => {
@@ -257,8 +257,15 @@ describe('Smapi test - CliCustomizationProcessor class', () => {
             const name = nestedEnumPropertyName;
             const bodyPath = nestedEnumPropertyName;
 
-            const expected = { ...bodyProperty, name, rootName, bodyPath, required: false, enum: enumValues, description: enumDescription, type: undefined };
-            expect(flatParamsMap.get(nestedEnumPropertyName)).eql(expected);
+            const expected = { ...bodyProperty,
+                name,
+                rootName,
+                bodyPath,
+                required: false,
+                enum: enumValues,
+                description: enumDescription,
+                type: undefined };
+            expect(flatParamsMap.get(standardize(nestedEnumPropertyName))).eql(expected);
         });
     });
 

--- a/test/unit/commands/smapi/smapi-command-handler-test.js
+++ b/test/unit/commands/smapi/smapi-command-handler-test.js
@@ -36,12 +36,12 @@ describe('Smapi test - smapiCommandHandler function', () => {
     };
 
     const flatParamsMap = new Map([
-        ['skillId', { name: 'skillId' }],
-        ['someJson', { name: 'someJson', json: true }],
-        ['someArray', { name: 'someArray', isArray: true }],
-        ['someNumber', { rootName: 'simulationsApiRequest', bodyPath: 'input>>>someNumber', isNumber: true }],
-        ['someBoolean', { rootName: 'simulationsApiRequest', bodyPath: 'input>>>someBoolean', isBoolean: true }],
-        ['sessionMode', { rootName: 'simulationsApiRequest', bodyPath: 'session>>>mode' }]]);
+        ['skillid', { name: 'skillId' }],
+        ['somejson', { name: 'someJson', json: true }],
+        ['somearray', { name: 'someArray', isArray: true }],
+        ['somenumber', { rootName: 'simulationsApiRequest', bodyPath: 'input>>>someNumber', isNumber: true }],
+        ['someboolean', { rootName: 'simulationsApiRequest', bodyPath: 'input>>>someBoolean', isBoolean: true }],
+        ['sessionmode', { rootName: 'simulationsApiRequest', bodyPath: 'session>>>mode' }]]);
 
     const commanderToApiCustomizationMap = new Map();
     let cmdObj;


### PR DESCRIPTION
I discovered when I was testing adding a new smapi command. 

casing for keys was not matching. for example blaNLU vs blaNlu and it was breaking auto gen logic.

standardizing keys by camel casing (to join all words together) and then lower casing.

