### PR TITLE
fix: smapi - improve logic to determine required for nested body params

### DIFF
--- a/lib/commands/smapi/cli-customization-processor.js
+++ b/lib/commands/smapi/cli-customization-processor.js
@@ -142,13 +142,15 @@ class CliCustomizationProcessor {
         if (secondLevelDefinition.enum) {
             const { type } = secondLevelDefinition;
             const { description, enumOptions } = this._mapEnum(parentDescription, secondLevelDefinition);
-            customizedParameter = { name: parentName,
+            customizedParameter = {
+                name: parentName,
                 description,
                 rootName,
                 required: parentRequired,
                 bodyPath: parentName,
                 enum: enumOptions,
-                type };
+                type
+            };
             this._addCustomizedParameter(customizationMetadata, customizedParameter);
         }
     }

--- a/lib/commands/smapi/cli-customization-processor.js
+++ b/lib/commands/smapi/cli-customization-processor.js
@@ -108,7 +108,14 @@ class CliCustomizationProcessor {
         return false;
     }
 
-    _appendSecondLevelProperty(customizationMetadata, parentName, rootName, secondLevelDefinition, required, definitions) {
+    _isRequired(definition, key, parentRequired) {
+        if (definition.required) {
+            return definition.required.includes(key);
+        }
+        return !!parentRequired;
+    }
+
+    _appendSecondLevelProperty(customizationMetadata, parentName, rootName, secondLevelDefinition, parentRequired, definitions) {
         let customizedParameter;
         const parentDescription = secondLevelDefinition.description;
         this._ensureNumberOfProperties(rootName, secondLevelDefinition.properties);
@@ -128,31 +135,39 @@ class CliCustomizationProcessor {
             }
             const json = this._shouldParseAsJson(property, definitions);
             const bodyPath = `${parentName}${BODY_PATH_DELIMITER}${key}`;
+            const required = this._isRequired(secondLevelDefinition, key, parentRequired);
             customizedParameter = { name: `${parentName} ${key}`, description, rootName, required, bodyPath, enum: enumOptions, json, type };
             this._addCustomizedParameter(customizationMetadata, customizedParameter);
         });
         if (secondLevelDefinition.enum) {
             const { type } = secondLevelDefinition;
             const { description, enumOptions } = this._mapEnum(parentDescription, secondLevelDefinition);
-            customizedParameter = { name: parentName, description, rootName, required, bodyPath: parentName, enum: enumOptions, type };
+            customizedParameter = { name: parentName,
+                description,
+                rootName,
+                required: parentRequired,
+                bodyPath: parentName,
+                enum: enumOptions,
+                type };
             this._addCustomizedParameter(customizationMetadata, customizedParameter);
         }
     }
 
     _processNestedBodyParam(param, properties, customizationMetadata, rootName, definitions) {
-        const requiredInCurrentShape = this._getDefinitionSchema(param.schema.$ref, definitions).required || [];
-
         this._ensureNumberOfProperties(rootName, properties);
+        const parentRequired = this._getDefinitionSchema(param.schema.$ref, definitions).required;
         Object.keys(properties).forEach(key => {
             const property = properties[key];
+            const isParentRequired = parentRequired && parentRequired.includes(key);
             if (property.$ref) {
                 const secondLevelDefinition = this._getDefinitionSchema(property.$ref, definitions);
-                const isRequired = requiredInCurrentShape.includes(key);
+                const isRequired = this._isRequired(secondLevelDefinition, key, isParentRequired);
                 this._appendSecondLevelProperty(customizationMetadata, key, rootName, secondLevelDefinition, isRequired, definitions);
             } else {
                 const { description, type } = property;
                 const json = this._shouldParseAsJson(property, definitions);
-                const required = param.required && requiredInCurrentShape.includes(key); // true when the shape and the property are both required
+                const parentDefinition = this._getDefinitionSchema(param.schema.$ref, definitions);
+                const required = this._isRequired(parentDefinition, key, isParentRequired);
                 const customizedParameter = { name: key, description, rootName, required, bodyPath: key, json, type };
                 this._addCustomizedParameter(customizationMetadata, customizedParameter);
             }

--- a/test/unit/commands/smapi/cli-customization-processor-test.js
+++ b/test/unit/commands/smapi/cli-customization-processor-test.js
@@ -226,7 +226,7 @@ describe('Smapi test - CliCustomizationProcessor class', () => {
                 name,
                 rootName,
                 bodyPath,
-                required: true,
+                required: false,
                 enum: null,
                 json: false,
                 isNumber: true,


### PR DESCRIPTION
required will be determined as the following

1) if parent has required array and the child key is in the array then true else false
2) else if parent does not have required array then inherit require from parent.

Step 2: Update swagger to make sure lower leafs have required defined to fix some minor inconsistencies.


