### PR TITLE
Parse csv fix

### DIFF
--- a/lib/commands/smapi/smapi-command-handler.js
+++ b/lib/commands/smapi/smapi-command-handler.js
@@ -82,7 +82,9 @@ const _sdkFunctionName = (swaggerApiOperationName) => `call${swaggerApiOperation
 const parseSmapiResponse = (response) => {
     let result = '';
     const { body, headers } = response;
-    const isJson = headers.find(h => h.key === 'content-type' && h.value.includes('application/json'));
+    const contentType = headers.find((h) => h.key === 'content-type');
+    // json if no content type or content type is application/json
+    const isJson = !contentType || contentType.value.includes('application/json');
     if (body && Object.keys(body).length) {
         result = isJson ? jsonView.toString(body) : body;
     } else {

--- a/lib/commands/smapi/smapi-command-handler.js
+++ b/lib/commands/smapi/smapi-command-handler.js
@@ -76,6 +76,22 @@ const _mapToParams = (optionsValues, flatParamsMap, commanderToApiCustomizationM
 const _sdkFunctionName = (swaggerApiOperationName) => `call${swaggerApiOperationName.charAt(0).toUpperCase() + swaggerApiOperationName.slice(1)}`;
 
 /**
+ * Parses response from smapi
+ * @param {Object} response object
+ */
+const parseSmapiResponse = (response) => {
+    let result = '';
+    const { body, headers } = response;
+    const isJson = headers.find(h => h.key === 'content-type' && h.value.includes('application/json'));
+    if (body && Object.keys(body).length) {
+        result = isJson ? jsonView.toString(body) : body;
+    } else {
+        result = 'Command executed successfully!';
+    }
+    return result;
+};
+
+/**
  * Handles smapi command request
  * @param {string} swaggerApiOperationName Swagger operation name.
  * @param {Array} swaggerParams Parameters for operation from the Swagger model.
@@ -135,10 +151,10 @@ const smapiCommandHandler = (swaggerApiOperationName, flatParamsMap, commanderTo
                 Messenger.getInstance().info(`Response headers: ${jsonView.toString(headers)}`);
                 Messenger.getInstance().info(`Response body: ${jsonView.toString(body)}`);
             } else {
-                result = body && Object.keys(body).length ? jsonView.toString(body) : 'Command executed successfully!';
+                result = parseSmapiResponse(response);
             }
             return result;
         });
 };
 
-module.exports = smapiCommandHandler;
+module.exports = { smapiCommandHandler, parseSmapiResponse };

--- a/lib/commands/smapi/smapi-commander.js
+++ b/lib/commands/smapi/smapi-commander.js
@@ -3,7 +3,7 @@ const { ModelIntrospector } = require('ask-smapi-sdk');
 const { kebabCase } = require('@src/utils/string-utils');
 const { CliCustomizationProcessor } = require('@src/commands/smapi/cli-customization-processor');
 const optionModel = require('@src/commands/option-model.json');
-const smapiCommandHandler = require('@src/commands/smapi/smapi-command-handler');
+const { smapiCommandHandler } = require('@src/commands/smapi/smapi-command-handler');
 const aliases = require('@src/commands/smapi/customizations/aliases.json');
 const { apiToCommanderMap } = require('@src/commands/smapi/customizations/parameters-map');
 

--- a/test/unit/commands/smapi/smapi-command-handler-test.js
+++ b/test/unit/commands/smapi/smapi-command-handler-test.js
@@ -150,4 +150,12 @@ describe('Smapi test - parseSmapiResponse function', () => {
 
         expect(result).eql(jsonView.toString(content));
     });
+
+    it('| should return command executed successfully if not response body', () => {
+        const response = { headers: [] };
+
+        const result = parseSmapiResponse(response);
+
+        expect(result).eql('Command executed successfully!');
+    });
 });

--- a/test/unit/commands/smapi/smapi-command-handler-test.js
+++ b/test/unit/commands/smapi/smapi-command-handler-test.js
@@ -9,7 +9,7 @@ const jsonView = require('@src/view/json-view');
 const BeforeSendProcessor = require('@src/commands/smapi/before-send-processor');
 const AuthorizationController = require('@src/controllers/authorization-controller');
 const profileHelper = require('@src/utils/profile-helper');
-const smapiCommandHandler = require('@src/commands/smapi/smapi-command-handler');
+const { smapiCommandHandler, parseSmapiResponse } = require('@src/commands/smapi/smapi-command-handler');
 
 
 describe('Smapi test - smapiCommandHandler function', () => {
@@ -129,5 +129,25 @@ describe('Smapi test - smapiCommandHandler function', () => {
 
     afterEach(() => {
         sinon.restore();
+    });
+});
+
+describe('Smapi test - parseSmapiResponse function', () => {
+    it('| should parse text/csv response', () => {
+        const content = 'foo bar\n foo';
+        const response = { headers: [{ key: 'content-type', value: 'text/csv' }], body: content };
+
+        const result = parseSmapiResponse(response);
+
+        expect(result).eql(content);
+    });
+
+    it('| should parse application/json response', () => {
+        const content = { foo: 'bar' };
+        const response = { headers: [{ key: 'content-type', value: 'application/json' }], body: content };
+
+        const result = parseSmapiResponse(response);
+
+        expect(result).eql(jsonView.toString(content));
     });
 });


### PR DESCRIPTION
adding support for non json response.
Need to wait until ask-smapi-sdk also fixes this issue.

example command with non json response

`ask smapi get-annotations-for-nlu-annotation-sets -s amzn1.ask.skill.e9ac9d7f-5c4f-4c3b-8e41-1b347f625d95 --annotation-id 0ed2ab5f-8b1b-423e-995c-1381d14cd496 --accept text/csv`
