### PR TITLE
feat: add default value development when stage is required

### DIFF
--- a/lib/commands/smapi/smapi-commander.js
+++ b/lib/commands/smapi/smapi-commander.js
@@ -43,7 +43,8 @@ const _makeAlias = (kebabName) => (aliases[kebabName] ? `-${aliases[kebabName]},
 const _makeOption = (param) => {
     const name = apiToCommanderMap.get(param.name) || param.name;
     const defaultValue = defaultValues.get(name);
-    if (defaultValue) {
+    const shouldMakeOptional = param.required && defaultValue;
+    if (shouldMakeOptional) {
         param.required = false;
     }
     const paramName = kebabCase(name);
@@ -58,7 +59,7 @@ const _makeOption = (param) => {
         + `${arrayTemplate}`
         + `${jsonTemplate[json]}`
         + `${enumTemplate} `).trim(),
-        defaultValue
+        defaultValue: shouldMakeOptional ? defaultValue : undefined
     };
 };
 /**

--- a/lib/commands/smapi/smapi-commander.js
+++ b/lib/commands/smapi/smapi-commander.js
@@ -26,6 +26,10 @@ const defaultOptions = [
         description: optionModel.debug.description
     }
 ];
+
+const defaultValues = new Map();
+defaultValues.set('stage', 'development');
+
 const requiredTemplate = { true: '[REQUIRED]', false: '[OPTIONAL]' };
 const jsonTemplate = { true: '[JSON]: JSON string or a file. Example: "$(cat {filePath})" '
 + 'or "file:{filePath}", either absolute or relative path are supported.\n',
@@ -49,7 +53,8 @@ const _makeOption = (param) => {
         (`${requiredTemplate[param.required]} ${(param.description || '').trim()} \n`
         + `${arrayTemplate}`
         + `${jsonTemplate[json]}`
-        + `${enumTemplate} `).trim()
+        + `${enumTemplate} `).trim(),
+        defaultValue: defaultValues.get(name)
     };
 };
 /**
@@ -79,7 +84,7 @@ const makeSmapiCommander = () => {
             }
             const option = _makeOption(param);
             if (param.required) {
-                commanderInstance.requiredOption(option.name, option.description);
+                commanderInstance.requiredOption(option.name, option.description, option.defaultValue);
             } else {
                 commanderInstance.option(option.name, option.description);
             }

--- a/lib/commands/smapi/smapi-commander.js
+++ b/lib/commands/smapi/smapi-commander.js
@@ -42,6 +42,10 @@ const _makeAlias = (kebabName) => (aliases[kebabName] ? `-${aliases[kebabName]},
 
 const _makeOption = (param) => {
     const name = apiToCommanderMap.get(param.name) || param.name;
+    const defaultValue = defaultValues.get(name);
+    if (defaultValue) {
+        param.required = false;
+    }
     const paramName = kebabCase(name);
     const alias = _makeAlias(paramName);
     const json = param.json || false;
@@ -54,7 +58,7 @@ const _makeOption = (param) => {
         + `${arrayTemplate}`
         + `${jsonTemplate[json]}`
         + `${enumTemplate} `).trim(),
-        defaultValue: defaultValues.get(name)
+        defaultValue
     };
 };
 /**
@@ -84,9 +88,9 @@ const makeSmapiCommander = () => {
             }
             const option = _makeOption(param);
             if (param.required) {
-                commanderInstance.requiredOption(option.name, option.description, option.defaultValue);
+                commanderInstance.requiredOption(option.name, option.description);
             } else {
-                commanderInstance.option(option.name, option.description);
+                commanderInstance.option(option.name, option.description, option.defaultValue);
             }
         });
 


### PR DESCRIPTION
Adding default value of development for stage when stage is required.
example
```
Options:
  -s,--skill-id <skill-id>         [REQUIRED] The skill ID.
  -g,--stage <stage>               [REQUIRED] Stage for skill. (default: "development")
```
still kept it required but added default value.