### PR TITLE
feat: add support for csv content type body param in smapi

### DIFF
--- a/lib/commands/smapi/smapi-command-handler.js
+++ b/lib/commands/smapi/smapi-command-handler.js
@@ -12,7 +12,7 @@ const jsonView = require('@src/view/json-view');
 const Messenger = require('@src/view/messenger');
 const profileHelper = require('@src/utils/profile-helper');
 const unflatten = require('@src/utils/unflatten');
-const { getParamNames, standardize } = require('@src/utils/string-utils');
+const { getParamNames, standardize, canParseAsJson } = require('@src/utils/string-utils');
 
 const BeforeSendProcessor = require('./before-send-processor');
 const { BODY_PATH_DELIMITER, ARRAY_SPLIT_DELIMITER } = require('./cli-customization-processor');
@@ -33,19 +33,20 @@ const _mapToArgs = (params, paramsObject) => {
     return res;
 };
 
-const _loadJson = (value) => {
-    const filePrefix = 'file:';
-    let json;
-    if (value.startsWith(filePrefix)) {
-        const filePath = value.split(filePrefix).pop();
-        json = fs.readJSONSync(filePath);
-    } else {
-        json = JSON.parse(value);
+const _loadValue = (param, value) => {
+    let result = value;
+    if (param.json) {
+        const filePrefix = 'file:';
+        if (value.startsWith(filePrefix)) {
+            const filePath = value.split(filePrefix).pop();
+            const fileContent = fs.readFileSync(filePath, { encoding: 'utf8' });
+            result = canParseAsJson(fileContent) ? JSON.parse(fileContent) : fileContent;
+        } else {
+            result = canParseAsJson(value) ? JSON.parse(value) : value;
+        }
     }
-    return json;
+    return result;
 };
-
-const _loadValue = (param, value) => (param.json ? _loadJson(value) : value);
 
 const _mapToParams = (optionsValues, flatParamsMap, commanderToApiCustomizationMap) => {
     const res = {};

--- a/lib/utils/string-utils.js
+++ b/lib/utils/string-utils.js
@@ -6,6 +6,7 @@ module.exports = {
     camelCase,
     kebabCase,
     standardize,
+    canParseAsJson,
     isNonEmptyString,
     isNonBlankString,
     isLambdaFunctionName,
@@ -40,6 +41,15 @@ function kebabCase(str) {
 
 function standardize(str) {
     return filterNonAlphanumeric(camelCase(str).toLowerCase());
+}
+
+function canParseAsJson(value) {
+    try {
+        JSON.parse(value);
+        return true;
+    } catch (err) {
+        return false;
+    }
 }
 function isNonEmptyString(str) {
     return R.is(String, str) && !R.isEmpty(str);

--- a/test/unit/utils/string-utils-test.js
+++ b/test/unit/utils/string-utils-test.js
@@ -165,6 +165,28 @@ describe('Utils test - string utility', () => {
         });
     });
 
+    describe('# test function canParseAsJson', () => {
+        [
+            {
+                testCase: 'parse non json',
+                str: 'some non json string',
+                expectation: false
+            },
+            {
+                testCase: 'parse json string',
+                str: JSON.stringify({ x: 'x' }),
+                expectation: true
+            },
+        ].forEach(({ testCase, str, expectation }) => {
+            it(`| ${testCase}, expect standardize ${str}`, () => {
+                // call
+                const callResult = stringUtils.canParseAsJson(str);
+                // verify
+                expect(callResult).equal(expectation);
+            });
+        });
+    });
+
     describe('# test function isNonBlankString', () => {
         [
             {


### PR DESCRIPTION
trying to test with

```
ask smapi update-annotations-for-nlu-annotation-sets -s amzn1.ask.skill.e9ac9d7f-5c4f-4c3b-8e41-1b347f625d95 --annotation-id 0ed2ab5f-8b1b-423e-995c-1381d14cd496 --content-type text/csv --update-nlu-annotation-set-annotations-request file:fixtures/annotation-set.csv
```

but getting

```
"response": {
    "message": "Validation error: Could not process Annotation Set content with format text/csv for the following reason: (line 1) invalid char between encapsulated token and delimiter.."
  }
```

my csv file

```
"utterance","referenceTimestamp","intent","slot[toCity]","slot[fromCity]","slot[travelDate]"
"plan a trip","","PlanMyTripIntent","","",""
```
