### PR TITLE
fix: initialise app config for authorization-controller

### DIFF
--- a/lib/controllers/authorization-controller/index.js
+++ b/lib/controllers/authorization-controller/index.js
@@ -1,4 +1,6 @@
 const open = require('open');
+const os = require('os');
+const path = require('path');
 const portscanner = require('portscanner');
 const url = require('url');
 
@@ -22,6 +24,20 @@ module.exports = class AuthorizationController {
     constructor(config) {
         this.authConfig = config;
         this.oauthClient = this._getAuthClientInstance();
+
+        try {
+            this._initiateAppConfig();
+        } catch (e) {
+            console.log('Failed AppConfig initialisation');
+        }
+    }
+
+    /**
+     * Initiate App Config
+     */
+    _initiateAppConfig() {
+        const configFilePath = path.join(os.homedir(), CONSTANTS.FILE_PATH.ASK.HIDDEN_FOLDER, CONSTANTS.FILE_PATH.ASK.PROFILE_FILE);
+        new AppConfig(configFilePath);
     }
 
     /**
@@ -167,7 +183,16 @@ module.exports = class AuthorizationController {
     _getAuthClientInstance() {
         if (this.authConfig.auth_client_type === 'LWA') {
             const { clientId, clientConfirmation, authorizeHost, tokenHost, scope, state, doDebug, redirectUri } = this.authConfig;
-            return new LWAAuthCodeClient({ clientId, clientConfirmation, authorizeHost, tokenHost, scope, state, doDebug, redirectUri });
+            return new LWAAuthCodeClient({
+                clientId,
+                clientConfirmation,
+                authorizeHost,
+                tokenHost,
+                scope,
+                state,
+                doDebug,
+                redirectUri
+            });
         }
     }
 };

--- a/test/unit/controller/authorization-controller/index-test.js
+++ b/test/unit/controller/authorization-controller/index-test.js
@@ -57,6 +57,31 @@ describe('Controller test - Authorization controller test', () => {
         state: TEST_STATE,
     };
 
+    describe('# test constructor', () => {
+        it('| initialise AppConfig', () => {
+            // setup
+            var appConfigSpy = sinon.spy(AuthorizationController.prototype, '_initiateAppConfig');
+
+            // call and verify
+            new AuthorizationController({ auth_client_type: 'UNKNOWN' });
+            expect(appConfigSpy.called).to.eq(true);
+        });
+
+        it('| failure to initialise AppConfig does not fail constructor', () => {
+            // setup
+            var appConfigStub = sinon.stub(AuthorizationController.prototype, '_initiateAppConfig');
+            appConfigStub.throws("blah");
+
+            // call and verify
+            var authorizationController = new AuthorizationController({ auth_client_type: 'UNKNOWN' });
+            expect(authorizationController).not.to.eq(null);
+        });
+
+        afterEach(() => {
+            sinon.restore();
+        })
+    });
+
     describe('# test _getAuthClientInstance', () => {
         it('| returns undefined', () => {
             // setup


### PR DESCRIPTION
… so deploy works seamlessly

*Issue #, if available:* #194 

*Description of changes:*
Deployment (`ask deploy`) fails during skill enablement because authorisation for smapi calls do not take ~/.ask/cli_config into consideration when authorisation-controller is triggered. This change ensures AppConfig is initialised when the controller is constructed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
