### PR TITLE
fix: fix to allow dialog without providing skill id for hosted skills

### DIFF
--- a/lib/commands/dialog/index.js
+++ b/lib/commands/dialog/index.js
@@ -80,11 +80,11 @@ class DialogCommand extends AbstractCommand {
             const dialogReplayConfig = new DialogReplayFile(cmd.replay);
             skillId = dialogReplayConfig.getSkillId();
             if (!stringUtils.isNonBlankString(skillId)) {
-                return callback(new CliError('Replay file must contain skillId'));
+                return process.nextTick(callback(new CliError('Replay file must contain skillId')));
             }
             locale = dialogReplayConfig.getLocale();
             if (!stringUtils.isNonBlankString(locale)) {
-                return callback(new CliError('Replay file must contain locale'));
+                return process.nextTick(callback(new CliError('Replay file must contain locale')));
             }
             try {
                 userInputs = this._validateUserInputs(dialogReplayConfig.getUserInput());
@@ -97,11 +97,12 @@ class DialogCommand extends AbstractCommand {
                     new ResourcesConfig(path.join(process.cwd(), CONSTANTS.FILE_PATH.ASK_RESOURCES_JSON_CONFIG));
                     skillId = ResourcesConfig.getInstance().getSkillId(profile);
                 } catch (err) {
-                    return callback(new CliError('Failed to read project resource file. Please run the command within a ask-cli project.'));
+                    return process.nextTick(callback(new CliError('Failed to read project resource file. '
+                    + 'Please run the command within a ask-cli project.')));
                 }
                 if (!stringUtils.isNonBlankString(skillId)) {
-                    return callback(new CliError('Failed to obtain skill-id from project '
-                    + `resource file ${CONSTANTS.FILE_PATH.ASK_RESOURCES_JSON_CONFIG}`));
+                    return process.nextTick(callback(new CliError('Failed to obtain skill-id from project '
+                    + `resource file ${CONSTANTS.FILE_PATH.ASK_RESOURCES_JSON_CONFIG}`)));
                 }
             }
         }

--- a/lib/commands/dialog/index.js
+++ b/lib/commands/dialog/index.js
@@ -6,7 +6,7 @@ const optionModel = require('@src/commands/option-model');
 const CliError = require('@src/exceptions/cli-error');
 const DialogReplayFile = require('@src/model/dialog-replay-file');
 const ResourcesConfig = require('@src/model/resources-config');
-const Manifest = require('@src/model/manifest');
+const jsonView = require('@src/view/json-view');
 const CONSTANTS = require('@src/utils/constants');
 const profileHelper = require('@src/utils/profile-helper');
 const Messenger = require('@src/view/messenger');
@@ -37,28 +37,28 @@ class DialogCommand extends AbstractCommand {
 
     handle(cmd, cb) {
         let dialogMode;
-        try {
-            dialogMode = this._dialogModeFactory(this._getDialogConfig(cmd));
-        } catch (err) {
-            Messenger.getInstance().error(err);
-            return cb(err);
-        }
-
-        const spinner = new SpinnerView();
-        spinner.start('Checking if skill is ready to simulate...');
-        helper.validateDialogArgs(dialogMode, (dialogArgsValidationError) => {
-            if (dialogArgsValidationError) {
-                spinner.terminate(SpinnerView.TERMINATE_STYLE.FAIL, 'Failed to validate command options');
-                Messenger.getInstance().error(dialogArgsValidationError);
-                return cb(dialogArgsValidationError);
+        this._getDialogConfig(cmd, (err, config) => {
+            if (err) {
+                Messenger.getInstance().error(err);
+                return cb(err);
             }
-            spinner.terminate();
-            dialogMode.start((controllerError) => {
-                if (controllerError) {
-                    Messenger.getInstance().error(controllerError);
-                    return cb(controllerError);
+            dialogMode = this._dialogModeFactory(config);
+            const spinner = new SpinnerView();
+            spinner.start('Checking if skill is ready to simulate...');
+            helper.validateDialogArgs(dialogMode, (dialogArgsValidationError) => {
+                if (dialogArgsValidationError) {
+                    spinner.terminate(SpinnerView.TERMINATE_STYLE.FAIL, 'Failed to validate command options');
+                    Messenger.getInstance().error(dialogArgsValidationError);
+                    return cb(dialogArgsValidationError);
                 }
-                cb();
+                spinner.terminate();
+                dialogMode.start((controllerError) => {
+                    if (controllerError) {
+                        Messenger.getInstance().error(controllerError);
+                        return cb(controllerError);
+                    }
+                    cb();
+                });
             });
         });
     }
@@ -68,51 +68,58 @@ class DialogCommand extends AbstractCommand {
      * @param {Object} cmd encapsulates arguments provided to the dialog command.
      * @return { skillId, locale, stage, profile, debug, replayFile, smapiClient, userInputs <for replay mode> }
      */
-    _getDialogConfig(cmd) {
+    _getDialogConfig(cmd, callback) {
         const debug = Boolean(cmd.debug);
         let { skillId, locale, stage, profile } = cmd;
         profile = profileHelper.runtimeProfile(profile);
         stage = stage || CONSTANTS.SKILL.STAGE.DEVELOPMENT;
         let firstLocaleFromManifest;
         let userInputs;
+        const smapiClient = new SmapiClient({ profile, doDebug: debug });
         if (cmd.replay) {
             const dialogReplayConfig = new DialogReplayFile(cmd.replay);
             skillId = dialogReplayConfig.getSkillId();
             if (!stringUtils.isNonBlankString(skillId)) {
-                throw 'Replay file must contain skillId';
+                return callback(new CliError('Replay file must contain skillId'));
             }
             locale = dialogReplayConfig.getLocale();
             if (!stringUtils.isNonBlankString(locale)) {
-                throw 'Replay file must contain locale';
+                return callback(new CliError('Replay file must contain locale'));
             }
-            userInputs = this._validateUserInputs(dialogReplayConfig.getUserInput());
+            try {
+                userInputs = this._validateUserInputs(dialogReplayConfig.getUserInput());
+            } catch (err) {
+                return callback(err);
+            }
         } else {
             if (!stringUtils.isNonBlankString(skillId)) {
                 try {
                     new ResourcesConfig(path.join(process.cwd(), CONSTANTS.FILE_PATH.ASK_RESOURCES_JSON_CONFIG));
                     skillId = ResourcesConfig.getInstance().getSkillId(profile);
                 } catch (err) {
-                    throw new CliError('Failed to read project resource file. Please run the command within a ask-cli project.');
+                    return callback(new CliError('Failed to read project resource file. Please run the command within a ask-cli project.'));
                 }
                 if (!stringUtils.isNonBlankString(skillId)) {
-                    throw `Failed to obtain skill-id from project resource file ${CONSTANTS.FILE_PATH.ASK_RESOURCES_JSON_CONFIG}`;
+                    return callback(new CliError('Failed to obtain skill-id from project '
+                    + `resource file ${CONSTANTS.FILE_PATH.ASK_RESOURCES_JSON_CONFIG}`));
                 }
-                const skillPackageSrc = ResourcesConfig.getInstance().getSkillMetaSrc(profile);
-                const manifestPath = path.join(skillPackageSrc, CONSTANTS.FILE_PATH.SKILL_PACKAGE.MANIFEST);
-                new Manifest(manifestPath);
-                [firstLocaleFromManifest] = Object.keys(Manifest.getInstance().getPublishingLocales());
             }
-
+        }
+        smapiClient.skill.manifest.getManifest(skillId, stage, (err, res) => {
+            if (err) {
+                return callback(err);
+            }
+            if (res.statusCode >= 300) {
+                const error = jsonView.toString(res.body);
+                return callback(error);
+            }
+            [firstLocaleFromManifest] = Object.keys(res.body.manifest.publishingInformation.locales);
             if (!locale && !process.env.ASK_DEFAULT_DEVICE_LOCALE && firstLocaleFromManifest) {
                 Messenger.getInstance().info(`Defaulting locale to the first value from the skill manifest: ${firstLocaleFromManifest}`);
             }
             locale = locale || process.env.ASK_DEFAULT_DEVICE_LOCALE || firstLocaleFromManifest;
-            if (!stringUtils.isNonBlankString(locale)) {
-                throw 'Locale has not been specified.';
-            }
-        }
-        const smapiClient = new SmapiClient({ profile, doDebug: debug });
-        return { skillId, locale, stage, profile, debug, replay: cmd.replay, smapiClient, userInputs };
+            callback(null, { skillId, locale, stage, profile, debug, replay: cmd.replay, smapiClient, userInputs });
+        });
     }
 
     _dialogModeFactory(config) {
@@ -127,7 +134,7 @@ class DialogCommand extends AbstractCommand {
         userInputs.forEach((input) => {
             const trimmedInput = input.trim();
             if (!stringUtils.isNonBlankString(trimmedInput)) {
-                throw "Replay file's userInput cannot contain empty string.";
+                throw new CliError("Replay file's userInput cannot contain empty string.");
             }
             validatedInputs.push(trimmedInput);
         });

--- a/test/unit/commands/dialog/index-test.js
+++ b/test/unit/commands/dialog/index-test.js
@@ -2,18 +2,19 @@ const { expect } = require('chai');
 const sinon = require('sinon');
 const path = require('path');
 
+const AuthorizationController = require('@src/controllers/authorization-controller');
 const DialogCommand = require('@src/commands/dialog');
 const helper = require('@src/commands/dialog/helper');
+const httpClient = require('@src/clients/http-client');
 const InteractiveMode = require('@src/commands/dialog/interactive-mode');
 const optionModel = require('@src/commands/option-model');
 const ResourcesConfig = require('@src/model/resources-config');
-const Manifest = require('@src/model/manifest');
+const jsonView = require('@src/view/json-view');
 const CONSTANTS = require('@src/utils/constants');
 const profileHelper = require('@src/utils/profile-helper');
 const stringUtils = require('@src/utils/string-utils');
 const Messenger = require('@src/view/messenger');
 const SpinnerView = require('@src/view/spinner-view');
-
 
 describe('Commands Dialog test - command class test', () => {
     const TEST_ERROR = 'error';
@@ -38,6 +39,7 @@ describe('Commands Dialog test - command class test', () => {
             error: errorStub,
             info: infoStub
         });
+        sinon.stub(AuthorizationController.prototype, 'tokenRefreshAndRead').yields();
     });
 
     afterEach(() => {
@@ -69,7 +71,7 @@ describe('Commands Dialog test - command class test', () => {
 
         it('| error while creating dialogMode', (done) => {
             // setup
-            sinon.stub(DialogCommand.prototype, '_getDialogConfig').throws(new Error(TEST_ERROR));
+            sinon.stub(DialogCommand.prototype, '_getDialogConfig').yields(new Error(TEST_ERROR));
 
             // call
             instance.handle(TEST_CMD, (err) => {
@@ -82,7 +84,7 @@ describe('Commands Dialog test - command class test', () => {
 
         it('| error while validating dialog arguments', (done) => {
             // setup
-            sinon.stub(DialogCommand.prototype, '_getDialogConfig');
+            sinon.stub(DialogCommand.prototype, '_getDialogConfig').yields();
             sinon.stub(DialogCommand.prototype, '_dialogModeFactory');
             sinon.stub(helper, 'validateDialogArgs').callsArgWith(1, TEST_ERROR);
             // call
@@ -101,7 +103,7 @@ describe('Commands Dialog test - command class test', () => {
 
         it('| dialogMode returns error', (done) => {
             // setup
-            sinon.stub(DialogCommand.prototype, '_getDialogConfig').returns({});
+            sinon.stub(DialogCommand.prototype, '_getDialogConfig').yields(null, {});
             sinon.stub(InteractiveMode.prototype, 'start').callsArgWith(0, TEST_ERROR);
             sinon.stub(helper, 'validateDialogArgs').callsArgWith(1, null);
             // call
@@ -118,7 +120,7 @@ describe('Commands Dialog test - command class test', () => {
 
         it('| dialog command successfully completes execution', (done) => {
             // setup
-            sinon.stub(DialogCommand.prototype, '_getDialogConfig').returns({});
+            sinon.stub(DialogCommand.prototype, '_getDialogConfig').yields(null, {});
             sinon.stub(InteractiveMode.prototype, 'start').callsArgWith(0, null);
             sinon.stub(helper, 'validateDialogArgs').callsArgWith(1, null);
             // call
@@ -151,7 +153,7 @@ describe('Commands Dialog test - command class test', () => {
                 // call
                 instance.handle(TEST_CMD_WITH_VALUES, (err) => {
                     // verify
-                    expect(err).eq('Replay file must contain skillId');
+                    expect(err.message).eq('Replay file must contain skillId');
                     done();
                 });
             });
@@ -168,7 +170,7 @@ describe('Commands Dialog test - command class test', () => {
                 // call
                 instance.handle(TEST_CMD_WITH_VALUES, (err) => {
                     // verify
-                    expect(err).eq('Replay file must contain locale');
+                    expect(err.message).eq('Replay file must contain locale');
                     done();
                 });
             });
@@ -186,7 +188,7 @@ describe('Commands Dialog test - command class test', () => {
                 // call
                 instance.handle(TEST_CMD_WITH_VALUES, (err) => {
                     // verify
-                    expect(err).eq("Replay file's userInput cannot contain empty string.");
+                    expect(err.message).eq("Replay file's userInput cannot contain empty string.");
                     done();
                 });
             });
@@ -199,38 +201,56 @@ describe('Commands Dialog test - command class test', () => {
                 };
                 sinon.stub(profileHelper, 'runtimeProfile').returns(TEST_PROFILE);
                 // call
-                const config = instance._getDialogConfig(TEST_CMD_WITH_VALUES);
-                // verify
-                expect(config.debug).equal(false);
-                expect(config.locale).equal('en-US');
-                expect(config.profile).equal('default');
-                expect(config.replay).equal(DIALOG_REPLAY_FILE_JSON_PATH);
-                expect(config.skillId).equal('amzn1.ask.skill.1234567890');
-                expect(config.stage).equal('development');
-                expect(config.userInputs).deep.equal(['hello', 'world']);
+                instance._getDialogConfig(TEST_CMD_WITH_VALUES, (err, config) => {
+                    // verify
+                    expect(config.debug).equal(false);
+                    expect(config.locale).equal('en-US');
+                    expect(config.profile).equal('default');
+                    expect(config.replay).equal(DIALOG_REPLAY_FILE_JSON_PATH);
+                    expect(config.skillId).equal('amzn1.ask.skill.1234567890');
+                    expect(config.stage).equal('development');
+                    expect(config.userInputs).deep.equal(['hello', 'world']);
+                });
+            });
+
+            it('| returns return error when smapi get manifest call fails', () => {
+                // setup
+                const TEST_CMD_WITH_VALUES = {
+                    stage: '',
+                    replay: DIALOG_REPLAY_FILE_JSON_PATH
+                };
+                const smapiError = 'error';
+                sinon.stub(profileHelper, 'runtimeProfile').returns(TEST_PROFILE);
+                sinon.stub(httpClient, 'request').yields(smapiError);
+                // call
+                instance._getDialogConfig(TEST_CMD_WITH_VALUES, (err) => {
+                    // verify
+                    expect(err).eq(smapiError);
+                });
+            });
+
+            it('| returns return error when smapi get manifest call returns failure http status code', () => {
+                // setup
+                const TEST_CMD_WITH_VALUES = {
+                    stage: '',
+                    replay: DIALOG_REPLAY_FILE_JSON_PATH
+                };
+                const smapiError = 'error';
+                sinon.stub(profileHelper, 'runtimeProfile').returns(TEST_PROFILE);
+                sinon.stub(httpClient, 'request').yields(null, { statusCode: 400, body: { message: smapiError } });
+                // call
+                instance._getDialogConfig(TEST_CMD_WITH_VALUES, (err) => {
+                    // verify
+                    expect(err).eq(jsonView.toString({ message: smapiError }));
+                });
             });
         });
 
         describe('# test with default (interactive) option', () => {
-
-            it('| empty locale throws error', (done) => {
-                // setup
-                const TEST_CMD_WITH_VALUES = {
-                    skillId: 'skillId'
-                };
-                sinon.stub(profileHelper, 'runtimeProfile').returns(TEST_PROFILE);
-                const getSkillMetaSrc = () => {};
-                sinon.stub(ResourcesConfig, 'getInstance').returns({ getSkillMetaSrc });
-
-                const getPublishingLocales = () => ({});
-                sinon.stub(Manifest, 'getInstance').returns({ getPublishingLocales });
-                sinon.stub(path, 'join').returns(VALID_MANIFEST_JSON_PATH);
-                // call
-                instance.handle(TEST_CMD_WITH_VALUES, (err) => {
-                    // verify
-                    expect(err).equal('Locale has not been specified.');
-                    done();
-                });
+            let manifest;
+            beforeEach(() => {
+                manifest = { publishingInformation: { locales: { us: {} } } };
+                sinon.stub(httpClient, 'request').yields(null, { statusCode: 20, body: { manifest } });
             });
 
             it('| no resources config file found', (done) => {
@@ -255,12 +275,12 @@ describe('Commands Dialog test - command class test', () => {
                 // call
                 instance.handle(TEST_CMD_WITH_VALUES, (err) => {
                     // verify
-                    expect(err).equal(`Failed to obtain skill-id from project resource file ${CONSTANTS.FILE_PATH.ASK_RESOURCES_JSON_CONFIG}`);
+                    expect(err.message).equal(`Failed to obtain skill-id from project resource file ${CONSTANTS.FILE_PATH.ASK_RESOURCES_JSON_CONFIG}`);
                     done();
                 });
             });
 
-            it('| check valid values are returned in interactive mode', () => {
+            it('| check valid values are returned in interactive mode', (done) => {
                 // setup
                 const TEST_CMD_WITH_VALUES = {};
                 sinon.stub(profileHelper, 'runtimeProfile').returns(TEST_PROFILE);
@@ -274,42 +294,42 @@ describe('Commands Dialog test - command class test', () => {
                 path.join.callThrough();
                 process.env.ASK_DEFAULT_DEVICE_LOCALE = 'en-US';
                 // call
-                const config = instance._getDialogConfig(TEST_CMD_WITH_VALUES);
+                instance._getDialogConfig(TEST_CMD_WITH_VALUES, (err, config) => {
                 // verify
-                expect(config.debug).equal(false);
-                expect(config.locale).equal('en-US');
-                expect(config.profile).equal('default');
-                expect(config.replay).equal(undefined);
-                expect(config.skillId).equal('amzn1.ask.skill.1234567890');
-                expect(config.stage).equal('development');
-                expect(config.userInputs).equal(undefined);
+                    expect(config.debug).equal(false);
+                    expect(config.locale).equal('en-US');
+                    expect(config.profile).equal('default');
+                    expect(config.replay).equal(undefined);
+                    expect(config.skillId).equal('amzn1.ask.skill.1234567890');
+                    expect(config.stage).equal('development');
+                    expect(config.userInputs).equal(undefined);
+                    done();
+                });
             });
 
             it('| check locale defaults to first value from manifest', () => {
                 // setup
-                const expectedLocale = 'de-DE';
+                const [expectedLocale] = Object.keys(manifest.publishingInformation.locales);
                 const TEST_CMD_WITH_VALUES = {};
                 sinon.stub(profileHelper, 'runtimeProfile').returns(TEST_PROFILE);
                 const pathJoinStub = sinon.stub(path, 'join');
                 pathJoinStub.withArgs(
                     process.cwd(), CONSTANTS.FILE_PATH.ASK_RESOURCES_JSON_CONFIG
                 ).returns(VALID_RESOURCES_CONFIG_JSON_PATH);
-                pathJoinStub.withArgs(
-                    './skillPackage', CONSTANTS.FILE_PATH.SKILL_PACKAGE.MANIFEST
-                ).returns(VALID_MANIFEST_JSON_PATH);
                 path.join.callThrough();
 
                 // call
-                const config = instance._getDialogConfig(TEST_CMD_WITH_VALUES);
+                instance._getDialogConfig(TEST_CMD_WITH_VALUES, (err, config) => {
                 // verify
-                expect(config.debug).equal(false);
-                expect(infoStub.args[0][0]).eq(`Defaulting locale to the first value from the skill manifest: ${expectedLocale}`);
-                expect(config.locale).equal(expectedLocale);
-                expect(config.profile).equal('default');
-                expect(config.replay).equal(undefined);
-                expect(config.skillId).equal('amzn1.ask.skill.1234567890');
-                expect(config.stage).equal('development');
-                expect(config.userInputs).equal(undefined);
+                    expect(config.debug).equal(false);
+                    expect(infoStub.args[0][0]).eq(`Defaulting locale to the first value from the skill manifest: ${expectedLocale}`);
+                    expect(config.locale).equal(expectedLocale);
+                    expect(config.profile).equal('default');
+                    expect(config.replay).equal(undefined);
+                    expect(config.skillId).equal('amzn1.ask.skill.1234567890');
+                    expect(config.stage).equal('development');
+                    expect(config.userInputs).equal(undefined);
+                });
             });
 
             afterEach(() => {
@@ -318,7 +338,6 @@ describe('Commands Dialog test - command class test', () => {
             });
         });
     });
-
 
     describe('# test _validateUserInputs', () => {
         let instance;


### PR DESCRIPTION
Since we dont have 
```
"skillMetadata": {
        "src": "./skill-package"
      },

```
for hosted skill. dialog command would not work without providing skill id similar to other types of skills (lambda and cf).

Updated to default to skill-package to allow working with hosted skills.