### PR TITLE
fix: output deploy error if error not string

### DIFF
--- a/lib/view/multi-tasks-view.js
+++ b/lib/view/multi-tasks-view.js
@@ -58,7 +58,7 @@ class ListrReactiveTask {
                 subscriber.next(status);
             });
             this._eventEmitter.on('error', (error) => {
-                if (error && typeof error === 'string') {
+                if (error) {
                     subscriber.error(error);
                 } else if (error && error.resultMessage) {
                     subscriber.error(error.resultMessage);

--- a/test/unit/view/multi-tasks-view-test.js
+++ b/test/unit/view/multi-tasks-view-test.js
@@ -214,8 +214,7 @@ describe('View test - ListReactiveTask test', () => {
             const obsv = rxTask.buildObservable()(TEST_CONTEXT, TEST_TASK);
             obsv._subscribe(subscribeStub);
             // verify
-            expect(subscribeStub.error.args[0][0]).equal('error');
-            expect(TEST_CONTEXT[TEST_TASK_ID]).deep.equal(TEST_ERROR_OBJ);
+            expect(subscribeStub.error.args[0][0]).deep.equal(TEST_ERROR_OBJ);
         });
 
         it('| when "error" event emit with error object structure, expect subscriber to call "error" and set context', () => {
@@ -233,8 +232,7 @@ describe('View test - ListReactiveTask test', () => {
             const obsv = rxTask.buildObservable()(TEST_CONTEXT, TEST_TASK);
             obsv._subscribe(subscribeStub);
             // verify
-            expect(subscribeStub.error.args[0][0]).equal('error');
-            expect(TEST_CONTEXT[TEST_TASK_ID]).deep.equal(TEST_ERROR_OBJ);
+            expect(subscribeStub.error.args[0][0]).deep.equal(TEST_ERROR_OBJ);
         });
 
         it('| when "title" event emit, expect subscriber to call "title"', () => {


### PR DESCRIPTION
Steps to reproduce
1) update ~/.aws/credentials and put invalid aws_secret_access_key
2) ask deploy with lambda deployer

the deploy will hang on creating IAM role step

This PR make sure the error gets propagates and fail the command.
