### PR TITLE
fix: add ability to read with file: option for nested json params for…

### DIFF
--- a/lib/commands/smapi/smapi-command-handler.js
+++ b/lib/commands/smapi/smapi-command-handler.js
@@ -45,6 +45,8 @@ const _loadJson = (value) => {
     return json;
 };
 
+const _loadValue = (param, value) => (param.json ? _loadJson(value) : value);
+
 const _mapToParams = (optionsValues, flatParamsMap, commanderToApiCustomizationMap) => {
     const res = {};
     Object.keys(optionsValues).forEach(key => {
@@ -60,13 +62,11 @@ const _mapToParams = (optionsValues, flatParamsMap, commanderToApiCustomizationM
                     res[param.rootName] = {};
                 }
                 let mergeObject = {};
-                mergeObject[param.bodyPath] = value;
+                mergeObject[param.bodyPath] = _loadValue(param, value);
                 mergeObject = unflatten(mergeObject, BODY_PATH_DELIMITER);
                 res[param.rootName] = R.mergeDeepRight(res[param.rootName], mergeObject);
-            } else if (param.json) {
-                res[param.name] = _loadJson(value);
             } else {
-                res[param.name] = value;
+                res[param.name] = _loadValue(param, value);
             }
         }
     });


### PR DESCRIPTION

we were not supporting reading from file when nested body param is json
for example
{
  "endpointRegion": "NA",
  "skillRequest": {
    "body": {}
  }
}

`ask smapi invoke-skill-end-point -s amzn1.ask.skill.e9ac9d7f-5c4f-4c3b-8e41-1b347f625d95 --skill-request-body file:./fixtures/skill-request.json -g development --endpoint-region NA`

--skill-request-body file:./some-file.json was not supported

Adding support for it.

