### PR TITLE
feat: add full-response flag to smapi commands

### DIFF
--- a/lib/commands/option-model.json
+++ b/lib/commands/option-model.json
@@ -11,6 +11,12 @@
     "alias": null,
     "stringInput": "NONE"
   },
+  "full-response": {
+    "name": "full-response",
+    "description": "Returns body, headers and status code of the response as one object.",
+    "alias": null,
+    "stringInput": "NONE"
+  },
   "ignore-hash": {
     "name": "ignore-hash",
     "description": "Forces ASK CLI deploy skill package even if the hash of current skill package folder does not change.",

--- a/lib/commands/smapi/smapi-command-handler.js
+++ b/lib/commands/smapi/smapi-command-handler.js
@@ -131,9 +131,8 @@ const smapiCommandHandler = (swaggerApiOperationName, flatParamsMap, commanderTo
             const { body, headers, statusCode } = response;
             let result = '';
             if (inputOpts.debug) {
-                Messenger.getInstance().info(`Status code: ${statusCode}`);
-                Messenger.getInstance().info(`Response headers: ${jsonView.toString(headers)}`);
-                Messenger.getInstance().info(`Response body: ${jsonView.toString(body)}`);
+                Messenger.getInstance().info('Response:');
+                Messenger.getInstance().info(jsonView.toString({ body, headers, statusCode }));
             } else if (inputOpts.fullResponse) {
                 result = jsonView.toString({ body, headers, statusCode });
             } else {

--- a/lib/commands/smapi/smapi-command-handler.js
+++ b/lib/commands/smapi/smapi-command-handler.js
@@ -134,6 +134,8 @@ const smapiCommandHandler = (swaggerApiOperationName, flatParamsMap, commanderTo
                 Messenger.getInstance().info(`Status code: ${statusCode}`);
                 Messenger.getInstance().info(`Response headers: ${jsonView.toString(headers)}`);
                 Messenger.getInstance().info(`Response body: ${jsonView.toString(body)}`);
+            } else if (inputOpts.fullResponse) {
+                result = jsonView.toString({ body, headers, statusCode });
             } else {
                 result = body && Object.keys(body).length ? jsonView.toString(body) : 'Command executed successfully!';
             }

--- a/lib/commands/smapi/smapi-commander.js
+++ b/lib/commands/smapi/smapi-commander.js
@@ -13,14 +13,20 @@ const getTask = require('./appended-commands/get-task');
 const searchTask = require('./appended-commands/search-task');
 
 
-const defaultOptions = [{
-    flags: `-${optionModel.profile.alias}, --profile <profile>`,
-    description: optionModel.profile.description
-},
-{
-    flags: '--debug',
-    description: optionModel.debug.description
-}];
+const defaultOptions = [
+    {
+        flags: `-${optionModel.profile.alias}, --profile <profile>`,
+        description: optionModel.profile.description
+    },
+    {
+        flags: '--full-response',
+        description: optionModel['full-response'].description
+    },
+    {
+        flags: '--debug',
+        description: optionModel.debug.description
+    }
+];
 const requiredTemplate = { true: '[REQUIRED]', false: '[OPTIONAL]' };
 const jsonTemplate = { true: '[JSON]: JSON string or a file. Example: "$(cat {filePath})" '
 + 'or "file:{filePath}", either absolute or relative path are supported.\n',

--- a/test/unit/commands/smapi/smapi-command-handler-test.js
+++ b/test/unit/commands/smapi/smapi-command-handler-test.js
@@ -122,9 +122,8 @@ describe('Smapi test - smapiCommandHandler function', () => {
                 someNonPopulatedProperty: null,
                 someArray: null,
                 simulationsApiRequest: null })}\n`]);
-        expect(messengerStub.args[3]).eql(['INFO', `Status code: ${fakeResponse.statusCode}`]);
-        expect(messengerStub.args[4]).eql(['INFO', `Response headers: ${jsonView.toString(fakeResponse.headers)}`]);
-        expect(messengerStub.args[5]).eql(['INFO', `Response body: ${jsonView.toString(fakeResponse.body)}`]);
+        expect(messengerStub.args[3]).eql(['INFO', 'Response:']);
+        expect(messengerStub.args[4]).eql(['INFO', jsonView.toString(fakeResponse)]);
     });
 
     it('| should display body, headers and status code when full response flag is passed', async () => {

--- a/test/unit/commands/smapi/smapi-command-handler-test.js
+++ b/test/unit/commands/smapi/smapi-command-handler-test.js
@@ -127,6 +127,19 @@ describe('Smapi test - smapiCommandHandler function', () => {
         expect(messengerStub.args[5]).eql(['INFO', `Response body: ${jsonView.toString(fakeResponse.body)}`]);
     });
 
+    it('| should display body, headers and status code when full response flag is passed', async () => {
+        const cmdObjDebug = {
+            opts() {
+                return { fullResponse: true, skillId };
+            },
+            _name: commandName
+        };
+
+        const result = await smapiCommandHandler(apiOperationName, flatParamsMap, commanderToApiCustomizationMap, cmdObjDebug, modelInterceptor);
+
+        expect(result).eql(jsonView.toString(fakeResponse));
+    });
+
     afterEach(() => {
         sinon.restore();
     });


### PR DESCRIPTION
adding full-response flag to smapi commands

Example:

`ask smapi get-skill-credentials -s amzn1.ask.skill.e9ac9d7f-5c4f-4c3b-8e41-1b347f625d95 --full-response`
