### PR TITLE
Ignore hash flag

### DIFF
--- a/lib/builtins/deploy-delegates/lambda-deployer/helper.js
+++ b/lib/builtins/deploy-delegates/lambda-deployer/helper.js
@@ -15,7 +15,7 @@ module.exports = {
     deployLambdaFunction
 };
 
-function validateLambdaDeployState(reporter, awsProfile, awsRegion, currentRegionDeployState, callback) {
+function validateLambdaDeployState(reporter, awsProfile, awsRegion, currentRegionDeployState, ignoreHash, callback) {
     const lambdaData = currentRegionDeployState.lambda;
     if (R.isNil(lambdaData) || R.isEmpty(lambdaData) || R.isNil(lambdaData.arn)) {
         return callback(null, { updatedDeployState: currentRegionDeployState });
@@ -39,7 +39,7 @@ Please solve this IAM role mismatch and re-deploy again.`);
         // 2. check revision id
         const localRevisionId = lambdaData.revisionId;
         const remoteRevisionId = data.Configuration.RevisionId;
-        if (stringUtils.isNonBlankString(localRevisionId) && !R.equals(localRevisionId, remoteRevisionId)) {
+        if (stringUtils.isNonBlankString(localRevisionId) && !R.equals(localRevisionId, remoteRevisionId) && !ignoreHash) {
             return callback(`The current revisionId (The revision ID for Lambda ARN (${lambdaArn}) should be ${remoteRevisionId}, \
 but found ${localRevisionId}. Please solve this revision mismatch and re-deploy again.`);
         }

--- a/lib/builtins/deploy-delegates/lambda-deployer/index.js
+++ b/lib/builtins/deploy-delegates/lambda-deployer/index.js
@@ -36,7 +36,7 @@ function bootstrap(options, callback) {
  * @param {Function} callback
  */
 function invoke(reporter, options, callback) {
-    const { profile, alexaRegion, skillId, skillName, code, userConfig, deployState = {} } = options;
+    const { profile, ignoreHash, alexaRegion, skillId, skillName, code, userConfig, deployState = {} } = options;
     const awsProfile = awsUtil.getAWSProfile(profile);
     if (!stringUtils.isNonBlankString(awsProfile)) {
         return callback(`Profile [${profile}] doesn't have AWS profile linked to it. Please run "ask configure" to re-configure your porfile.`);
@@ -53,7 +53,7 @@ function invoke(reporter, options, callback) {
         return callback(`Unsupported Alexa region: ${alexaRegion}. Please check your region name or use "regionalOverrides" to specify AWS region.`);
     }
 
-    helper.validateLambdaDeployState(reporter, awsProfile, awsRegion, currentRegionDeployState, (validationErr, validationData) => {
+    helper.validateLambdaDeployState(reporter, awsProfile, awsRegion, currentRegionDeployState, ignoreHash, (validationErr, validationData) => {
         if (validationErr) {
             return callback(validationErr);
         }

--- a/lib/commands/deploy/helper.js
+++ b/lib/commands/deploy/helper.js
@@ -55,10 +55,11 @@ function buildSkillCode(profile, doDebug, callback) {
  * Deploy skill code by calling SkillInfrastructureController
  * @param {String} profile ask-cli profile
  * @param {Boolean} doDebug
+ * @param {Boolean} ignoreHash
  * @param {*} callback (error)
  */
-function deploySkillInfrastructure(profile, doDebug, callback) {
-    const skillInfraController = new SkillInfrastructureController({ profile, doDebug });
+function deploySkillInfrastructure(profile, doDebug, ignoreHash, callback) {
+    const skillInfraController = new SkillInfrastructureController({ profile, doDebug, ignoreHash });
     skillInfraController.deployInfrastructure((deployError) => {
         if (deployError) {
             return callback(deployError);

--- a/lib/commands/deploy/index.js
+++ b/lib/commands/deploy/index.js
@@ -101,10 +101,11 @@ class DeployCommand extends AbstractCommand {
  * This steps includes the deploy of skillMeta, skillCode and skillInfra using the deployDelegate plugin
  * @param {String} profile The profile name
  * @param {Boolean} doDebug The flag of debug or not
+ * @param {Boolean} ignoreHash The flag to ignore difference between local and remote version
  * @param {Function} callback
  */
 function deployResources(options, callback) {
-    const { profile, doDebug } = options;
+    const { profile, doDebug, ignoreHash } = options;
     // Skill Metadata
     Messenger.getInstance().info('==================== Deploy Skill Metadata ====================');
     const skillMetaSpinner = new SpinnerView();
@@ -147,7 +148,7 @@ with build flow ${codeProperty.buildFlow}.`);
                 return callback();
             }
             Messenger.getInstance().info('\n==================== Deploy Skill Infrastructure ====================');
-            helper.deploySkillInfrastructure(profile, doDebug, (infraErr) => {
+            helper.deploySkillInfrastructure(profile, doDebug, ignoreHash, (infraErr) => {
                 if (infraErr) {
                     return callback(infraErr);
                 }

--- a/lib/controllers/skill-infrastructure-controller/index.js
+++ b/lib/controllers/skill-infrastructure-controller/index.js
@@ -16,9 +16,10 @@ const DeployDelegate = require('./deploy-delegate');
 
 module.exports = class SkillInfrastructureController {
     constructor(configuration) {
-        const { profile, doDebug } = configuration;
+        const { profile, doDebug, ignoreHash } = configuration;
         this.profile = profile;
         this.doDebug = doDebug;
+        this.ignoreHash = ignoreHash;
     }
 
     /**
@@ -180,6 +181,7 @@ module.exports = class SkillInfrastructureController {
     _deployInfraByRegion(reporter, dd, alexaRegion, skillName, callback) {
         const regionConfig = {
             profile: this.profile,
+            ignoreHash: this.ignoreHash,
             alexaRegion,
             skillId: ResourcesConfig.getInstance().getSkillId(this.profile),
             skillName,

--- a/test/unit/builtins/lambda-deployer/helper-test.js
+++ b/test/unit/builtins/lambda-deployer/helper-test.js
@@ -12,6 +12,7 @@ const Manifest = require('@src/model/manifest');
 describe('Builtins test - lambda-deployer helper.js test', () => {
     const FIXTURE_MANIFEST_FILE_PATH = path.join(process.cwd(), 'test', 'unit', 'fixture', 'model', 'manifest.json');
     const TEST_PROFILE = 'default'; // test file uses 'default' profile
+    const TEST_IGNORE_HASH = false;
     const TEST_AWS_PROFILE = 'default';
     const TEST_AWS_REGION = 'us-east-1';
     const TEST_ALEXA_REGION = 'default';
@@ -52,7 +53,7 @@ describe('Builtins test - lambda-deployer helper.js test', () => {
             // setup
             const TEST_DEPLOY_STATE_NO_LAMBDA = {};
             // call
-            helper.validateLambdaDeployState(REPORTER, TEST_AWS_PROFILE, TEST_AWS_REGION, TEST_DEPLOY_STATE_NO_LAMBDA, (err, data) => {
+            helper.validateLambdaDeployState(REPORTER, TEST_AWS_PROFILE, TEST_AWS_REGION, TEST_DEPLOY_STATE_NO_LAMBDA, TEST_IGNORE_HASH, (err, data) => {
                 // verify
                 expect(data.updatedDeployState).equal(TEST_DEPLOY_STATE_NO_LAMBDA);
                 done();
@@ -64,7 +65,7 @@ describe('Builtins test - lambda-deployer helper.js test', () => {
             const TEST_GET_FUNCTION_ERROR = 'get_function_error';
             sinon.stub(LambdaClient.prototype, 'getFunction').callsArgWith(1, TEST_GET_FUNCTION_ERROR);
             // call
-            helper.validateLambdaDeployState(REPORTER, TEST_AWS_PROFILE, TEST_AWS_REGION, TEST_LOCAL_DEPLOY_STATE, (err) => {
+            helper.validateLambdaDeployState(REPORTER, TEST_AWS_PROFILE, TEST_AWS_REGION, TEST_LOCAL_DEPLOY_STATE, TEST_IGNORE_HASH, (err) => {
                 // verify
                 expect(err).equal(TEST_GET_FUNCTION_ERROR);
                 done();
@@ -84,7 +85,7 @@ describe('Builtins test - lambda-deployer helper.js test', () => {
 but found ${TEST_LOCAL_IAM_ROLE}. Please solve this IAM role mismatch and re-deploy again.`;
             sinon.stub(LambdaClient.prototype, 'getFunction').callsArgWith(1, null, TEST_REMOTE_DEPLOY_STATE);
             // call
-            helper.validateLambdaDeployState(REPORTER, TEST_AWS_PROFILE, TEST_AWS_REGION, TEST_LOCAL_DEPLOY_STATE, (err) => {
+            helper.validateLambdaDeployState(REPORTER, TEST_AWS_PROFILE, TEST_AWS_REGION, TEST_LOCAL_DEPLOY_STATE, TEST_IGNORE_HASH, (err) => {
                 // verify
                 expect(err).equal(TEST_IAM_ROLE_ERROR);
                 done();
@@ -104,7 +105,7 @@ but found ${TEST_LOCAL_IAM_ROLE}. Please solve this IAM role mismatch and re-dep
 ${TEST_REMOTE_REVISION_ID}, but found ${TEST_LOCAL_REVISION_ID}. Please solve this revision mismatch and re-deploy again.`;
             sinon.stub(LambdaClient.prototype, 'getFunction').callsArgWith(1, null, TEST_REMOTE_DEPLOY_STATE);
             // call
-            helper.validateLambdaDeployState(REPORTER, TEST_AWS_PROFILE, TEST_AWS_REGION, TEST_LOCAL_DEPLOY_STATE, (err) => {
+            helper.validateLambdaDeployState(REPORTER, TEST_AWS_PROFILE, TEST_AWS_REGION, TEST_LOCAL_DEPLOY_STATE, TEST_IGNORE_HASH, (err) => {
                 // verify
                 expect(err).equal(TEST_REVISION_ID_ERROR);
                 done();
@@ -121,7 +122,7 @@ ${TEST_REMOTE_REVISION_ID}, but found ${TEST_LOCAL_REVISION_ID}. Please solve th
             };
             sinon.stub(LambdaClient.prototype, 'getFunction').callsArgWith(1, null, TEST_REMOTE_DEPLOY_STATE);
             // call
-            helper.validateLambdaDeployState(REPORTER, TEST_AWS_PROFILE, TEST_AWS_REGION, TEST_LOCAL_DEPLOY_STATE, (err, data) => {
+            helper.validateLambdaDeployState(REPORTER, TEST_AWS_PROFILE, TEST_AWS_REGION, TEST_LOCAL_DEPLOY_STATE, TEST_IGNORE_HASH, (err, data) => {
                 // verify
                 expect(data.updatedDeployState.iamRole).equal(TEST_LOCAL_IAM_ROLE);
                 expect(data.updatedDeployState.lambda.revisionId).equal(TEST_LOCAL_REVISION_ID);

--- a/test/unit/builtins/lambda-deployer/helper-test.js
+++ b/test/unit/builtins/lambda-deployer/helper-test.js
@@ -112,6 +112,25 @@ ${TEST_REMOTE_REVISION_ID}, but found ${TEST_LOCAL_REVISION_ID}. Please solve th
             });
         });
 
+        it('| an existing lambda arn found, getFunction request passes, the local revisionId and remote revisionId compare is ignored'
+        + 'expect updated deploy state return', (done) => {
+            // setup
+            const TEST_REMOTE_DEPLOY_STATE = {
+                Configuration: {
+                    Role: TEST_LOCAL_IAM_ROLE,
+                    RevisionId: TEST_REMOTE_REVISION_ID
+                }
+            };
+            const IGNORE_HASH = true;
+            sinon.stub(LambdaClient.prototype, 'getFunction').callsArgWith(1, null, TEST_REMOTE_DEPLOY_STATE);
+            // call
+            helper.validateLambdaDeployState(REPORTER, TEST_AWS_PROFILE, TEST_AWS_REGION, TEST_LOCAL_DEPLOY_STATE, IGNORE_HASH, (err, data) => {
+                // verify
+                expect(data.updatedDeployState.iamRole).equal(TEST_LOCAL_IAM_ROLE);
+                done();
+            });
+        });
+
         it('| an existing lambda arn found, getFunction request passes, expect updated deploy state return', (done) => {
             // setup
             const TEST_REMOTE_DEPLOY_STATE = {

--- a/test/unit/builtins/lambda-deployer/index-test.js
+++ b/test/unit/builtins/lambda-deployer/index-test.js
@@ -6,9 +6,9 @@ const CONSTANTS = require('@src/utils/constants');
 const helper = require('@src/builtins/deploy-delegates/lambda-deployer/helper');
 const lambdaDeployer = require('@src/builtins/deploy-delegates/lambda-deployer/index');
 
-
 describe('Builtins test - lambda-deployer index.js test', () => {
     const TEST_PROFILE = 'default'; // test file uses 'default' profile
+    const TEST_IGNORE_HASH = false;
     const TEST_ALEXA_REGION_DEFAULT = 'default';
     const TEST_AWS_REGION_DEFAULT = 'us-east-1';
     const TEST_SKILL_NAME = 'skill_name';
@@ -44,6 +44,7 @@ describe('Builtins test - lambda-deployer index.js test', () => {
         const REPORTER = {};
         const TEST_OPTIONS = {
             profile: TEST_PROFILE,
+            ignoreHash: TEST_IGNORE_HASH,
             alexaRegion: TEST_ALEXA_REGION_DEFAULT,
             skillId: '',
             skillName: TEST_SKILL_NAME,
@@ -102,7 +103,7 @@ Please run "ask configure" to re-configure your porfile.`;
             // setup
             const TEST_ERROR = 'validateLambdaDeployState error message';
             sinon.stub(awsUtil, 'getAWSProfile').withArgs(TEST_PROFILE).returns(TEST_PROFILE);
-            sinon.stub(helper, 'validateLambdaDeployState').callsArgWith(4, TEST_ERROR);
+            sinon.stub(helper, 'validateLambdaDeployState').callsArgWith(5, TEST_ERROR);
             // call
             lambdaDeployer.invoke(REPORTER, TEST_OPTIONS, (err) => {
                 // verify
@@ -115,7 +116,7 @@ Please run "ask configure" to re-configure your porfile.`;
             // setup
             const TEST_ERROR = 'IAMRole error message';
             sinon.stub(awsUtil, 'getAWSProfile').withArgs(TEST_PROFILE).returns(TEST_PROFILE);
-            sinon.stub(helper, 'validateLambdaDeployState').callsArgWith(4, null, TEST_VALIDATED_DEPLOY_STATE);
+            sinon.stub(helper, 'validateLambdaDeployState').callsArgWith(5, null, TEST_VALIDATED_DEPLOY_STATE);
             sinon.stub(helper, 'deployIAMRole').callsArgWith(6, TEST_ERROR);
             // call
             lambdaDeployer.invoke(REPORTER, TEST_OPTIONS, (err) => {
@@ -130,7 +131,7 @@ Please run "ask configure" to re-configure your porfile.`;
             const TEST_ERROR = 'LambdaFunction error message';
             const TEST_ERROR_MESSAGE_RESPONSE = `The lambda deploy failed for Alexa region "default": ${TEST_ERROR}`;
             sinon.stub(awsUtil, 'getAWSProfile').withArgs(TEST_PROFILE).returns(TEST_PROFILE);
-            sinon.stub(helper, 'validateLambdaDeployState').callsArgWith(4, null, TEST_VALIDATED_DEPLOY_STATE);
+            sinon.stub(helper, 'validateLambdaDeployState').callsArgWith(5, null, TEST_VALIDATED_DEPLOY_STATE);
             sinon.stub(helper, 'deployIAMRole').callsArgWith(6, null, TEST_IAM_ROLE_ARN);
             sinon.stub(helper, 'deployLambdaFunction').callsArgWith(2, TEST_ERROR);
             // call
@@ -147,7 +148,7 @@ Please run "ask configure" to re-configure your porfile.`;
             const TEST_ERROR = 'LambdaFunction error message';
             const TEST_ERROR_MESSAGE_RESPONSE = `The lambda deploy failed for Alexa region "default": ${TEST_ERROR}`;
             sinon.stub(awsUtil, 'getAWSProfile').withArgs(TEST_PROFILE).returns(TEST_PROFILE);
-            sinon.stub(helper, 'validateLambdaDeployState').callsArgWith(4, null, TEST_VALIDATED_DEPLOY_STATE);
+            sinon.stub(helper, 'validateLambdaDeployState').callsArgWith(5, null, TEST_VALIDATED_DEPLOY_STATE);
             sinon.stub(helper, 'deployIAMRole').callsArgWith(6, null, TEST_IAM_ROLE_ARN);
             sinon.stub(helper, 'deployLambdaFunction').callsArgWith(2, TEST_ERROR);
             // call
@@ -177,7 +178,7 @@ with output Lambda ARN: ${LAMBDA_ARN}.`;
                 lambdaResponse: LAMDBA_RESPONSE
             };
             sinon.stub(awsUtil, 'getAWSProfile').withArgs(TEST_PROFILE).returns(TEST_PROFILE);
-            sinon.stub(helper, 'validateLambdaDeployState').callsArgWith(4, null, TEST_VALIDATED_DEPLOY_STATE);
+            sinon.stub(helper, 'validateLambdaDeployState').callsArgWith(5, null, TEST_VALIDATED_DEPLOY_STATE);
             sinon.stub(helper, 'deployIAMRole').callsArgWith(6, null, TEST_IAM_ROLE_ARN);
             sinon.stub(helper, 'deployLambdaFunction').callsArgWith(2, null, TEST_LAMBDA_RESULT);
             // call
@@ -212,7 +213,7 @@ with output Lambda ARN: ${LAMBDA_ARN}.`;
                 lambdaResponse: {}
             };
             sinon.stub(awsUtil, 'getAWSProfile').withArgs(TEST_PROFILE).returns(TEST_PROFILE);
-            sinon.stub(helper, 'validateLambdaDeployState').callsArgWith(4, null, TEST_VALIDATED_DEPLOY_STATE);
+            sinon.stub(helper, 'validateLambdaDeployState').callsArgWith(5, null, TEST_VALIDATED_DEPLOY_STATE);
             sinon.stub(helper, 'deployIAMRole').callsArgWith(6, null, TEST_IAM_ROLE_ARN);
             sinon.stub(helper, 'deployLambdaFunction').callsArgWith(2, null, TEST_LAMBDA_RESULT);
             // call
@@ -239,7 +240,7 @@ with output Lambda ARN: ${LAMBDA_ARN}.`;
             };
             const LAMDBA_RESULT = {};
             sinon.stub(awsUtil, 'getAWSProfile').withArgs(TEST_PROFILE).returns(TEST_PROFILE);
-            sinon.stub(helper, 'validateLambdaDeployState').callsArgWith(4, null, TEST_VALIDATED_DEPLOY_STATE);
+            sinon.stub(helper, 'validateLambdaDeployState').callsArgWith(5, null, TEST_VALIDATED_DEPLOY_STATE);
             sinon.stub(helper, 'deployIAMRole').callsArgWith(6, null, TEST_IAM_ROLE_ARN);
             sinon.stub(helper, 'deployLambdaFunction').callsArgWith(2, null, LAMDBA_RESULT);
             // call
@@ -273,7 +274,7 @@ with output Lambda ARN: ${LAMBDA_ARN}.`;
             };
             const LAMDBA_RESULT = {};
             sinon.stub(awsUtil, 'getAWSProfile').withArgs(TEST_PROFILE).returns(TEST_PROFILE);
-            sinon.stub(helper, 'validateLambdaDeployState').callsArgWith(4, null, TEST_VALIDATED_DEPLOY_STATE);
+            sinon.stub(helper, 'validateLambdaDeployState').callsArgWith(5, null, TEST_VALIDATED_DEPLOY_STATE);
             sinon.stub(helper, 'deployIAMRole').callsArgWith(6, null, TEST_IAM_ROLE_ARN);
             sinon.stub(helper, 'deployLambdaFunction').callsArgWith(2, null, LAMDBA_RESULT);
             // call
@@ -302,7 +303,7 @@ with output Lambda ARN: ${LAMBDA_ARN}.`;
             };
             const LAMDBA_RESULT = {};
             sinon.stub(awsUtil, 'getAWSProfile').withArgs(TEST_PROFILE).returns(TEST_PROFILE);
-            sinon.stub(helper, 'validateLambdaDeployState').callsArgWith(4, null, TEST_VALIDATED_DEPLOY_STATE);
+            sinon.stub(helper, 'validateLambdaDeployState').callsArgWith(5, null, TEST_VALIDATED_DEPLOY_STATE);
             sinon.stub(helper, 'deployIAMRole').callsArgWith(6, null, TEST_IAM_ROLE_ARN);
             sinon.stub(helper, 'deployLambdaFunction').callsArgWith(2, null, LAMDBA_RESULT);
             // call

--- a/test/unit/commands/deploy/helper-test.js
+++ b/test/unit/commands/deploy/helper-test.js
@@ -10,9 +10,10 @@ const profileHelper = require('@src/utils/profile-helper');
 
 describe('Commands deploy test - helper test', () => {
     const TEST_PROFILE = 'default';
+    const TEST_IGNORE_HASH = false;
     const TEST_VENDOR_ID = 'vendor';
     const TEST_DO_DEBUG = false;
-    const TEST_OPTIONS = { profile: TEST_PROFILE, doDebug: TEST_DO_DEBUG };
+    const TEST_OPTIONS = { profile: TEST_PROFILE, doDebug: TEST_DO_DEBUG, ignoreHash: TEST_IGNORE_HASH };
 
     describe('# test helper method - deploySkillMetadata', () => {
         afterEach(() => {
@@ -97,7 +98,7 @@ describe('Commands deploy test - helper test', () => {
             // setup
             sinon.stub(SkillInfrastructureController.prototype, 'deployInfrastructure').callsArgWith(0, 'error');
             // call
-            helper.deploySkillInfrastructure(TEST_PROFILE, TEST_DO_DEBUG, (err, res) => {
+            helper.deploySkillInfrastructure(TEST_PROFILE, TEST_DO_DEBUG, TEST_IGNORE_HASH, (err, res) => {
                 // verify
                 expect(err).equal('error');
                 expect(res).equal(undefined);
@@ -109,7 +110,7 @@ describe('Commands deploy test - helper test', () => {
             // setup
             sinon.stub(SkillInfrastructureController.prototype, 'deployInfrastructure').callsArgWith(0);
             // call
-            helper.deploySkillInfrastructure(TEST_PROFILE, TEST_DO_DEBUG, (err, res) => {
+            helper.deploySkillInfrastructure(TEST_PROFILE, TEST_DO_DEBUG, TEST_IGNORE_HASH, (err, res) => {
                 // verify
                 expect(err).equal(undefined);
                 expect(res).equal(undefined);

--- a/test/unit/commands/deploy/index-test.js
+++ b/test/unit/commands/deploy/index-test.js
@@ -19,6 +19,7 @@ describe('Commands deploy test - command class test', () => {
     const FIXTURE_MANIFEST_FILE = path.join(process.cwd(), 'test', 'unit', 'fixture', 'model', 'manifest.json');
     const TEST_PROFILE = 'default';
     const TEST_DEBUG = false;
+    const TEST_IGNORE_HASH = false;
 
     let infoStub;
     let errorStub;
@@ -50,7 +51,8 @@ describe('Commands deploy test - command class test', () => {
     describe('validate command handle', () => {
         const TEST_CMD = {
             profile: TEST_PROFILE,
-            debug: TEST_DEBUG
+            debug: TEST_DEBUG,
+            ignoreHash: TEST_IGNORE_HASH
         };
         const TEST_SKILL_METADATA_SRC = './skillPackage';
         let instance;
@@ -289,7 +291,7 @@ with build flow ${TEST_CODE_BUILD_RESULT[0].buildFlow}.`);
                 // setup
                 sinon.stub(helper, 'deploySkillMetadata').callsArgWith(1);
                 sinon.stub(helper, 'buildSkillCode').callsArgWith(2, null, TEST_CODE_BUILD_RESULT);
-                sinon.stub(helper, 'deploySkillInfrastructure').callsArgWith(2, 'error');
+                sinon.stub(helper, 'deploySkillInfrastructure').callsArgWith(3, 'error');
                 sinon.stub(helper, 'enableSkill').callsArgWith(2);
                 sinon.stub(path, 'resolve').returns(TEST_CODE_SRC_BASENAME);
                 sinon.stub(fs, 'statSync').returns({
@@ -318,7 +320,7 @@ with build flow ${TEST_CODE_BUILD_RESULT[0].buildFlow}.`);
                 // setup
                 sinon.stub(helper, 'deploySkillMetadata').callsArgWith(1);
                 sinon.stub(helper, 'buildSkillCode').callsArgWith(2, null, TEST_CODE_BUILD_RESULT);
-                sinon.stub(helper, 'deploySkillInfrastructure').callsArgWith(2);
+                sinon.stub(helper, 'deploySkillInfrastructure').callsArgWith(3);
                 sinon.stub(helper, 'enableSkill').callsArgWith(2);
                 sinon.stub(path, 'resolve').returns(TEST_CODE_SRC_BASENAME);
                 sinon.stub(fs, 'statSync').returns({
@@ -367,7 +369,7 @@ with build flow ${TEST_CODE_BUILD_RESULT[0].buildFlow}.`);
                 const TEST_ERROR = 'error';
                 sinon.stub(helper, 'deploySkillMetadata').callsArgWith(1);
                 sinon.stub(helper, 'buildSkillCode').callsArgWith(2, null, TEST_CODE_BUILD_RESULT);
-                sinon.stub(helper, 'deploySkillInfrastructure').callsArgWith(2);
+                sinon.stub(helper, 'deploySkillInfrastructure').callsArgWith(3);
                 sinon.stub(helper, 'enableSkill').callsArgWith(2, 'error');
                 instance.handle(TEST_CMD, (err) => {
                     expect(errorStub.args[0][0]).equal(TEST_ERROR);


### PR DESCRIPTION
*Issue #, if available:*

--ignore-hash option not implemented

*Description of changes:*

Deploy command updated to support the ignoreHash option.

The deploySkillInfrastructure helper command now accepts an ignoreHash parameter alongside profile and debug.

The builtin lambda-deployer validateLambdaDeployState method supports an ignoreHash parameter.

All tests use the TEST_IGNORE_HASH default.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
