### PR TITLE
fix: add behaviour to http client to reject on bad http status codes

### DIFF
--- a/lib/commands/abstract-command.js
+++ b/lib/commands/abstract-command.js
@@ -189,8 +189,9 @@ class AbstractCommand {
             url: `${CONSTANTS.NPM_REGISTRY_URL_BASE}/${CONSTANTS.APPLICATION_NAME}/latest`,
             method: CONSTANTS.HTTP_REQUEST.VERB.GET
         }, 'GET_NPM_REGISTRY', doDebug, (err, response) => {
-            if (err) {
-                Messenger.getInstance().error(`Failed to get the latest version for ${CONSTANTS.APPLICATION_NAME} from NPM registry.\n${err}\n`);
+            if (err || response.statusCode > 300) {
+                const error = err || `Http Status Code: ${response.statusCode}.`;
+                Messenger.getInstance().error(`Failed to get the latest version for ${CONSTANTS.APPLICATION_NAME} from NPM registry.\n${error}\n`);
             } else {
                 const BANNER_WITH_HASH = '##########################################################################';
                 const latestVersion = JSON.parse(response.body).version;

--- a/test/unit/commands/abstract-command-test.js
+++ b/test/unit/commands/abstract-command-test.js
@@ -342,6 +342,24 @@ describe('Command test - AbstractCommand class', () => {
             });
         });
 
+        it('| http client request error status code , should warn it out and pass the process', (done) => {
+            // setup
+            httpClient.request.yields(undefined, { statusCode: 400 });
+            // call
+            AbstractCommand.prototype._remindsIfNewVersion(TEST_DO_DEBUG_FALSE, undefined, (err) => {
+                // verify
+                expect(httpClient.request.args[0][0].url).equal(
+                    `${CONSTANTS.NPM_REGISTRY_URL_BASE}/${CONSTANTS.APPLICATION_NAME}/latest`
+                );
+                expect(httpClient.request.args[0][0].method).equal(CONSTANTS.HTTP_REQUEST.VERB.GET);
+                expect(errorStub.args[0][0]).equal(
+                    `Failed to get the latest version for ${CONSTANTS.APPLICATION_NAME} from NPM registry.\nHttp Status Code: 400.\n`
+                );
+                expect(err).equal(undefined);
+                done();
+            });
+        });
+
         it('| new major version released, should error out and pass the process', (done) => {
             // setup
             const latestVersion = `${currentMajor + 1}.0.0`;


### PR DESCRIPTION
Addressing https://github.com/alexa/ask-cli/issues/193

http client should reject on bad status code.

for example this how axios behaves.

https://github.com/axios/axios

Side Note: Request lib is deprecated https://www.npmjs.com/package/request
