### PR TITLE
fix: add error handling when refresh lwa token fails, pass in debug flag to all the authorizationController

### DIFF
--- a/lib/clients/lwa-auth-code-client/index.js
+++ b/lib/clients/lwa-auth-code-client/index.js
@@ -4,10 +4,12 @@ const queryString = require('querystring');
 const addSeconds = require('date-fns/addSeconds');
 const isAfter = require('date-fns/isAfter');
 const parseISO = require('date-fns/parseISO');
-const stringUtils = require('@src/utils/string-utils');
-const CONSTANTS = require('@src/utils/constants');
+
 const httpClient = require('@src/clients/http-client');
+const CONSTANTS = require('@src/utils/constants');
 const providerChainUtils = require('@src/utils/provider-chain-utils');
+const stringUtils = require('@src/utils/string-utils');
+const jsonView = require('@src/view/json-view');
 
 module.exports = class LWAAuthCodeClient {
     constructor(config) {
@@ -67,8 +69,17 @@ module.exports = class LWAAuthCodeClient {
             if (err) {
                 return callback(err);
             }
+            const responseErr = R.view(R.lensPath(['body', 'error']), response);
+            if (stringUtils.isNonBlankString(responseErr)) {
+                return callback(`Refresh LWA tokens failed, please run "ask configure" to manually update your tokens. Error: ${responseErr}.`);
+            }
+            const expiresIn = R.view(R.lensPath(['body', 'expires_in']), response);
+            if (!expiresIn) {
+                return callback(`Received invalid response body from LWA without "expires_in":\n${jsonView.toString(response.body)}`);
+            }
+
             const tokenBody = R.clone(response.body);
-            tokenBody.expires_at = this._getExpiresAt(tokenBody.expires_in).toISOString();
+            tokenBody.expires_at = this._getExpiresAt(expiresIn).toISOString();
             callback(null, tokenBody);
         });
     }

--- a/lib/clients/smapi-client/index.js
+++ b/lib/clients/smapi-client/index.js
@@ -75,7 +75,8 @@ module.exports = class SmapiClient {
             body: NULL_PAYLOAD,
         };
         const authorizationController = new AuthorizationController({
-            auth_client_type: 'LWA'
+            auth_client_type: 'LWA',
+            doDebug: this.doDebug
         });
         authorizationController.tokenRefreshAndRead(this.profile, (tokenErr, token) => {
             if (tokenErr) {
@@ -152,7 +153,8 @@ module.exports = class SmapiClient {
             json: !!payload
         };
         const authorizationController = new AuthorizationController({
-            auth_client_type: 'LWA'
+            auth_client_type: 'LWA',
+            doDebug: this.doDebug
         });
         authorizationController.tokenRefreshAndRead(this.profile, (tokenErr, token) => {
             if (tokenErr) {

--- a/lib/commands/configure/ask-profile-setup-helper.js
+++ b/lib/commands/configure/ask-profile-setup-helper.js
@@ -130,6 +130,7 @@ function _buildAuthorizationConfiguration(config) {
         scopes: CONSTANTS.LWA.DEFAULT_SCOPES,
         state: CONSTANTS.LWA.DEFAULT_STATE,
         auth_client_type: 'LWA',
-        redirectUri: CONSTANTS.LWA.S3_RESPONSE_PARSER_URL
+        redirectUri: CONSTANTS.LWA.S3_RESPONSE_PARSER_URL,
+        doDebug: config.doDebug
     };
 }

--- a/lib/commands/configure/index.js
+++ b/lib/commands/configure/index.js
@@ -112,7 +112,7 @@ function _buildAskConfig(cmd, askFolderPath, configFilePath) {
         isFirstTimeProfileCreation: AppConfig.getInstance().getProfilesList().length < 1,
         askProfile: cmd.profile,
         needBrowser: cmd.browser,
-        debug: cmd.debug
+        doDebug: cmd.debug
     };
 }
 

--- a/lib/commands/new/hosted-skill-helper.js
+++ b/lib/commands/new/hosted-skill-helper.js
@@ -92,7 +92,6 @@ function createHostedSkill(hostedSkillController, userInput, vendorId, callback)
             }
             skillMetadataController.enableSkill((enableErr) => {
                 if (enableErr) {
-                    Messenger.getInstance().error(enableErr);
                     return callback(enableErr);
                 }
                 const templateUrl = CONSTANTS.HOSTED_SKILL.GIT_HOOKS_TEMPLATES.PRE_PUSH.URL;

--- a/lib/commands/smapi/smapi-command-handler.js
+++ b/lib/commands/smapi/smapi-command-handler.js
@@ -82,14 +82,16 @@ const _sdkFunctionName = (swaggerApiOperationName) => `call${swaggerApiOperation
  * @param {Map} flatParamsMap Flattened parameters.
  * @param {Map} commanderToApiCustomizationMap Map of commander options to custom options
  * for api properties.
+ * @param {Boolean} doDebug
  * @param {Object} cmdObj Commander object with passed values.
  */
 const smapiCommandHandler = (swaggerApiOperationName, flatParamsMap, commanderToApiCustomizationMap, inputCmdObj, modelIntrospector) => {
     new AppConfig(configFilePath);
-    const authorizationController = new AuthorizationController({
-        auth_client_type: 'LWA'
-    });
     const inputOpts = inputCmdObj.opts();
+    const authorizationController = new AuthorizationController({
+        auth_client_type: 'LWA',
+        doDebug: inputOpts.debug
+    });
     const profile = profileHelper.runtimeProfile(inputOpts.profile);
     const refreshTokenConfig = {
         clientId: authorizationController.oauthClient.config.clientId,


### PR DESCRIPTION
This commit is to solve the error stack trace when users run `ask configure` but fail with the following message:

```
/ASK-CLI/lib/clients/lwa-auth-code-client/index.js:42
            tokenBody.expires_at = this._getExpiresAt(tokenBody.expires_in).toISOString();
                                                                            ^

RangeError: Invalid time value
    at Date.toISOString (<anonymous>)
    at /ASK-CLI/lib/clients/lwa-auth-code-client/index.js:42:77
```

Now it fails with better message, and users are able to see full network activity using `--debug` for LWA requests.