### PR TITLE
fix: pass profile to status hint; handle customized param names

### DIFF
--- a/lib/commands/smapi/smapi-command-handler.js
+++ b/lib/commands/smapi/smapi-command-handler.js
@@ -3,6 +3,7 @@ const fs = require('fs-extra');
 const R = require('ramda');
 const queryString = require('querystring');
 
+const { apiToCommanderMap } = require('@src/commands/smapi/customizations/parameters-map');
 const AppConfig = require('@src/model/app-config');
 const AuthorizationController = require('@src/controllers/authorization-controller');
 const CONSTANTS = require('@src/utils/constants');
@@ -97,7 +98,7 @@ const _matchSwaggerPattern = (url, swaggerPatternUrl) => {
     return { swaggerPatternUrl, params };
 };
 
-const _showCheckStatusHint = (locationHeader) => {
+const _showCheckStatusHint = (locationHeader, profile) => {
     const { value } = locationHeader;
     const [baseUrl, queryStringPart] = value.split('?');
     const modelIntrospector = new ModelIntrospector();
@@ -115,8 +116,13 @@ const _showCheckStatusHint = (locationHeader) => {
         const baseCliCommand = processor.processOperationName(operationName);
         const queryStringParameters = queryString.parse(queryStringPart);
         parameters = { ...swaggerMatch.params, ...queryStringParameters };
-        const cliParams = Object.keys(parameters).map(key => `--${kebabCase(key)} ${parameters[key]}`).join(' ');
-        statusCheckHintCommand = `ask smapi ${baseCliCommand} ${cliParams}`;
+        const cliParams = Object.keys(parameters).map(key => {
+            // mapping custom command option if exists
+            const commandOption = kebabCase(apiToCommanderMap.get(key) || key);
+            return `--${commandOption} ${parameters[key]}`;
+        }).join(' ');
+        const profileFlag = profile ? ` --profile ${profile}` : '';
+        statusCheckHintCommand = `ask smapi ${baseCliCommand} ${cliParams}${profileFlag}`;
         Messenger.getInstance().warn(`This is an asynchronous operation. Check the progress using the following command: ${statusCheckHintCommand}`);
     } else {
         Messenger.getInstance().warn(`This is an asynchronous operation. Check the progress using the following url: ${value}`);
@@ -127,7 +133,7 @@ const _showCheckStatusHint = (locationHeader) => {
  * Parses response from smapi
  * @param {Object} response object
  */
-const parseSmapiResponse = (response) => {
+const parseSmapiResponse = (response, profile) => {
     let result = '';
     const { body, headers, statusCode } = response;
     const contentType = headers.find((h) => h.key === 'content-type');
@@ -135,7 +141,7 @@ const parseSmapiResponse = (response) => {
     // json if no content type or content type is application/json
     const isJson = !contentType || contentType.value.includes('application/json');
     if (statusCode === CONSTANTS.HTTP_REQUEST.STATUS_CODE.ACCEPTED && locationHeader) {
-        _showCheckStatusHint(locationHeader);
+        _showCheckStatusHint(locationHeader, profile);
     }
     if (body && Object.keys(body).length) {
         result = isJson ? jsonView.toString(body) : body;
@@ -206,7 +212,7 @@ const smapiCommandHandler = (swaggerApiOperationName, flatParamsMap, commanderTo
             } else if (inputOpts.fullResponse) {
                 result = jsonView.toString({ body, headers, statusCode });
             } else {
-                result = parseSmapiResponse(response);
+                result = parseSmapiResponse(response, profile);
             }
             return result;
         });

--- a/lib/commands/smapi/smapi-command-handler.js
+++ b/lib/commands/smapi/smapi-command-handler.js
@@ -3,7 +3,7 @@ const fs = require('fs-extra');
 const R = require('ramda');
 const queryString = require('querystring');
 
-const { apiToCommanderMap } = require('@src/commands/smapi/customizations/parameters-map');
+const { apiToCommanderMap, customizationMap } = require('@src/commands/smapi/customizations/parameters-map');
 const AppConfig = require('@src/model/app-config');
 const AuthorizationController = require('@src/controllers/authorization-controller');
 const CONSTANTS = require('@src/utils/constants');
@@ -117,10 +117,12 @@ const _showCheckStatusHint = (locationHeader, profile) => {
         const queryStringParameters = queryString.parse(queryStringPart);
         parameters = { ...swaggerMatch.params, ...queryStringParameters };
         const cliParams = Object.keys(parameters).map(key => {
+            const customization = customizationMap.get(key);
+            if (customization && customization.skip) return '';
             // mapping custom command option if exists
             const commandOption = kebabCase(apiToCommanderMap.get(key) || key);
             return `--${commandOption} ${parameters[key]}`;
-        }).join(' ');
+        }).join(' ').trim();
         const profileFlag = profile ? ` --profile ${profile}` : '';
         statusCheckHintCommand = `ask smapi ${baseCliCommand} ${cliParams}${profileFlag}`;
         Messenger.getInstance().warn(`This is an asynchronous operation. Check the progress using the following command: ${statusCheckHintCommand}`);

--- a/test/integration/commands/smapi-commands-test.js
+++ b/test/integration/commands/smapi-commands-test.js
@@ -1097,20 +1097,6 @@ parallel('smapi command test', () => {
         expect(result).be.an('object');
     });
 
-    it('| should clone locale', async () => {
-        const args = [subCmd, 'clone-locale', '-s', skillId, '--source-locale', 'sourceLocale', '--target-locales', 'targetLocales'];
-        addCoveredCommand(args);
-        const result = await run(cmd, args, { ...options, parse: false });
-        expect(result).include('Command executed successfully!');
-    });
-
-    it('| should get clone locale status', async () => {
-        const args = [subCmd, 'get-clone-locale-status', '-s', skillId, '--clone-locale-request-id', 'x'];
-        addCoveredCommand(args);
-        const result = await run(cmd, args, options);
-        expect(result).be.an('object');
-    });
-
     after(() => {
         mockSmapiServer.kill();
         mockLwaServer.kill();

--- a/test/integration/commands/smapi-commands-test.js
+++ b/test/integration/commands/smapi-commands-test.js
@@ -183,7 +183,6 @@ parallel('smapi command test', () => {
         expect(result).include('Command executed successfully!');
     });
 
-
     it('| should display catalog list for skill', async () => {
         const args = [subCmd, 'list-catalogs-for-skill', '-s', skillId, '--max-results', 1];
         addCoveredCommand(args);
@@ -390,7 +389,6 @@ parallel('smapi command test', () => {
         const result = await run(cmd, args, options);
         expect(result).be.an('object');
     });
-
 
     it('| should get content upload by id', async () => {
         const args = [subCmd, 'get-content-upload-by-id', '-c', catalogId, '--upload-id', uploadId];
@@ -1094,6 +1092,20 @@ parallel('smapi command test', () => {
 
     it('| should list interaction model catalog versions', async () => {
         const args = [subCmd, 'list-interaction-model-catalog-versions', '-c', catalogId];
+        addCoveredCommand(args);
+        const result = await run(cmd, args, options);
+        expect(result).be.an('object');
+    });
+
+    it('| should clone locale', async () => {
+        const args = [subCmd, 'clone-locale', '-s', skillId, '--source-locale', 'sourceLocale', '--target-locales', 'targetLocales'];
+        addCoveredCommand(args);
+        const result = await run(cmd, args, { ...options, parse: false });
+        expect(result).include('Command executed successfully!');
+    });
+
+    it('| should get clone locale status', async () => {
+        const args = [subCmd, 'get-clone-locale-status', '-s', skillId, '--clone-locale-request-id', 'x'];
         addCoveredCommand(args);
         const result = await run(cmd, args, options);
         expect(result).be.an('object');

--- a/test/unit/commands/smapi/smapi-command-handler-test.js
+++ b/test/unit/commands/smapi/smapi-command-handler-test.js
@@ -219,12 +219,25 @@ describe('Smapi test - parseSmapiResponse function', () => {
     it('| should show warning with status hint command when able to find one', () => {
         const skillId = 'someSkillId';
         const resource = 'someResource';
+        const profile = 'test';
+        const url = `/v1/skills/${skillId}/status?resource=${resource}`;
+        const response = { headers: [{ key: 'location', value: url }], statusCode: 202 };
+
+        parseSmapiResponse(response, profile);
+        expect(warnStub.firstCall.lastArg).eql('This is an asynchronous operation. Check the progress '
+        + `using the following command: ask smapi get-skill-status --skill-id ${skillId} --resource ${resource} --profile ${profile}`);
+    });
+
+    it('| should show warning with status hint that has parameter with customized name', () => {
+        const skillId = 'someSkillId';
+        const resource = 'someResource';
+        sinon.stub(Map.prototype, 'get').withArgs('resource').returns('someCustomName');
         const url = `/v1/skills/${skillId}/status?resource=${resource}`;
         const response = { headers: [{ key: 'location', value: url }], statusCode: 202 };
 
         parseSmapiResponse(response);
         expect(warnStub.firstCall.lastArg).eql('This is an asynchronous operation. Check the progress '
-        + `using the following command: ask smapi get-skill-status --skill-id ${skillId} --resource ${resource}`);
+        + `using the following command: ask smapi get-skill-status --skill-id ${skillId} --some-custom-name ${resource}`);
     });
 
     it('| should not show warning with status hint command when not able to find one', () => {

--- a/test/unit/commands/smapi/smapi-command-handler-test.js
+++ b/test/unit/commands/smapi/smapi-command-handler-test.js
@@ -228,11 +228,17 @@ describe('Smapi test - parseSmapiResponse function', () => {
         + `using the following command: ask smapi get-skill-status --skill-id ${skillId} --resource ${resource} --profile ${profile}`);
     });
 
-    it('| should show warning with status hint that has parameter with customized name', () => {
+    it('| should show warning with status hint for customized parameters', () => {
         const skillId = 'someSkillId';
         const resource = 'someResource';
-        sinon.stub(Map.prototype, 'get').withArgs('resource').returns('someCustomName');
-        const url = `/v1/skills/${skillId}/status?resource=${resource}`;
+        const vendorId = 'someVendorId';
+        sinon.stub(Map.prototype, 'get')
+            .withArgs('vendorId')
+            .returns({ skip: true })
+            .withArgs('resource')
+            .returns('someCustomName');
+
+        const url = `/v1/skills/${skillId}/status?resource=${resource}&vendorId=${vendorId}`;
         const response = { headers: [{ key: 'location', value: url }], statusCode: 202 };
 
         parseSmapiResponse(response);


### PR DESCRIPTION
fixing 2 minor issues
1) passing profile to status hint if it was provided for the command
2) fixing to pass correct parameter name if it was customized. for example: stageV2 should be state.
