### PR TITLE
feat: modify the default AWS region for FE to us-west-2

### DIFF
--- a/lib/builtins/deploy-delegates/cfn-deployer/helper.js
+++ b/lib/builtins/deploy-delegates/cfn-deployer/helper.js
@@ -10,7 +10,7 @@ const alexaAwsRegionMap = {
     default: 'us-east-1',
     NA: 'us-east-1',
     EU: 'eu-west-1',
-    FE: 'ap-northeast-1'
+    FE: 'us-west-2'
 };
 
 module.exports = {

--- a/lib/builtins/deploy-delegates/lambda-deployer/index.js
+++ b/lib/builtins/deploy-delegates/lambda-deployer/index.js
@@ -8,7 +8,7 @@ const alexaAwsRegionMap = {
     default: 'us-east-1',
     NA: 'us-east-1',
     EU: 'eu-west-1',
-    FE: 'ap-northeast-1'
+    FE: 'us-west-2'
 };
 
 module.exports = {


### PR DESCRIPTION
This change of default AWS region is based on the smartHome skill developers' feedback. Our documentation shows us-west-2 is the optimal AWS region for FE endpoint:

https://developer.amazon.com/en-US/docs/alexa/smarthome/develop-smart-home-skills-in-multiple-languages.html#deploy

https://developer.amazon.com/en-US/docs/alexa/custom-skills/host-a-custom-skill-as-an-aws-lambda-function.html#allowed-regions