### PR TITLE
fix: allow ask init with only skillMetadata and fix NPEs during the flow

### DIFF
--- a/lib/commands/deploy/index.js
+++ b/lib/commands/deploy/index.js
@@ -125,6 +125,10 @@ function deployResources(options, callback) {
         Messenger.getInstance().info(`Skill ID: ${ResourcesConfig.getInstance().getSkillId(profile)}`);
 
         // Skill Code
+        const regionsList = ResourcesConfig.getInstance().getCodeRegions(profile);
+        if (!regionsList || regionsList.length === 0) {
+            return callback();
+        }
         Messenger.getInstance().info('\n==================== Build Skill Code ====================');
         helper.buildSkillCode(profile, doDebug, (buildErr, uniqueCodeList) => {
             if (buildErr) {

--- a/lib/commands/init/helper.js
+++ b/lib/commands/init/helper.js
@@ -149,19 +149,19 @@ function previewAndWriteAskResources(rootPath, userInput, profile, callback) {
 function _assembleAskResources(userInput, profile) {
     const askResourcesJson = R.clone(AskResources.BASE);
     const askStatesJson = R.clone(AskStates.BASE);
-    const askProfileResources = {
-        skillMetadata: userInput.skillMeta,
-        code: userInput.skillCode,
-        skillInfrastructure: userInput.skillInfra
-    };
-    const askProfileStates = {
-        skillId: userInput.skillId,
-        skillInfrastructure: {
+    const askProfileResources = { skillMetadata: userInput.skillMeta };
+    const askProfileStates = { skillId: userInput.skillId };
+    if (userInput.skillCode) {
+        askProfileResources.code = userInput.skillCode;
+    }
+    if (userInput.skillInfra) {
+        askProfileResources.skillInfrastructure = userInput.skillInfra;
+        askProfileStates.skillInfrastructure = {
             [userInput.skillInfra.type]: {
                 deployState: {}
             }
-        }
-    };
+        };
+    }
     return {
         askResources: R.set(R.lensPath(['profiles', profile]), askProfileResources, askResourcesJson),
         askStates: R.set(R.lensPath(['profiles', profile]), askProfileStates, askStatesJson)

--- a/lib/commands/init/ui.js
+++ b/lib/commands/init/ui.js
@@ -88,7 +88,7 @@ function getSkillMetaSrc(callback) {
 
 function getCodeSrcForRegion(region, callback) {
     inquirer.prompt([{
-        message: `Lambda code path (for ${region} region): `,
+        message: `Lambda code path for ${region} region (leave empty to not deploy Lambda): `,
         type: 'input',
         default: './lambda',
         name: 'skillCodeSrc',
@@ -99,7 +99,7 @@ function getCodeSrcForRegion(region, callback) {
             return true;
         }
     }]).then((answer) => {
-        callback(null, answer.skillCodeSrc);
+        callback(null, answer.skillCodeSrc.trim());
     }).catch((error) => {
         callback(error);
     });

--- a/lib/controllers/skill-code-controller/index.js
+++ b/lib/controllers/skill-code-controller/index.js
@@ -49,13 +49,10 @@ module.exports = class SkillCodeController {
      * @return {Array} codeList in the structure of [{ src, build, regionsList }]
      */
     _resolveUniqueCodeList() {
-        const codeRegions = ResourcesConfig.getInstance().getCodeRegions(this.profile);
-        if (!codeRegions) {
-            throw 'Invalid skill code settings. Please make sure to provide the "code" field correctly in ask-resources file.';
-        }
+        const codeRegionsList = ResourcesConfig.getInstance().getCodeRegions(this.profile);
         // register codeResources as a HashMap with following structure { codeSrc: [regionsList] }
         const codeSrcToRegionMap = new Map();
-        for (const region of codeRegions) {
+        for (const region of codeRegionsList) {
             const codeSrc = ResourcesConfig.getInstance().getCodeSrcByRegion(this.profile, region);
             if (!stringUtils.isNonBlankString(codeSrc)) {
                 throw `Invalid code setting in region ${region}. "src" must be set if you want to deploy skill code with skill package.`;

--- a/lib/model/resources-config/ask-resources.js
+++ b/lib/model/resources-config/ask-resources.js
@@ -57,7 +57,7 @@ module.exports = class AskResources extends ConfigFile {
 
     // Group for the "code"
     getCodeRegions(profile) {
-        return Object.keys(this.getProperty(['profiles', profile, 'code']));
+        return Object.keys(this.getProperty(['profiles', profile, 'code']) || []);
     }
 
     getCodeSrcByRegion(profile, region) {

--- a/test/unit/commands/deploy/index-test.js
+++ b/test/unit/commands/deploy/index-test.js
@@ -194,6 +194,25 @@ describe('Commands deploy test - command class test', () => {
                     done();
                 });
             });
+
+            it('| helper deploy skill metadata and no skillCode portion of work, expect quit with no error', (done) => {
+                // setup
+                sinon.stub(helper, 'deploySkillMetadata').callsArgWith(1,
+                    'The hash of current skill package folder does not change compared to the last deploy hash result, '
+                    + 'CLI will skip the deploy of skill package.');
+                sinon.stub(ResourcesConfig.prototype, 'getCodeRegions').returns([]);
+                sinon.stub(helper, 'enableSkill').callsArgWith(2);
+                // call
+                instance.handle(TEST_CMD, (err) => {
+                    // verify
+                    expect(err).equal(undefined);
+                    expect(infoStub.args[0][0]).equal('==================== Deploy Skill Metadata ====================');
+                    expect(infoStub.args[1][0].startsWith('Skill ID:')).equal(true);
+                    expect(errorStub.callCount).equal(0);
+                    expect(warnStub.callCount).equal(1);
+                    done();
+                });
+            });
         });
 
         describe('command handle - build skill code', () => {

--- a/test/unit/commands/init/ui-test.js
+++ b/test/unit/commands/init/ui-test.js
@@ -211,7 +211,7 @@ describe('Commands init - UI test', () => {
             ui.getCodeSrcForRegion(TEST_REGION, (err, response) => {
                 // verify
                 validateInquirerConfig(inquirer.prompt.args[0][0][0], {
-                    message: `Lambda code path (for ${TEST_REGION} region): `,
+                    message: `Lambda code path for ${TEST_REGION} region (leave empty to not deploy Lambda): `,
                     type: 'input',
                     default: './lambda',
                 });

--- a/test/unit/controller/skill-code-controller-test.js
+++ b/test/unit/controller/skill-code-controller-test.js
@@ -101,7 +101,7 @@ describe('Controller test - skill code controller test', () => {
 
         it('| codeResources does not exist, expect error throws', () => {
             // setup
-            sinon.stub(ResourcesConfig.prototype, 'getCodeRegions').returns(null);
+            sinon.stub(ResourcesConfig.prototype, 'getCodeRegions').returns([]);
             // call
             try {
                 skillCodeController._resolveUniqueCodeList();

--- a/test/unit/controller/skill-infrastructure-controller-test.js
+++ b/test/unit/controller/skill-infrastructure-controller-test.js
@@ -228,7 +228,7 @@ describe('Controller test - skill infrastructure controller test', () => {
 
         it('| code does not have any region, expect error called back', (done) => {
             // setup
-            sinon.stub(ResourcesConfig.prototype, 'getCodeRegions').returns(null);
+            sinon.stub(ResourcesConfig.prototype, 'getCodeRegions').returns([]);
             // call
             skillInfraController.deployInfraToAllRegions(TEST_DD, (err, res) => {
                 // verify


### PR DESCRIPTION
The issues are related to the use case of ask-init with skillMetadata only. Supporting people who only wish to use ask-cli to deploy skill-package.

Originally, if users only do ask-init and use empty string for `Lambda code path`, they will see the following error which blocks their skill-package only settings:
```
? ask-resources.json already exists in current directory. Do you want to overwrite it?  Yes
? Skill Id (leave empty to create one):
? Skill package path:  ./skill-package
? Lambda code path (for default region):
[Error]: TypeError: Cannot read property 'type' of undefined
```

Even the ask-resources.json doesn't have code field, the deploy will still continue to try to deploy skill code:
```
$ ask deploy
==================== Deploy Skill Metadata ====================
Skill package deployed successfully.
Skill ID: amzn1.ask.skill.###

==================== Build Skill Code ====================
[Error]: TypeError: Cannot convert undefined or null to object
```

After this fix, deploy of skill-package only has a smooth experience.