### PR TITLE
fix: add host url to apply credential helper to hosted skill repo only

### DIFF
--- a/lib/clients/git-client.js
+++ b/lib/clients/git-client.js
@@ -36,12 +36,13 @@ module.exports = class GitClient {
     /**
      * Config local git credential helper with credentialHelperPath
      * @param {string} credentialHelperPath the path of git credential helper
+     * @param {string} hostUrl host url to apply credential helper to
      */
-    configureCredentialHelper(credentialHelperPath) {
+    configureCredentialHelper(credentialHelperPath, hostUrl) {
         const commands = [
-            'git config --local credential.helper ""',
-            `git config --local --add credential.helper "!${credentialHelperPath}"`,
-            'git config --local credential.UseHttpPath true'];
+            `git config --local credential.${hostUrl}.helper ""`,
+            `git config --local --add credential.${hostUrl}.helper "!${credentialHelperPath}"`,
+            `git config --local credential.${hostUrl}.UseHttpPath true`];
         const options = {
             showStdOut: this.verbosityOptions.showOutput,
             showStdErr: true,

--- a/lib/clients/git-client.js
+++ b/lib/clients/git-client.js
@@ -36,7 +36,7 @@ module.exports = class GitClient {
     /**
      * Config local git credential helper with credentialHelperPath
      * @param {string} credentialHelperPath the path of git credential helper
-     * @param {string} hostUrl host url to apply credential helper to
+     * @param {string} hostUrl the host url to apply to the credential helper
      */
     configureCredentialHelper(credentialHelperPath, hostUrl) {
         const commands = [

--- a/lib/controllers/hosted-skill-controller/clone-flow.js
+++ b/lib/controllers/hosted-skill-controller/clone-flow.js
@@ -76,7 +76,7 @@ function _gitCloneWorkflow(projectPath, repositoryUrl, verbosityOptions, profile
     const gitClient = new GitClient(projectPath, verbosityOptions);
     gitClient.init();
     const credentialHelperPath = `ask util git-credentials-helper --profile ${profile}`;
-    gitClient.configureCredentialHelper(credentialHelperPath);
+    gitClient.configureCredentialHelper(credentialHelperPath, repositoryUrl);
     gitClient.addOrigin(repositoryUrl);
 
     if (verbose) {

--- a/test/unit/clients/git-client-test.js
+++ b/test/unit/clients/git-client-test.js
@@ -63,10 +63,11 @@ describe('Clients test - cli git client', () => {
 
     describe('# test configureCredentialHelper', () => {
         const TEST_CREDENTIAL_HELPER_PATH = 'TEST_CREDENTIAL_HELPER_PATH';
+        const TEST_GIT_HOST_URL = 'SOME_URL';
         const TEST_COMMAND = [
-            'git config --local credential.helper ""',
-            `git config --local --add credential.helper "!${TEST_CREDENTIAL_HELPER_PATH}"`,
-            'git config --local credential.UseHttpPath true'];
+            `git config --local credential.${TEST_GIT_HOST_URL}.helper ""`,
+            `git config --local --add credential.${TEST_GIT_HOST_URL}.helper "!${TEST_CREDENTIAL_HELPER_PATH}"`,
+            `git config --local credential.${TEST_GIT_HOST_URL}.UseHttpPath true`];
 
         afterEach(() => {
             sinon.restore();
@@ -77,7 +78,7 @@ describe('Clients test - cli git client', () => {
             const gitClient = new GitClient(TEST_PROJECT_PATH, TEST_VERBOSITY_OPTIONS);
             sinon.stub(gitClient, '_execChildProcessSync');
             // call
-            gitClient.configureCredentialHelper(TEST_CREDENTIAL_HELPER_PATH);
+            gitClient.configureCredentialHelper(TEST_CREDENTIAL_HELPER_PATH, TEST_GIT_HOST_URL);
             // verify
             expect(gitClient._execChildProcessSync.callCount).eq(3);
             expect(gitClient._execChildProcessSync.args[0][0]).eq(TEST_COMMAND[0]);


### PR DESCRIPTION
before credential helper was applied to all remotes in the repo.
this would not allow developers to use git to push to their repo if they used hosted skill.

scoped credential helper to hosted skill repo only.

before config looked like this
`cat .git/config`
```
[credential]
	helper = 
	helper = ask configure util git-credentials-helper
	UseHttpPath = true
```
after:
```
[credential "https://git-codecommit.us-east-1.amazonaws.com/v1/repos/da0f45e9-8931-40d1-942a-bce471b1fc55"]
        helper = 
        helper = !ask util git-credentials-helper --profile default
        UseHttpPath = true
```
You can test by adding second remote and pushing to it

```
git remote add personal git@github.com:kakhaUrigashvili/alexa-hosted-skill.git
git push personal master
```