### PR TITLE
fix: improve the description for ask-smapi command [JSON] options

### DIFF
--- a/lib/commands/smapi/smapi-commander.js
+++ b/lib/commands/smapi/smapi-commander.js
@@ -31,8 +31,9 @@ const defaultValues = new Map();
 defaultValues.set('stage', 'development');
 
 const requiredTemplate = { true: '[REQUIRED]', false: '[OPTIONAL]' };
-const jsonTemplate = { true: '[JSON]: JSON string or a file. Example: "$(cat {filePath})" '
-+ 'or "file:{filePath}", either absolute or relative path are supported.\n',
+const jsonTemplate = { true: '[JSON]: Option value is JSON string, accepts JSON file by using either:'
++ '\n- "$(cat {filePath})", use "type" command to replace "cat" command in Windows.'
++ '\n- "file:{filePath}", file descriptor with either absolute or relative file path.\n',
 false: '' };
 
 const _makeEnumTemplate = (param) => (param.enum ? `[ENUM]: ${param.enum.join()}.\n` : '');


### PR DESCRIPTION
Issue: developers from Windows cannot use "$cat" command, suggest them using "type" command in the option's description, plus some rephasing. 

Preview of the result (check --manifest option):
```
$ ask smapi update-skill-manifest -h
Usage: ask smapi update-skill-manifest [options]

Updates skill manifest for given skillId and stage.

Options:
  --if-match <if-match>     [OPTIONAL] Request header that specified an entity tag. The server will update the resource only if the eTag matches with the resource's current
                            eTag.
  -s,--skill-id <skill-id>  [REQUIRED] The skill ID.
  -g,--stage <stage>        [OPTIONAL] Stages of a skill including the new certified stage.
                            * `development` - skills which are currently in development corresponds to this stage.
                            * `certified` -  skills which have completed certification and ready for publishing corresponds to this stage.
                            * `live` - skills which are currently live corresponds to this stage. (default: "development")
  --manifest <manifest>     [REQUIRED] Defines the request body for updateSkill API.
                            [JSON]: Option value is JSON string, accepts JSON file by using:
                            - "$(cat {filePath})", use "type" command to replace "cat" command in Windows.
                            - "file:{filePath}", file descriptor with either absolute or relative file path.
  -p, --profile <profile>   Provides the ASK CLI profile to use. When you don't include this option, ASK CLI uses the default profile.
  --full-response           Returns body, headers and status code of the response as one object.
  --debug                   Enables the ASK CLI  to show debug messages in the output of the command.
  -h, --help                output usage information
```