### PR TITLE
feat: add a AWS:Logs:LogGroup Resource in cfn-deployer template

### DIFF
--- a/lib/builtins/deploy-delegates/cfn-deployer/assets/basic-lambda.yaml
+++ b/lib/builtins/deploy-delegates/cfn-deployer/assets/basic-lambda.yaml
@@ -54,6 +54,11 @@ Resources:
       FunctionName: !GetAtt AlexaSkillFunction.Arn
       Principal: alexa-appkit.amazon.com
       EventSourceToken: !Ref SkillId
+  AlexaSkillFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub /aws/lambda/${AlexaSkillFunction}
+      RetentionInDays: 14
 Outputs:
   SkillEndpoint:
     Description: LambdaARN for the regional endpoint


### PR DESCRIPTION
## Summary

Define a CloudWatch Logs LogGroup in the Skill's CloudFormation template.

## Motivation

We can easy to manage own Log Group.

### Issue

For now, the Lambda function will create the functions LogGroup automatically.
But, the LogGroup has a several problems.

- The LogGroup does not delete when the CloudFormation deleted
- The LogGroup's retention in days is forever.

![スクリーンショット 2020-05-17 1 43 53](https://user-images.githubusercontent.com/6883571/82125566-c95d6b80-97e1-11ea-8979-7e945f158d22.png)

So if we create multiple skills by using the CLI, our AWS fee will be getting higher and higher by  LogGroup of these skills.
Because no LogGroup will be deleted without manual operation.

### Solution

When we define the LogGroup Resource in our CloudFormation, we can easy to manage it!

We can update the log's retention days by updating the CloudFormation.
When we delete the skill, the CloudFormation will be delete the LogGroup automatically.
If we want to retain the LogGroup, just update the CloudFormation to add a Retain property before delete it.
