### PR TITLE
fix: show full context if error happens, and don't fail smapi-sdk's error response

### DIFF
--- a/bin/ask-smapi.js
+++ b/bin/ask-smapi.js
@@ -13,7 +13,7 @@ if (!process.argv.slice(2).length) {
     commander.parseAsync(process.argv)
         .then(result => Messenger.getInstance().info(result))
         .catch(err => {
-            Messenger.getInstance().error(jsonView.toString(err.response));
+            Messenger.getInstance().error(jsonView.toString(err));
             process.exit(1);
         });
 }


### PR DESCRIPTION
Currently if smapi-sdk fails with a certain setup (like Login with Amazon failure), it will throw error object which doesn't have "response" field. CLI will returns with: 
```
$ ask smapi get-vendor-list
(node:61479) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'constructor' of undefined
    at Messenger.error (/Users/x/.nvm/versions/node/v10.8.0/lib/node_modules/ask-cli/lib/view/messenger.js:145:26)
    ...
(node:61479) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

After the change, it will show as 
```
$ ask smapi get-vendor-list
[Error]: {
  "name": "AskSdkModelRuntime.DefaultApiClient Error"
}
```

And for other smapi api's error, it will show the full response.