### PR TITLE
test: increase timeout to fix sporadic test timeout error

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "deploy"
   ],
   "scripts": {
-    "test": "node ./node_modules/mocha/bin/_mocha -u exports -R spec test/unit/run-test.js",
+    "test": "node ./node_modules/mocha/bin/_mocha -t 10000 -u exports -R spec test/unit/run-test.js",
     "test:watch": "node ./node_modules/mocha/bin/_mocha test/unit/run-test.js -w",
     "test:report": "nyc --cache npm test && nyc report --reporter=html",
     "test:browser": "npm run test:report && open coverage/index.html",


### PR DESCRIPTION
Sometimes( may be once in 2-3 weeks), unit test will fail with the following error
1) Command test - AbstractCommand class # check AppConfig object  | should not be null for non-configure commands:
     Error: Timeout of 2000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves.
      at listOnTimeout (internal/timers.js:531:17)
      at processTimers (internal/timers.js:475:7)

  2) Command test - AbstractCommand class # check AppConfig object  | should be null for configure command:
     Error: Timeout of 2000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves.
      at listOnTimeout (internal/timers.js:531:17)
      at processTimers (internal/timers.js:475:7)

I tried adding done but get this following error

Error: Resolution method is overspecified. Specify a callback *or* return a Promise; not both.


Increasing timeout to 10 seconds