### PR TITLE
fix: add pageSize to avoid the description of the template gets too long and breaks the line

### DIFF
--- a/lib/commands/new/ui.js
+++ b/lib/commands/new/ui.js
@@ -74,13 +74,14 @@ function selectSkillCodeLanguage(callback) {
 function getTargetTemplateName(templateMap, callback) {
     const templateList = R.keys(templateMap).map((templateName) => {
         const description = templateMap[templateName].description || '';
-        return `${templateName}\t\t    ${chalk.gray(description)}`;
+        return `${templateName}\n  ${chalk.gray(description)}`;
     });
     inquirer.prompt([{
         type: 'list',
         message: 'Choose a template to start with: ',
         name: 'templateName',
         choices: templateList,
+        pageSize: 30,
         filter: input => input.replace(/\s{4}.*/g, '')
     }]).then((answer) => {
         callback(null, answer.templateName);

--- a/lib/commands/new/ui.js
+++ b/lib/commands/new/ui.js
@@ -82,7 +82,7 @@ function getTargetTemplateName(templateMap, callback) {
         name: 'templateName',
         choices: templateList,
         pageSize: 30,
-        filter: input => input.replace(/\s{4}.*/g, '')
+        filter: input => input.replace(/\n.*/g, '')
     }]).then((answer) => {
         callback(null, answer.templateName);
     }).catch((error) => {

--- a/test/unit/commands/new/ui-test.js
+++ b/test/unit/commands/new/ui-test.js
@@ -294,7 +294,7 @@ describe('Commands new - UI test', () => {
                     choices: TEST_TEMPLATE_CHOICES,
                     pageSize: 30
                 });
-                expect(inquirer.prompt.args[0][0][0].filter('a         b')).equal('a');
+                expect(inquirer.prompt.args[0][0][0].filter('a\nb')).equal('a');
                 expect(err).equal(null);
                 expect(response).equal(TEST_TEMPLATE_NAME);
                 done();
@@ -313,7 +313,7 @@ describe('Commands new - UI test', () => {
                     choices: TEST_TEMPLATE_CHOICES,
                     pageSize: 30
                 });
-                expect(inquirer.prompt.args[0][0][0].filter('a         b')).equal('a');
+                expect(inquirer.prompt.args[0][0][0].filter('a\nb')).equal('a');
                 expect(err.message).equal(TEST_ERROR);
                 expect(response).equal(undefined);
                 done();

--- a/test/unit/commands/new/ui-test.js
+++ b/test/unit/commands/new/ui-test.js
@@ -51,8 +51,8 @@ describe('Commands new - UI test', () => {
         }
     };
     const TEST_TEMPLATE_CHOICES = [
-        `template1\t\t    ${chalk.gray('templateDescription1')}`,
-        `template2\t\t    ${chalk.gray('')}`
+        `template1\n  ${chalk.gray('templateDescription1')}`,
+        `template2\n  ${chalk.gray('')}`
     ];
     const TEST_DEPLOYMENT_CHOICES_WITH_SEP = [
         `${TEST_DEPLOYMENT_OPTION_NAME}\n  ${chalk.gray('HOSTED_DESCRIPTION')}`,
@@ -291,7 +291,8 @@ describe('Commands new - UI test', () => {
                 validateInquirerConfig(inquirer.prompt.args[0][0][0], {
                     message: 'Choose a template to start with: ',
                     type: 'list',
-                    choices: TEST_TEMPLATE_CHOICES
+                    choices: TEST_TEMPLATE_CHOICES,
+                    pageSize: 30
                 });
                 expect(inquirer.prompt.args[0][0][0].filter('a         b')).equal('a');
                 expect(err).equal(null);
@@ -309,7 +310,8 @@ describe('Commands new - UI test', () => {
                 validateInquirerConfig(inquirer.prompt.args[0][0][0], {
                     message: 'Choose a template to start with: ',
                     type: 'list',
-                    choices: TEST_TEMPLATE_CHOICES
+                    choices: TEST_TEMPLATE_CHOICES,
+                    pageSize: 30
                 });
                 expect(inquirer.prompt.args[0][0][0].filter('a         b')).equal('a');
                 expect(err.message).equal(TEST_ERROR);


### PR DESCRIPTION
When the terminal is not wide enough this will happen when moving the cursor:
```
$ ask new
Please follow the wizard to start your Alexa skill project ->
? Choose the programming language you will use to code your skill:  NodeJS
? Choose a method to host your skill's backend resources:  AWS with CloudFormation
  Host your skill code with AWS services and provision with AWS CloudFormation (requires AWS account)
? Choose a template to start with:  (Use arrow keys)
❯ Hello world		    Alexa's hello world skill to send the greetings to the world!
? Choose a template to start with:
  Hello world		    Alexa's hello world skill to send the greetings to the world!
? Choose a template to start with:
  Hello world		    Alexa's hello world skill to send the greetings to the world!
? Choose a template to start with:
  Hello world		    Alexa's hello world skill to send the greetings to the world!
  Fact skill		    Quick sample skill to manage a collection of voice data.
  High low game		    Guess a number high or low using persistent attributes. Make sure your AWS account h
as the permission to manage DynamoDB!
```
After the change it looks like below now, which gives more space for the description and reduce this impact from inquirer.js.
```
(descriptions are gray color)
$ ask new
Please follow the wizard to start your Alexa skill project ->
? Choose the programming language you will use to code your skill:  NodeJS
? Choose a method to host your skill's backend resources:  AWS with CloudFormation
  Host your skill code with AWS services and provision with AWS CloudFormation (requires AWS account)
? Choose a template to start with:
  Hello world
  Alexa's hello world skill to send the greetings to the world!
  Fact skill
  Quick sample skill to manage a collection of voice data.
❯ High low game
  Guess a number high or low using persistent attributes. Make sure your AWS account has the permission to manage DynamoDB!
```