### PR TITLE
fix: error object Object to show meaningful error message

### DIFF
--- a/lib/builtins/deploy-delegates/lambda-deployer/helper.js
+++ b/lib/builtins/deploy-delegates/lambda-deployer/helper.js
@@ -33,7 +33,7 @@ function validateLambdaDeployState(reporter, awsProfile, awsRegion, currentRegio
         const remoteIAMRole = data.Configuration.Role;
         if (stringUtils.isNonBlankString(localIAMRole) && !R.equals(localIAMRole, remoteIAMRole)) {
             return callback(`The IAM role for Lambda ARN (${lambdaArn}) should be ${remoteIAMRole}, but found ${localIAMRole}. \
-Please solve this IAM role mismatch and re-deploy again. To ignore this error run ask deploy --ignore-hash.`);
+Please solve this IAM role mismatch and re-deploy again. To ignore this error run "ask deploy --ignore-hash".`);
         }
         updatedDeployState = R.set(R.lensPath(['iamRole']), remoteIAMRole, currentRegionDeployState);
         // 2. check revision id
@@ -42,7 +42,7 @@ Please solve this IAM role mismatch and re-deploy again. To ignore this error ru
         if (stringUtils.isNonBlankString(localRevisionId) && !R.equals(localRevisionId, remoteRevisionId) && !ignoreHash) {
             return callback(`The current revisionId (The revision ID for Lambda ARN (${lambdaArn}) should be ${remoteRevisionId}, \
 but found ${localRevisionId}. Please solve this revision mismatch and re-deploy again. \
-To ignore this error run ask deploy --ignore-hash.`);
+To ignore this error run "ask deploy --ignore-hash".`);
         }
         updatedDeployState = R.set(R.lensPath(['lambda', 'revisionId']), remoteRevisionId, updatedDeployState);
         // 3. add lastModified

--- a/lib/builtins/deploy-delegates/lambda-deployer/helper.js
+++ b/lib/builtins/deploy-delegates/lambda-deployer/helper.js
@@ -33,7 +33,7 @@ function validateLambdaDeployState(reporter, awsProfile, awsRegion, currentRegio
         const remoteIAMRole = data.Configuration.Role;
         if (stringUtils.isNonBlankString(localIAMRole) && !R.equals(localIAMRole, remoteIAMRole)) {
             return callback(`The IAM role for Lambda ARN (${lambdaArn}) should be ${remoteIAMRole}, but found ${localIAMRole}. \
-Please solve this IAM role mismatch and re-deploy again.`);
+Please solve this IAM role mismatch and re-deploy again. To ignore this error run ask deploy --ignore-hash.`);
         }
         updatedDeployState = R.set(R.lensPath(['iamRole']), remoteIAMRole, currentRegionDeployState);
         // 2. check revision id
@@ -41,7 +41,8 @@ Please solve this IAM role mismatch and re-deploy again.`);
         const remoteRevisionId = data.Configuration.RevisionId;
         if (stringUtils.isNonBlankString(localRevisionId) && !R.equals(localRevisionId, remoteRevisionId) && !ignoreHash) {
             return callback(`The current revisionId (The revision ID for Lambda ARN (${lambdaArn}) should be ${remoteRevisionId}, \
-but found ${localRevisionId}. Please solve this revision mismatch and re-deploy again.`);
+but found ${localRevisionId}. Please solve this revision mismatch and re-deploy again. \
+To ignore this error run ask deploy --ignore-hash.`);
         }
         updatedDeployState = R.set(R.lensPath(['lambda', 'revisionId']), remoteRevisionId, updatedDeployState);
         // 3. add lastModified

--- a/lib/view/multi-tasks-view.js
+++ b/lib/view/multi-tasks-view.js
@@ -1,6 +1,7 @@
 const Listr = require('listr');
 const { EventEmitter } = require('events');
 const { Observable } = require('rxjs');
+const CliError = require('@src/exceptions/cli-error');
 
 /**
  * Reactive (rxjs) task class which serve as the middleware for Listr task registration
@@ -119,9 +120,10 @@ class MultiTasksView {
         this.taskRunner.run().then((context) => {
             callback(null, context);
         }).catch((listrError) => {
-            // listError { errors: [], context } contains array of errors from tasks and all context
+            const errorMessage = listrError.errors
+                .map(e => e.resultMessage || e.message || e).join('\n');
             callback({
-                error: [...new Set(listrError.errors)].join('\n- '),
+                error: new CliError(errorMessage),
                 partialResult: listrError.context
             });
         });

--- a/test/unit/builtins/lambda-deployer/helper-test.js
+++ b/test/unit/builtins/lambda-deployer/helper-test.js
@@ -82,7 +82,7 @@ describe('Builtins test - lambda-deployer helper.js test', () => {
                 }
             };
             const TEST_IAM_ROLE_ERROR = `The IAM role for Lambda ARN (${TEST_LAMBDA_ARN}) should be ${TEST_REMOTE_IAM_ROLE}, \
-but found ${TEST_LOCAL_IAM_ROLE}. Please solve this IAM role mismatch and re-deploy again. To ignore this error run ask deploy --ignore-hash.`;
+but found ${TEST_LOCAL_IAM_ROLE}. Please solve this IAM role mismatch and re-deploy again. To ignore this error run "ask deploy --ignore-hash".`;
             sinon.stub(LambdaClient.prototype, 'getFunction').callsArgWith(1, null, TEST_REMOTE_DEPLOY_STATE);
             // call
             helper.validateLambdaDeployState(REPORTER, TEST_AWS_PROFILE, TEST_AWS_REGION, TEST_LOCAL_DEPLOY_STATE, TEST_IGNORE_HASH, (err) => {
@@ -102,7 +102,7 @@ but found ${TEST_LOCAL_IAM_ROLE}. Please solve this IAM role mismatch and re-dep
                 }
             };
             const TEST_REVISION_ID_ERROR = `The current revisionId (The revision ID for Lambda ARN (${TEST_LAMBDA_ARN}) should be \
-${TEST_REMOTE_REVISION_ID}, but found ${TEST_LOCAL_REVISION_ID}. Please solve this revision mismatch and re-deploy again. To ignore this error run ask deploy --ignore-hash.`;
+${TEST_REMOTE_REVISION_ID}, but found ${TEST_LOCAL_REVISION_ID}. Please solve this revision mismatch and re-deploy again. To ignore this error run "ask deploy --ignore-hash".`;
             sinon.stub(LambdaClient.prototype, 'getFunction').callsArgWith(1, null, TEST_REMOTE_DEPLOY_STATE);
             // call
             helper.validateLambdaDeployState(REPORTER, TEST_AWS_PROFILE, TEST_AWS_REGION, TEST_LOCAL_DEPLOY_STATE, TEST_IGNORE_HASH, (err) => {

--- a/test/unit/builtins/lambda-deployer/helper-test.js
+++ b/test/unit/builtins/lambda-deployer/helper-test.js
@@ -82,7 +82,7 @@ describe('Builtins test - lambda-deployer helper.js test', () => {
                 }
             };
             const TEST_IAM_ROLE_ERROR = `The IAM role for Lambda ARN (${TEST_LAMBDA_ARN}) should be ${TEST_REMOTE_IAM_ROLE}, \
-but found ${TEST_LOCAL_IAM_ROLE}. Please solve this IAM role mismatch and re-deploy again.`;
+but found ${TEST_LOCAL_IAM_ROLE}. Please solve this IAM role mismatch and re-deploy again. To ignore this error run ask deploy --ignore-hash.`;
             sinon.stub(LambdaClient.prototype, 'getFunction').callsArgWith(1, null, TEST_REMOTE_DEPLOY_STATE);
             // call
             helper.validateLambdaDeployState(REPORTER, TEST_AWS_PROFILE, TEST_AWS_REGION, TEST_LOCAL_DEPLOY_STATE, TEST_IGNORE_HASH, (err) => {
@@ -102,7 +102,7 @@ but found ${TEST_LOCAL_IAM_ROLE}. Please solve this IAM role mismatch and re-dep
                 }
             };
             const TEST_REVISION_ID_ERROR = `The current revisionId (The revision ID for Lambda ARN (${TEST_LAMBDA_ARN}) should be \
-${TEST_REMOTE_REVISION_ID}, but found ${TEST_LOCAL_REVISION_ID}. Please solve this revision mismatch and re-deploy again.`;
+${TEST_REMOTE_REVISION_ID}, but found ${TEST_LOCAL_REVISION_ID}. Please solve this revision mismatch and re-deploy again. To ignore this error run ask deploy --ignore-hash.`;
             sinon.stub(LambdaClient.prototype, 'getFunction').callsArgWith(1, null, TEST_REMOTE_DEPLOY_STATE);
             // call
             helper.validateLambdaDeployState(REPORTER, TEST_AWS_PROFILE, TEST_AWS_REGION, TEST_LOCAL_DEPLOY_STATE, TEST_IGNORE_HASH, (err) => {

--- a/test/unit/view/multi-tasks-view-test.js
+++ b/test/unit/view/multi-tasks-view-test.js
@@ -3,6 +3,7 @@ const sinon = require('sinon');
 const Listr = require('listr');
 const events = require('events');
 const { Observable } = require('rxjs');
+const CliError = require('@src/exceptions/cli-error');
 const MultiTasksView = require('@src/view/multi-tasks-view');
 
 const { ListrReactiveTask } = MultiTasksView;
@@ -62,14 +63,14 @@ describe('View test - MultiTasksView test', () => {
             // setup
             const multiTasks = new MultiTasksView(TEST_OPTIONS);
             const newTask = new ListrReactiveTask(TEST_TASK_HANDLE, TEST_TASK_ID);
-            sinon.stub(Listr.prototype, 'run').rejects({ errors: ['error'] });
+            sinon.stub(Listr.prototype, 'run').rejects({ errors: ['error 1', { resultMessage: 'error 2' }, new Error('error 3')] });
             sinon.stub(ListrReactiveTask.prototype, 'execute');
             multiTasks._listrTasks.push(newTask);
             // call
             multiTasks.start((err, res) => {
                 // verify
                 expect(res).equal(undefined);
-                expect(err.error).equal('error');
+                expect(err.error).eql(new CliError('error 1\nerror 2\nerror 3'));
                 expect(ListrReactiveTask.prototype.execute.callCount).equal(1);
                 done();
             });


### PR DESCRIPTION
Fixing issue when "[Error]: object Object” is thrown during deploy to show more meaningful error message.

Reproduce:
1) ask deploy with lambda deployer
2) remove lambda:UpdateFunctionConfiguration permission
3) change something in .ask/ask-states.json (for example skillId)
4) ask deploy or ask deploy --ignore-hash.
