### PR TITLE
fix: ingoring version check for credential helper

### DIFF
--- a/lib/commands/abstract-command.js
+++ b/lib/commands/abstract-command.js
@@ -77,9 +77,10 @@ class AbstractCommand {
 
             // Start metric client
             metricClient.startAction(commandInstance._name, 'command');
+            const isCredentialHelperCmd = commandInstance._name === 'git-credentials-helper';
 
             // Check if a new CLI version is released
-            this._remindsIfNewVersion(commandInstance.debug, process.env.ASK_SKIP_NEW_VERSION_REMINDER, () => {
+            this._remindsIfNewVersion(commandInstance.debug, isCredentialHelperCmd || process.env.ASK_SKIP_NEW_VERSION_REMINDER, () => {
                 try {
                     this._validateOptions(commandInstance);
 
@@ -192,18 +193,18 @@ class AbstractCommand {
                 const latestVersion = JSON.parse(response.body).version;
                 if (packageJson.version !== latestVersion) {
                     if (semver.major(packageJson.version) < semver.major(latestVersion)) {
-                        Messenger.getInstance().info(`\
+                        Messenger.getInstance().warn(`\
 ${BANNER_WITH_HASH}
-[Info]: New MAJOR version (v${latestVersion}) of ${CONSTANTS.APPLICATION_NAME} is available now. Current version v${packageJson.version}.
+New MAJOR version (v${latestVersion}) of ${CONSTANTS.APPLICATION_NAME} is available now. Current version v${packageJson.version}.
 It is recommended to use the latest version. Please update using "npm upgrade -g ${CONSTANTS.APPLICATION_NAME}".
 ${BANNER_WITH_HASH}\n`);
                     } else if (
                         semver.major(packageJson.version) === semver.major(latestVersion)
                         && semver.minor(packageJson.version) < semver.minor(latestVersion)
                     ) {
-                        Messenger.getInstance().info(`\
+                        Messenger.getInstance().warn(`\
 ${BANNER_WITH_HASH}
-[Info]: New MINOR version (v${latestVersion}) of ${CONSTANTS.APPLICATION_NAME} is available now. Current version v${packageJson.version}.
+New MINOR version (v${latestVersion}) of ${CONSTANTS.APPLICATION_NAME} is available now. Current version v${packageJson.version}.
 It is recommended to use the latest version. Please update using "npm upgrade -g ${CONSTANTS.APPLICATION_NAME}".
 ${BANNER_WITH_HASH}\n`);
                     }

--- a/test/unit/commands/abstract-command-test.js
+++ b/test/unit/commands/abstract-command-test.js
@@ -370,9 +370,9 @@ describe('Command test - AbstractCommand class', () => {
                     `${CONSTANTS.NPM_REGISTRY_URL_BASE}/${CONSTANTS.APPLICATION_NAME}/latest`
                 );
                 expect(httpClient.request.args[0][0].method).equal(CONSTANTS.HTTP_REQUEST.VERB.GET);
-                expect(infoStub.args[0][0]).equal(`\
+                expect(warnStub.args[0][0]).equal(`\
 ##########################################################################
-[Info]: New MAJOR version (v${latestVersion}) of ${CONSTANTS.APPLICATION_NAME} is available now. Current version v${packageJson.version}.
+New MAJOR version (v${latestVersion}) of ${CONSTANTS.APPLICATION_NAME} is available now. Current version v${packageJson.version}.
 It is recommended to use the latest version. Please update using "npm upgrade -g ${CONSTANTS.APPLICATION_NAME}".
 ##########################################################################\n`);
                 expect(err).equal(undefined);
@@ -391,9 +391,9 @@ It is recommended to use the latest version. Please update using "npm upgrade -g
                     `${CONSTANTS.NPM_REGISTRY_URL_BASE}/${CONSTANTS.APPLICATION_NAME}/latest`
                 );
                 expect(httpClient.request.args[0][0].method).equal(CONSTANTS.HTTP_REQUEST.VERB.GET);
-                expect(infoStub.args[0][0]).equal(`\
+                expect(warnStub.args[0][0]).equal(`\
 ##########################################################################
-[Info]: New MINOR version (v${latestVersion}) of ${CONSTANTS.APPLICATION_NAME} is available now. Current version v${packageJson.version}.
+New MINOR version (v${latestVersion}) of ${CONSTANTS.APPLICATION_NAME} is available now. Current version v${packageJson.version}.
 It is recommended to use the latest version. Please update using "npm upgrade -g ${CONSTANTS.APPLICATION_NAME}".
 ##########################################################################\n`);
                 expect(err).equal(undefined);


### PR DESCRIPTION
When we release new version. Every command has this header
##########################################################################
[Info]: New MINOR version (v2.11.0) of ask-cli is available now. Current version v2.10.1.
It is recommended to use the latest version. Please update using "npm upgrade -g ask-cli".
##########################################################################

This breaks git credential helper since we write it to stdout. 

Change to write to stderr and also added skip for credential helper.