### PR TITLE
fix: added logic to handle non alphanumeric characters in smapi swagg…

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Use Node.js
       uses: actions/setup-node@v1
       with:
-        node-version: '10.x'
+        node-version: '12.x'
     - run: npm install
     - run: npm link
     - run: npm run integration-test

--- a/lib/commands/smapi/smapi-command-handler.js
+++ b/lib/commands/smapi/smapi-command-handler.js
@@ -110,16 +110,19 @@ const smapiCommandHandler = (swaggerApiOperationName, flatParamsMap, commanderTo
     const beforeSendProcessor = new BeforeSendProcessor(inputCmdObj._name, paramsObject, modelIntrospector, profile);
     beforeSendProcessor.processAll();
 
-    // TODO revisit with debug flow
-    if (inputOpts.debug) {
-        Messenger.getInstance().info(`Operation: ${swaggerApiOperationName}`);
-        Messenger.getInstance().info('Payload:');
-        Messenger.getInstance().info(`${jsonView.toString(paramsObject)}\n`);
-    }
-
     const functionName = _sdkFunctionName(swaggerApiOperationName);
     const params = getParamNames(client[functionName]);
     const args = _mapToArgs(params, paramsObject);
+
+    if (inputOpts.debug) {
+        const payload = {};
+        params.forEach((k, i) => {
+            payload[k] = args[i];
+        });
+        Messenger.getInstance().info(`Operation: ${swaggerApiOperationName}`);
+        Messenger.getInstance().info('Payload:');
+        Messenger.getInstance().info(`${jsonView.toString(payload)}\n`);
+    }
 
     return client[functionName](...args)
         .then(response => {

--- a/lib/utils/string-utils.js
+++ b/lib/utils/string-utils.js
@@ -39,7 +39,7 @@ function kebabCase(str) {
 }
 
 function standardize(str) {
-    return camelCase(str).toLowerCase();
+    return filterNonAlphanumeric(camelCase(str).toLowerCase());
 }
 function isNonEmptyString(str) {
     return R.is(String, str) && !R.isEmpty(str);

--- a/test/unit/commands/smapi/smapi-command-handler-test.js
+++ b/test/unit/commands/smapi/smapi-command-handler-test.js
@@ -116,7 +116,12 @@ describe('Smapi test - smapiCommandHandler function', () => {
 
         expect(messengerStub.args[0]).eql(['INFO', 'Operation: someApiOperation']);
         expect(messengerStub.args[1]).eql(['INFO', 'Payload:']);
-        expect(messengerStub.args[2]).eql(['INFO', `${jsonView.toString({ skillId })}\n`]);
+        expect(messengerStub.args[2])
+            .eql(['INFO', `${jsonView.toString({ someJson: null,
+                skillId,
+                someNonPopulatedProperty: null,
+                someArray: null,
+                simulationsApiRequest: null })}\n`]);
         expect(messengerStub.args[3]).eql(['INFO', `Status code: ${fakeResponse.statusCode}`]);
         expect(messengerStub.args[4]).eql(['INFO', `Response headers: ${jsonView.toString(fakeResponse.headers)}`]);
         expect(messengerStub.args[5]).eql(['INFO', `Response body: ${jsonView.toString(fakeResponse.body)}`]);

--- a/test/unit/utils/string-utils-test.js
+++ b/test/unit/utils/string-utils-test.js
@@ -45,6 +45,33 @@ describe('Utils test - string utility', () => {
         });
     });
 
+    describe('# test function standardize', () => {
+        [
+            {
+                testCase: 'camel case to lower',
+                str: 'testTest',
+                expectation: 'testtest'
+            },
+            {
+                testCase: 'capital case to lower',
+                str: 'TestTest',
+                expectation: 'testtest'
+            },
+            {
+                testCase: 'non alphanumeric',
+                str: 'test.test',
+                expectation: 'testtest'
+            },
+        ].forEach(({ testCase, str, expectation }) => {
+            it(`| ${testCase}, expect standardize ${str}`, () => {
+                // call
+                const callResult = stringUtils.standardize(str);
+                // verify
+                expect(callResult).equal(expectation);
+            });
+        });
+    });
+
     describe('# test function isNonBlankString', () => {
         [
             {


### PR DESCRIPTION
Before slotName was not mapped since in swagger it is intent.name.
Added logic to handle non alphanumeric. 

Here is correct output.
```
ask smapi get-utterance-data -s amzn1.ask.skill.e9ac9d7f-5c4f-4c3b-8e41-1b347f625d95 --intent-name AMAZON.FallbackIntent --debug
Operation: getUtteranceDataV1
Payload:
{
  "skillId": "amzn1.ask.skill.e9ac9d7f-5c4f-4c3b-8e41-1b347f625d95",
  "nextToken": null,
  "maxResults": null,
  "sortDirection": null,
  "sortField": null,
  "stage": null,
  "locale": null,
  "dialogActName": null,
  "intentConfidenceBin": null,
  "intentName": [
    "AMAZON.FallbackIntent"
  ],
  "intentSlotsName": null,
  "interactionType": null,
  "publicationStatus": null,
  "utteranceText": null
}
```
