### PR TITLE
chore: add DEBUG to functional test

### DIFF
--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -26,3 +26,4 @@ jobs:
         ASK_REFRESH_TOKEN: ${{ secrets.ASK_REFRESH_TOKEN }}
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        DEBUG: true


### PR DESCRIPTION
Add DEBUG flag so we see why func test for hosted skill times out sometimes.
