### PR TITLE
feat: add support for template-branch parameter in new command

### DIFF
--- a/docs/concepts/New-Command.md
+++ b/docs/concepts/New-Command.md
@@ -5,7 +5,8 @@
 
 **STRUCTURE OF NEW COMMAND:**
 
-`ask new [--template-url <template name>]
+`ask new [--template-url <template url>]
+        [--template-branch <template branch>]
         [-p | --profile <profile>]
         [--debug]
         [-h | --help]`

--- a/docs/concepts/New-Command.md
+++ b/docs/concepts/New-Command.md
@@ -14,6 +14,8 @@
 
 **template-url**: Optional. Specify the URL of a Git repository that contains a skill template.
 
+**template-branch**: Optional. Specify the branch for a Git repository that contains a skill template.
+
 **profile**: Optional. Specify a profile name to be used. Defaults to use `default` as the profile name, if this option or environmental variable `ASK_DEFAULT_PROFILE` is not set.
 
 **debug**: Optional. Show debug messages.

--- a/lib/commands/new/helper.js
+++ b/lib/commands/new/helper.js
@@ -24,7 +24,8 @@ module.exports = {
 function downloadTemplateFromGit(userInput, doDebug, callback) {
     const projectFolderPath = path.join(process.cwd(), userInput.projectFolderName);
     const gitClient = new GitClient(projectFolderPath, { showOutput: !!doDebug, showCommand: !!doDebug });
-    gitClient.clone(userInput.templateInfo.templateUrl, CONSTANTS.TEMPLATES.TEMPLATE_BRANCH_NAME, projectFolderPath);
+    const branch = userInput.templateInfo.templateBranch || CONSTANTS.TEMPLATES.TEMPLATE_BRANCH_NAME;
+    gitClient.clone(userInput.templateInfo.templateUrl, branch, projectFolderPath);
     callback(null, projectFolderPath);
 }
 

--- a/lib/commands/new/index.js
+++ b/lib/commands/new/index.js
@@ -28,7 +28,7 @@ class NewCommand extends AbstractCommand {
     }
 
     optionalOptions() {
-        return ['templateUrl', 'profile', 'debug'];
+        return ['templateUrl', 'templateBranch', 'profile', 'debug'];
     }
 
     handle(cmd, cb) {

--- a/lib/commands/new/wizard-helper.js
+++ b/lib/commands/new/wizard-helper.js
@@ -84,7 +84,7 @@ function _getTemplateInfo(cmd, userInput, callback) {
             return callback('No custom template allowed for an Alexa hosted skill.');
         }
         process.nextTick(() => {
-            callback(null, { templateUrl: null, templateName: null });
+            callback(null, { templateUrl: null, templateName: null, templateBranch: null });
         });
     } else {
         if (cmd.templateUrl) {
@@ -95,6 +95,7 @@ function _getTemplateInfo(cmd, userInput, callback) {
                 if (!templateInfo) {
                     return callback();
                 }
+                templateInfo.templateBranch = cmd.templateBranch;
                 return callback(null, templateInfo);
             });
         }

--- a/lib/commands/option-model.json
+++ b/lib/commands/option-model.json
@@ -69,7 +69,7 @@
     "name": "template-branch",
     "description": "Git branch used with the template url",
     "alias": null,
-    "stringInput": "OPTIONAL"
+    "stringInput": "REQUIRED"
   },
   "file": {
     "name": "file",

--- a/lib/commands/option-model.json
+++ b/lib/commands/option-model.json
@@ -65,6 +65,12 @@
     "alias": null,
     "stringInput": "REQUIRED"
   },
+  "templateBranch": {
+    "name": "template-branch",
+    "description": "Git branch used with the template url",
+    "alias": null,
+    "stringInput": "OPTIONAL"
+  },
   "file": {
     "name": "file",
     "description": "Path to the target file input",

--- a/test/unit/commands/new/helper-test.js
+++ b/test/unit/commands/new/helper-test.js
@@ -115,6 +115,23 @@ describe('Commands new test - helper test', () => {
                 done();
             });
         });
+        it('| git clone with custom branch, expect return folder path', (done) => {
+            // setup
+            const TEST_FOLDER_PATH = 'TEST_FOLDER_PATH';
+            const TEST_TEMPLATE_BRANCH = 'test-branch';
+            TEST_USER_INPUT.templateInfo.templateBranch = TEST_TEMPLATE_BRANCH;
+            sinon.stub(path, 'join').returns(TEST_FOLDER_PATH);
+            sinon.stub(GitClient.prototype, 'clone');
+            // call
+            helper.downloadTemplateFromGit(TEST_USER_INPUT, TEST_DO_DEBUG, (err, res) => {
+                // verify
+                expect(GitClient.prototype.clone.args[0][0]).equal(TEST_TEMPLATE_URL);
+                expect(GitClient.prototype.clone.args[0][1]).equal(TEST_TEMPLATE_BRANCH);
+                expect(res).equal(TEST_FOLDER_PATH);
+                expect(err).equal(null);
+                done();
+            });
+        });
     });
 
     describe('# test helper method - loadSkillProjectModel', () => {

--- a/test/unit/commands/new/index-test.js
+++ b/test/unit/commands/new/index-test.js
@@ -53,7 +53,7 @@ describe('Commands new test - command class test', () => {
         expect(instance.name()).equal('new');
         expect(instance.description()).equal('create a new skill project from Alexa skill templates');
         expect(instance.requiredOptions()).deep.equal([]);
-        expect(instance.optionalOptions()).deep.equal(['templateUrl', 'profile', 'debug']);
+        expect(instance.optionalOptions()).deep.equal(['templateUrl', 'templateBranch', 'profile', 'debug']);
     });
 
     describe('validate command handle', () => {


### PR DESCRIPTION
add support for template-branch parameter in new command

Example:

```
ask new --template-url https://github.com/kakhaUrigashvili/skill-sample-nodejs-hello-world.git --template-branch develop
Please follow the wizard to start your Alexa skill project ->
? Choose a method to host your skill's backend resources:  AWS Lambda
  Host your skill code on AWS Lambda (requires AWS account).
[Warn]: CLI is about to download the skill template from unofficial template https://github.com/kakhaUrigashvili/skill-sample-nodejs-hello-world.git. Please make sure you understand the source code to best protect yourself from malicious usage.
? Would you like to continue download the skill template?  Yes
? Please type in your skill name:  skill-sample-nodejs-hello-world
? Please type in your folder name for the skill project (alphanumeric):  skill-sample-nodejs-hello-world
Project for skill "skill-sample-nodejs-hello-world" is successfully created at /Users/kakuri/Git/alexa-skill-cli-deploy/skill-sample-nodejs-hello-world

Project initialized with deploy delegate "@ask-cli/lambda-deployer" successfully.
```
