### PR TITLE
feat: support partial deploy for lambda-deployer and revisit the protocol for deployer response

### DIFF
--- a/lib/builtins/deploy-delegates/cfn-deployer/index.js
+++ b/lib/builtins/deploy-delegates/cfn-deployer/index.js
@@ -38,8 +38,15 @@ function bootstrap(options, callback) {
 /**
  * Invoke the actual deploy logic for skill's infrastructures
  * @param {Object} reporter upstream CLI status reporter
- * @param {Object} options
- * @param {Function} callback
+ * @param {Object} options request object from deploy-delegate which provides user's input and project's info
+ *                         { profile, alexaRegion, skillId, skillName, code, userConfig, deployState }
+ * @param {Function} callback { errorStr, responseObject }
+ *                            .errorStr deployDelegate will fail immediately with this errorStr
+ *                            .responseObject.isAllStepSuccess show if the entire process succeeds
+ *                            .responseObject.isCodeDeployed true if the code is uploaded sucessfully and no need to upload again
+ *                            .responseObject.deployState record the state of deployment back to file (including partial success)
+ *                            .responseObject.endpoint the final result endpoint response
+ *                            .responseObject.resultMessage the message to summarize current situation
  */
 function invoke(reporter, options, callback) {
     const { profile, alexaRegion, skillId, skillName, code, userConfig, deployState = {} } = options;
@@ -99,21 +106,29 @@ function invoke(reporter, options, callback) {
             if (deployErr) {
                 return callback(_composeErrorMessage(deployErr, alexaRegion));
             }
+            let isAllStepSuccess = false;
+            let isCodeDeployed = false;
             const { stackId, endpointUri, reasons } = deployResult;
             if (!reasons || reasons === []) {
+                isAllStepSuccess = true;
+                isCodeDeployed = true;
                 deployState[alexaRegion].stackId = stackId;
                 const invokeResponse = {
+                    isAllStepSuccess,
+                    isCodeDeployed,
+                    deployState: deployState[alexaRegion],
                     endpoint: { uri: endpointUri },
-                    message: _composeSuccessMessage(endpointUri, alexaRegion),
-                    deployState: deployState[alexaRegion]
+                    resultMessage: _composeSuccessMessage(endpointUri, alexaRegion)
                 };
                 return callback(null, invokeResponse);
             }
 
+            isCodeDeployed = !!(deployState && deployState[alexaRegion] && deployState[alexaRegion].s3);
             callback(null, {
-                reasons,
-                message: _composeErrorMessage(reasons, alexaRegion),
-                deployState: deployState[alexaRegion]
+                isAllStepSuccess,
+                isCodeDeployed,
+                deployState: deployState[alexaRegion],
+                resultMessage: _composeErrorMessage(reasons, alexaRegion)
             });
         });
     });

--- a/lib/builtins/deploy-delegates/lambda-deployer/helper.js
+++ b/lib/builtins/deploy-delegates/lambda-deployer/helper.js
@@ -212,12 +212,25 @@ function _updateLambdaFunction(reporter, lambdaClient, options, callback) {
         revisionId = codeData.RevisionId;
         lambdaClient.updateFunctionConfiguration(functionName, runtime, handler, revisionId, (configErr, configData) => {
             if (configErr) {
-                return callback(configErr);
+                return callback(null, {
+                    isAllStepSuccess: false,
+                    isCodeDeployed: true,
+                    lambdaResponse: {
+                        arn: codeData.FunctionArn,
+                        revisionId: codeData.RevisionId,
+                        lastModified: codeData.LastModified
+                    },
+                    resultMessage: configErr
+                });
             }
             callback(null, {
-                arn: configData.FunctionArn,
-                lastModified: configData.LastModified,
-                revisionId: configData.RevisionId
+                isAllStepSuccess: true,
+                isCodeDeployed: true,
+                lambdaResponse: {
+                    arn: configData.FunctionArn,
+                    lastModified: configData.LastModified,
+                    revisionId: configData.RevisionId
+                }
             });
         });
     });

--- a/lib/builtins/deploy-delegates/lambda-deployer/helper.js
+++ b/lib/builtins/deploy-delegates/lambda-deployer/helper.js
@@ -172,9 +172,13 @@ function _createLambdaFunction(reporter, lambdaClient, options, callback) {
                     return callback(revisionErr);
                 }
                 callback(null, {
-                    arn,
-                    lastModified: lambdaData.LastModified,
-                    revisionId: revisionData.Configuration.RevisionId
+                    isAllStepSuccess: true,
+                    isCodeDeployed: true,
+                    lambdaResponse: {
+                        arn,
+                        lastModified: lambdaData.LastModified,
+                        revisionId: revisionData.Configuration.RevisionId
+                    }
                 });
             });
         });

--- a/lib/builtins/deploy-delegates/lambda-deployer/helper.js
+++ b/lib/builtins/deploy-delegates/lambda-deployer/helper.js
@@ -221,8 +221,8 @@ function _updateLambdaFunction(reporter, lambdaClient, options, callback) {
                     isCodeDeployed: true,
                     lambdaResponse: {
                         arn: codeData.FunctionArn,
-                        revisionId: codeData.RevisionId,
-                        lastModified: codeData.LastModified
+                        lastModified: codeData.LastModified,
+                        revisionId: codeData.RevisionId
                     },
                     resultMessage: configErr
                 });

--- a/lib/builtins/deploy-delegates/lambda-deployer/index.js
+++ b/lib/builtins/deploy-delegates/lambda-deployer/index.js
@@ -76,25 +76,34 @@ function invoke(reporter, options, callback) {
                 currentRegionDeployState
             };
             helper.deployLambdaFunction(reporter, deployLambdaConfig, (lambdaErr, lambdaResult) => {
+                // 1.fatal error happens in Lambda deployment and nothing need to record additionally
                 if (lambdaErr) {
-                    const errMessage = `The lambda deploy failed for Alexa region "${alexaRegion}": ${lambdaErr}`;
-                    const reasons = [errMessage];
                     return callback(null, {
-                        reasons,
-                        message: errMessage,
-                        deployState: deployState[alexaRegion]
+                        isAllStepSuccess: false,
+                        isCodeDeployed: false,
+                        deployState: deployState[alexaRegion],
+                        resultMessage: `The lambda deploy failed for Alexa region "${alexaRegion}": ${lambdaErr}`
                     });
                 }
-                const { arn, lastModified, revisionId } = lambdaResult;
-                deployState[alexaRegion].lambda = {
-                    arn,
-                    lastModified,
-                    revisionId
-                };
+                const { isAllStepSuccess, isCodeDeployed, lambdaResponse = {} } = lambdaResult;
+                deployState[alexaRegion].lambda = lambdaResponse;
+                const { arn } = lambdaResponse;
+                // 2.full successs in Lambda deploy
+                if (isAllStepSuccess) {
+                    return callback(null, {
+                        isAllStepSuccess,
+                        isCodeDeployed,
+                        deployState: deployState[alexaRegion],
+                        endpoint: { uri: arn },
+                        resultMessage: `The lambda deploy succeeded for Alexa region "${alexaRegion}" with output Lambda ARN: ${arn}.`
+                    });
+                }
+                // 3.partial success in Lambda deploy (like only LambdaCode is deployed)
                 return callback(null, {
-                    endpoint: { uri: arn },
-                    message: `The lambda deploy succeeded for Alexa region "${alexaRegion}" with output Lambda ARN: ${arn}.`,
-                    deployState: deployState[alexaRegion]
+                    isAllStepSuccess,
+                    isCodeDeployed,
+                    deployState: deployState[alexaRegion],
+                    resultMessage: `The lambda deploy failed for Alexa region "${alexaRegion}": ${lambdaResult.resultMessage}`
                 });
             });
         });

--- a/lib/controllers/skill-infrastructure-controller/index.js
+++ b/lib/controllers/skill-infrastructure-controller/index.js
@@ -202,28 +202,20 @@ module.exports = class SkillInfrastructureController {
                 if (invokeErr) {
                     return callback(invokeErr);
                 }
-                const { deployState, message, reasons } = invokeResult;
-                // track the current hash when deploy state contains s3 result
-                if (deployState && deployState.s3) { // TODO how come there is an S3 here...
+                const { isAllStepSuccess, isCodeDeployed } = invokeResult;
+                // track the current hash if isCodeDeployed
+                if (isCodeDeployed) {
                     invokeResult.lastDeployHash = currentHash;
                 }
-                if (reasons) {
-                    // when "reasons" exist, regional deployment fails and need to callback with an error object with message and the deploy context
-                    const context = {
-                        deployState: invokeResult.deployState,
-                        lastDeployHash: invokeResult.lastDeployHash
-                    };
-                    callback({ message, context });
-                } else {
-                    callback(null, invokeResult);
-                }
+                // pass back result based on if isAllStepSuccess, pass result as error if not all steps succeed
+                callback(isAllStepSuccess ? null : invokeResult, isAllStepSuccess ? invokeResult : undefined);
             });
         });
     }
 
     /**
      * Update the the ask resources config and the deploy state.
-     * @param {Object} rawDeployResult deploy result from invoke: { $region: { endpoint: { url }, lastDeployHash, deployState } }
+     * @param {Object} rawDeployResult deploy result from invoke: { $region: deploy-delegate's response }
      */
     _updateResourcesConfig(rawDeployResult) {
         const newDeployState = {};

--- a/lib/view/multi-tasks-view.js
+++ b/lib/view/multi-tasks-view.js
@@ -60,11 +60,9 @@ class ListrReactiveTask {
             this._eventEmitter.on('error', (error) => {
                 if (error && typeof error === 'string') {
                     subscriber.error(error);
-                } else if (error && error.message) {
-                    subscriber.error(error.message);
-                    if (error.context) {
-                        ctx[this.taskId] = error.context;
-                    }
+                } else if (error && error.resultMessage) {
+                    subscriber.error(error.resultMessage);
+                    ctx[this.taskId] = error;
                 }
             });
             this._eventEmitter.on('title', (title) => {

--- a/test/unit/builtins/lambda-deployer/helper-test.js
+++ b/test/unit/builtins/lambda-deployer/helper-test.js
@@ -346,11 +346,12 @@ ${TEST_REMOTE_REVISION_ID}, but found ${TEST_LOCAL_REVISION_ID}. Please solve th
         it('| no Lambda found, create Lambda function, add Alexa Permission and get Function revisionId pass, expect Lambda data return.', (done) => {
             // setup
             const TEST_LAMBDA_DATA = {
-                FunctionArn: TEST_FUNCTION_ARN
+                FunctionArn: TEST_FUNCTION_ARN,
+                LastModified: TEST_LAST_MODIFIED
             };
             const TEST_GET_FUNCTION_RESPONSE = {
                 Configuration: {
-                    RevisionId: TEST_UPDATED_REVISION_ID
+                    RevisionId: TEST_UPDATED_REVISION_ID,
                 }
             };
             sinon.stub(fs, 'readFileSync').withArgs(TEST_ZIP_FILE_PATH).returns(TEST_ZIP_FILE);
@@ -362,8 +363,15 @@ ${TEST_REMOTE_REVISION_ID}, but found ${TEST_LOCAL_REVISION_ID}. Please solve th
             // call
             helper.deployLambdaFunction(REPORTER, TEST_CREATE_OPTIONS, (err, res) => {
                 // verify
-                expect(res.arn).equal(TEST_FUNCTION_ARN);
-                expect(res.revisionId).equal(TEST_UPDATED_REVISION_ID);
+                expect(res).deep.equal({
+                    isAllStepSuccess: true,
+                    isCodeDeployed: true,
+                    lambdaResponse: {
+                        arn: TEST_FUNCTION_ARN,
+                        lastModified: TEST_LAST_MODIFIED,
+                        revisionId: TEST_UPDATED_REVISION_ID
+                    }
+                });
                 done();
             });
         });

--- a/test/unit/builtins/lambda-deployer/helper-test.js
+++ b/test/unit/builtins/lambda-deployer/helper-test.js
@@ -390,9 +390,19 @@ ${TEST_REMOTE_REVISION_ID}, but found ${TEST_LOCAL_REVISION_ID}. Please solve th
             sinon.stub(LambdaClient.prototype, 'updateFunctionCode').callsArgWith(3, null, { RevisionId: TEST_REVISION_ID });
             sinon.stub(LambdaClient.prototype, 'updateFunctionConfiguration').callsArgWith(4, TEST_UPDATE_CONGIF_ERROR);
             // call
-            helper.deployLambdaFunction(REPORTER, TEST_UPDATE_OPTIONS, (err) => {
+            helper.deployLambdaFunction(REPORTER, TEST_UPDATE_OPTIONS, (err, res) => {
                 // verify
-                expect(err).equal(TEST_UPDATE_CONGIF_ERROR);
+                expect(err).equal(null);
+                expect(res).deep.equal({
+                    isAllStepSuccess: false,
+                    isCodeDeployed: true,
+                    lambdaResponse: {
+                        arn: undefined,
+                        lastModified: undefined,
+                        revisionId: TEST_REVISION_ID
+                    },
+                    resultMessage: TEST_UPDATE_CONGIF_ERROR
+                });
                 done();
             });
         });
@@ -411,9 +421,15 @@ ${TEST_REMOTE_REVISION_ID}, but found ${TEST_LOCAL_REVISION_ID}. Please solve th
             // call
             helper.deployLambdaFunction(REPORTER, TEST_UPDATE_OPTIONS, (err, data) => {
                 // verify
-                expect(data.arn).equal(TEST_LAMBDA_ARN);
-                expect(data.lastModified).equal(TEST_LAST_MODIFIED);
-                expect(data.revisionId).equal(TEST_REVISION_ID);
+                expect(data).deep.equal({
+                    isAllStepSuccess: true,
+                    isCodeDeployed: true,
+                    lambdaResponse: {
+                        arn: TEST_LAMBDA_ARN,
+                        lastModified: TEST_LAST_MODIFIED,
+                        revisionId: TEST_REVISION_ID
+                    }
+                });
                 done();
             });
         });

--- a/test/unit/controller/skill-infrastructure-controller-test.js
+++ b/test/unit/controller/skill-infrastructure-controller-test.js
@@ -455,15 +455,20 @@ describe('Controller test - skill infrastructure controller test', () => {
             });
         });
 
-        it('| deploy delegate invoke passes without deployState, expect invoke result called back', (done) => {
+        it('| deploy delegate invoke passes with isCodeDeployed true, expect invoke result called back with currentHash', (done) => {
             // setup
             sinon.stub(hashUtils, 'getHash').callsArgWith(1, null, TEST_HASH);
-            ddStub.callsArgWith(2, null, { invoke: 'result' });
+            ddStub.callsArgWith(2, null, {
+                isCodeDeployed: true,
+                isAllStepSuccess: true
+            });
             // call
             skillInfraController._deployInfraByRegion(TEST_REPORTER, TEST_DD, TEST_REGION, TEST_SKILL_NAME, (err, res) => {
                 // verify
                 expect(res).deep.equal({
-                    invoke: 'result'
+                    isCodeDeployed: true,
+                    isAllStepSuccess: true,
+                    lastDeployHash: TEST_HASH
                 });
                 expect(err).equal(null);
                 done();
@@ -473,13 +478,20 @@ describe('Controller test - skill infrastructure controller test', () => {
         it('| deploy delegate invoke passes, expect invoke result called back', (done) => {
             // setup
             sinon.stub(hashUtils, 'getHash').callsArgWith(1, null, TEST_HASH);
-            ddStub.callsArgWith(2, null, { deployState: { s3: { invoke: 'test' } } });
+            ddStub.callsArgWith(2, null, {
+                isCodeDeployed: false,
+                isAllStepSuccess: true,
+                resultMessage: 'success',
+                deployState: {}
+            });
             // call
             skillInfraController._deployInfraByRegion(TEST_REPORTER, TEST_DD, TEST_REGION, TEST_SKILL_NAME, (err, res) => {
                 // verify
                 expect(res).deep.equal({
-                    deployState: { s3: { invoke: 'test' } },
-                    lastDeployHash: TEST_HASH
+                    isCodeDeployed: false,
+                    isAllStepSuccess: true,
+                    resultMessage: 'success',
+                    deployState: {}
                 });
                 expect(err).equal(null);
                 done();
@@ -489,17 +501,22 @@ describe('Controller test - skill infrastructure controller test', () => {
         it('| deploy delegate invoke partial succeed with reasons called back, expect invoke result called back along with the message', (done) => {
             // setup
             sinon.stub(hashUtils, 'getHash').callsArgWith(1, null, TEST_HASH);
-            ddStub.callsArgWith(2, null, { reasons: 'reasons', message: 'message', deployState: { s3: 'test' } });
+            ddStub.callsArgWith(2, null, {
+                isCodeDeployed: true,
+                isAllStepSuccess: false,
+                resultMessage: 'partial fail',
+                deployState: {}
+            });
             // call
             skillInfraController._deployInfraByRegion(TEST_REPORTER, TEST_DD, TEST_REGION, TEST_SKILL_NAME, (err, res) => {
                 // verify
                 expect(res).equal(undefined);
                 expect(err).deep.equal({
-                    message: 'message',
-                    context: {
-                        deployState: { s3: 'test' },
-                        lastDeployHash: TEST_HASH
-                    }
+                    isCodeDeployed: true,
+                    isAllStepSuccess: false,
+                    lastDeployHash: TEST_HASH,
+                    resultMessage: 'partial fail',
+                    deployState: {}
                 });
                 done();
             });

--- a/test/unit/view/multi-tasks-view-test.js
+++ b/test/unit/view/multi-tasks-view-test.js
@@ -203,7 +203,7 @@ describe('View test - ListReactiveTask test', () => {
         it('| when "error" event emit with error.message, expect subscriber to call "error"', () => {
             // setup
             const TEST_ERROR_OBJ = {
-                message: 'error'
+                resultMessage: 'error'
             };
             const subscribeStub = {
                 error: sinon.stub()
@@ -215,14 +215,14 @@ describe('View test - ListReactiveTask test', () => {
             obsv._subscribe(subscribeStub);
             // verify
             expect(subscribeStub.error.args[0][0]).equal('error');
-            expect(TEST_CONTEXT).deep.equal({});
+            expect(TEST_CONTEXT[TEST_TASK_ID]).deep.equal(TEST_ERROR_OBJ);
         });
 
         it('| when "error" event emit with error object structure, expect subscriber to call "error" and set context', () => {
             // setup
             const TEST_ERROR_OBJ = {
-                message: 'error',
-                context: 'context'
+                resultMessage: 'error',
+                deployState: 'state'
             };
             const subscribeStub = {
                 error: sinon.stub()
@@ -234,7 +234,7 @@ describe('View test - ListReactiveTask test', () => {
             obsv._subscribe(subscribeStub);
             // verify
             expect(subscribeStub.error.args[0][0]).equal('error');
-            expect(TEST_CONTEXT[TEST_TASK_ID]).equal('context');
+            expect(TEST_CONTEXT[TEST_TASK_ID]).deep.equal(TEST_ERROR_OBJ);
         });
 
         it('| when "title" event emit, expect subscriber to call "title"', () => {


### PR DESCRIPTION
This fix solves issue https://github.com/alexa/ask-cli/issues/162.

It also cleans the logic for the response of `invoke` method for each deployer:
```
function invoke(..., callback) {
 * callback satisfies the structure of { errorStr, responseObj }
 *   .errorStr     deployDelegate will fail immediately with this errorStr
 *   .responseObject.isAllStepSuccess: show if the entire process succeeds
 *   .responseObject.isCodeDeployed: true if the code is uploaded sucessfully and no need to upload again
 *   .responseObject.deployState: record the state of deployment back to file (including partial success)
 *   .responseObject.endpoint: the final result endpoint response
 *   .responseObject.resultMessage: the message to summarize current situation
}
```