### PR TITLE
fix: add profile checker in the deploy flow

### DIFF
--- a/lib/commands/deploy/helper.js
+++ b/lib/commands/deploy/helper.js
@@ -1,22 +1,24 @@
 const SkillMetadataController = require('@src/controllers/skill-metadata-controller');
 const SkillCodeController = require('@src/controllers/skill-code-controller');
 const SkillInfrastructureController = require('@src/controllers/skill-infrastructure-controller');
+const CliError = require('@src/exceptions/cli-error');
 const ResourcesConfig = require('@src/model/resources-config');
 const profileHelper = require('@src/utils/profile-helper');
 const CONSTANTS = require('@src/utils/constants');
 const Messenger = require('@src/view/messenger');
 
 module.exports = {
-    highlightProfile,
+    confirmProfile,
     deploySkillMetadata,
     buildSkillCode,
     deploySkillInfrastructure,
     enableSkill
 };
 
-function highlightProfile(profile) {
+function confirmProfile(profile) {
     if (!ResourcesConfig.getInstance().getProfile(profile)) {
-        throw `Profile [${profile}] does not exist. Please configure it in your ${CONSTANTS.FILE_PATH.ASK_RESOURCES_JSON_CONFIG} file.`;
+        throw new CliError(`Profile [${profile}] does not exist. \
+Please configure it in your ${CONSTANTS.FILE_PATH.ASK_RESOURCES_JSON_CONFIG} file.`);
     }
 
     Messenger.getInstance().info(`Deploy project for profile [${profile}]\n`);

--- a/lib/commands/deploy/helper.js
+++ b/lib/commands/deploy/helper.js
@@ -1,15 +1,26 @@
 const SkillMetadataController = require('@src/controllers/skill-metadata-controller');
 const SkillCodeController = require('@src/controllers/skill-code-controller');
 const SkillInfrastructureController = require('@src/controllers/skill-infrastructure-controller');
+const ResourcesConfig = require('@src/model/resources-config');
 const profileHelper = require('@src/utils/profile-helper');
+const CONSTANTS = require('@src/utils/constants');
 const Messenger = require('@src/view/messenger');
 
 module.exports = {
+    highlightProfile,
     deploySkillMetadata,
     buildSkillCode,
     deploySkillInfrastructure,
     enableSkill
 };
+
+function highlightProfile(profile) {
+    if (!ResourcesConfig.getInstance().getProfile(profile)) {
+        throw `Profile [${profile}] does not exist. Please configure it in your ${CONSTANTS.FILE_PATH.ASK_RESOURCES_JSON_CONFIG} file.`;
+    }
+
+    Messenger.getInstance().info(`Deploy project for profile [${profile}]\n`);
+}
 
 /**
  * Deploy skill metadata by calling SkillMetadataController

--- a/lib/commands/deploy/index.js
+++ b/lib/commands/deploy/index.js
@@ -38,6 +38,8 @@ class DeployCommand extends AbstractCommand {
         try {
             profile = profileHelper.runtimeProfile(cmd.profile);
             new ResourcesConfig(path.join(process.cwd(), CONSTANTS.FILE_PATH.ASK_RESOURCES_JSON_CONFIG));
+            Messenger.getInstance().info(`Deploy configuration loaded from ${CONSTANTS.FILE_PATH.ASK_RESOURCES_JSON_CONFIG}`);
+            helper.highlightProfile(profile);
             this._filterAlexaHostedSkill(profile);
             this._initiateManifestModel(profile);
         } catch (err) {

--- a/lib/commands/deploy/index.js
+++ b/lib/commands/deploy/index.js
@@ -39,7 +39,7 @@ class DeployCommand extends AbstractCommand {
             profile = profileHelper.runtimeProfile(cmd.profile);
             new ResourcesConfig(path.join(process.cwd(), CONSTANTS.FILE_PATH.ASK_RESOURCES_JSON_CONFIG));
             Messenger.getInstance().info(`Deploy configuration loaded from ${CONSTANTS.FILE_PATH.ASK_RESOURCES_JSON_CONFIG}`);
-            helper.highlightProfile(profile);
+            helper.confirmProfile(profile);
             this._filterAlexaHostedSkill(profile);
             this._initiateManifestModel(profile);
         } catch (err) {
@@ -47,6 +47,8 @@ class DeployCommand extends AbstractCommand {
                 Messenger.getInstance().warn(err.message);
             } else if (err instanceof CliFileNotFoundError) {
                 Messenger.getInstance().warn(err.message);
+            } else if (err instanceof CliError) {
+                Messenger.getInstance().error(err.message);
             } else {
                 Messenger.getInstance().error(err);
             }

--- a/lib/utils/profile-helper.js
+++ b/lib/utils/profile-helper.js
@@ -16,7 +16,7 @@ module.exports = {
 function runtimeProfile(profile) {
     const askProfile = profile || _findEnvProfile() || process.env.ASK_DEFAULT_PROFILE || 'default';
     if (!module.exports.checkASKProfileExist(askProfile)) {
-        throw (`Cannot resolve profile [${askProfile}]`);
+        throw (`Can't resolve profile [${askProfile}] as it doesn't exist. Please run "ask configure --profile ${askProfile}" first.`);
     }
     return askProfile;
 }

--- a/lib/view/messenger.js
+++ b/lib/view/messenger.js
@@ -188,18 +188,13 @@ class Messenger {
      * @param {string} msg The text content to be displayed
      */
     static displayWithStyle(color, method, bold, msg) {
-        if (color) {
-            if (bold) {
-                console[method](chalk`{bold.${color} ${msg}}`);
-            } else {
-                console[method](chalk`{${color} ${msg}}`);
-            }
+        const boldTag = bold ? 'bold' : undefined;
+        const colorTag = color || undefined;
+        const finalTemplateTag = [boldTag, colorTag].filter(str => str).join('.');
+        if (!finalTemplateTag) {
+            console[method](msg);
         } else {
-            if (bold) {
-                console[method](chalk`{bold ${msg}}`);
-            } else {
-                console[method](msg);
-            }
+            console[method](chalk`{${finalTemplateTag} ${msg}}`);
         }
     }
 

--- a/test/unit/commands/configure/index-test.js
+++ b/test/unit/commands/configure/index-test.js
@@ -27,7 +27,6 @@ describe('Commands Configure test - command class test', () => {
     let infoStub;
     let errorStub;
     let warnStub;
-    let getProfileListStub;
 
     beforeEach(() => {
         infoStub = sinon.stub();

--- a/test/unit/commands/deploy/helper-test.js
+++ b/test/unit/commands/deploy/helper-test.js
@@ -1,14 +1,15 @@
 const { expect } = require('chai');
 const sinon = require('sinon');
-const Messenger = require('@src/view/messenger');
 
 const helper = require('@src/commands/deploy/helper');
 const SkillMetadataController = require('@src/controllers/skill-metadata-controller');
 const SkillCodeController = require('@src/controllers/skill-code-controller');
 const SkillInfrastructureController = require('@src/controllers/skill-infrastructure-controller');
+const CliError = require('@src/exceptions/cli-error');
 const ResourcesConfig = require('@src/model/resources-config');
 const CONSTANTS = require('@src/utils/constants');
 const profileHelper = require('@src/utils/profile-helper');
+const Messenger = require('@src/view/messenger');
 
 describe('Commands deploy test - helper test', () => {
     const TEST_PROFILE = 'default';
@@ -25,15 +26,9 @@ describe('Commands deploy test - helper test', () => {
         it('| profile does not exist, expect throw error', () => {
             // setup
             sinon.stub(ResourcesConfig.prototype, 'getProfile').returns(undefined);
-            try {
-                // call
-                helper.confirmProfile(TEST_PROFILE);
-            } catch (err) {
-                // verify
-                expect(err.message).equal(
-                    `Profile [${TEST_PROFILE}] does not exist. Please configure it in your ${CONSTANTS.FILE_PATH.ASK_RESOURCES_JSON_CONFIG} file.`
-                );
-            }
+            // call & verify
+            expect(() => helper.confirmProfile(TEST_PROFILE)).throw(CliError,
+                `Profile [${TEST_PROFILE}] does not exist. Please configure it in your ${CONSTANTS.FILE_PATH.ASK_RESOURCES_JSON_CONFIG} file.`);
         });
 
         it('| profile does exist, expect messenger info', () => {
@@ -43,13 +38,8 @@ describe('Commands deploy test - helper test', () => {
                 info: infoStub
             });
             sinon.stub(ResourcesConfig.prototype, 'getProfile').returns({ test: 'result' });
-            try {
-                // call
-                helper.confirmProfile(TEST_PROFILE);
-            } catch (err) {
-                // verify
-                expect(err).equal(undefined);
-            }
+            // call & verify
+            expect(() => helper.confirmProfile(TEST_PROFILE)).to.not.throw();
             expect(infoStub.args[0][0]).equal(`Deploy project for profile [${TEST_PROFILE}]\n`);
         });
     });

--- a/test/unit/commands/deploy/helper-test.js
+++ b/test/unit/commands/deploy/helper-test.js
@@ -17,7 +17,7 @@ describe('Commands deploy test - helper test', () => {
     const TEST_DO_DEBUG = false;
     const TEST_OPTIONS = { profile: TEST_PROFILE, doDebug: TEST_DO_DEBUG, ignoreHash: TEST_IGNORE_HASH };
 
-    describe('# test helper method - highlightProfile', () => {
+    describe('# test helper method - confirmProfile', () => {
         afterEach(() => {
             sinon.restore();
         });
@@ -27,10 +27,10 @@ describe('Commands deploy test - helper test', () => {
             sinon.stub(ResourcesConfig.prototype, 'getProfile').returns(undefined);
             try {
                 // call
-                helper.highlightProfile(TEST_PROFILE);
+                helper.confirmProfile(TEST_PROFILE);
             } catch (err) {
                 // verify
-                expect(err).equal(
+                expect(err.message).equal(
                     `Profile [${TEST_PROFILE}] does not exist. Please configure it in your ${CONSTANTS.FILE_PATH.ASK_RESOURCES_JSON_CONFIG} file.`
                 );
             }
@@ -45,7 +45,7 @@ describe('Commands deploy test - helper test', () => {
             sinon.stub(ResourcesConfig.prototype, 'getProfile').returns({ test: 'result' });
             try {
                 // call
-                helper.highlightProfile(TEST_PROFILE);
+                helper.confirmProfile(TEST_PROFILE);
             } catch (err) {
                 // verify
                 expect(err).equal(undefined);

--- a/test/unit/commands/deploy/helper-test.js
+++ b/test/unit/commands/deploy/helper-test.js
@@ -6,6 +6,8 @@ const helper = require('@src/commands/deploy/helper');
 const SkillMetadataController = require('@src/controllers/skill-metadata-controller');
 const SkillCodeController = require('@src/controllers/skill-code-controller');
 const SkillInfrastructureController = require('@src/controllers/skill-infrastructure-controller');
+const ResourcesConfig = require('@src/model/resources-config');
+const CONSTANTS = require('@src/utils/constants');
 const profileHelper = require('@src/utils/profile-helper');
 
 describe('Commands deploy test - helper test', () => {
@@ -14,6 +16,43 @@ describe('Commands deploy test - helper test', () => {
     const TEST_VENDOR_ID = 'vendor';
     const TEST_DO_DEBUG = false;
     const TEST_OPTIONS = { profile: TEST_PROFILE, doDebug: TEST_DO_DEBUG, ignoreHash: TEST_IGNORE_HASH };
+
+    describe('# test helper method - highlightProfile', () => {
+        afterEach(() => {
+            sinon.restore();
+        });
+
+        it('| profile does not exist, expect throw error', () => {
+            // setup
+            sinon.stub(ResourcesConfig.prototype, 'getProfile').returns(undefined);
+            try {
+                // call
+                helper.highlightProfile(TEST_PROFILE);
+            } catch (err) {
+                // verify
+                expect(err).equal(
+                    `Profile [${TEST_PROFILE}] does not exist. Please configure it in your ${CONSTANTS.FILE_PATH.ASK_RESOURCES_JSON_CONFIG} file.`
+                );
+            }
+        });
+
+        it('| profile does exist, expect messenger info', () => {
+            // setup
+            const infoStub = sinon.stub();
+            sinon.stub(Messenger, 'getInstance').returns({
+                info: infoStub
+            });
+            sinon.stub(ResourcesConfig.prototype, 'getProfile').returns({ test: 'result' });
+            try {
+                // call
+                helper.highlightProfile(TEST_PROFILE);
+            } catch (err) {
+                // verify
+                expect(err).equal(undefined);
+            }
+            expect(infoStub.args[0][0]).equal(`Deploy project for profile [${TEST_PROFILE}]\n`);
+        });
+    });
 
     describe('# test helper method - deploySkillMetadata', () => {
         afterEach(() => {

--- a/test/unit/commands/deploy/index-test.js
+++ b/test/unit/commands/deploy/index-test.js
@@ -64,6 +64,7 @@ describe('Commands deploy test - command class test', () => {
             pathStub.withArgs(process.cwd(), CONSTANTS.FILE_PATH.ASK_RESOURCES_JSON_CONFIG).returns(FIXTURE_RESOURCES_CONFIG_FILE_PATH);
             pathStub.withArgs(TEST_SKILL_METADATA_SRC, CONSTANTS.FILE_PATH.SKILL_PACKAGE.MANIFEST).returns(FIXTURE_MANIFEST_FILE);
             pathStub.callThrough();
+            // sinon.stub(helper, 'highlightProfile').returns(undefined);
             instance = new DeployCommand(optionModel);
         });
 
@@ -108,7 +109,7 @@ describe('Commands deploy test - command class test', () => {
                     // verify
                     expect(err).instanceOf(CliWarn);
                     expect(errorStub.callCount).equal(0);
-                    expect(infoStub.callCount).equal(0);
+                    expect(infoStub.callCount).equal(2);
                     expect(warnStub.callCount).equal(1);
                     done();
                 });
@@ -122,7 +123,7 @@ describe('Commands deploy test - command class test', () => {
                     // verify
                     expect(err.message).equal('Skill package src is not found in ask-resources.json.');
                     expect(errorStub.args[0][0].message).equal('Skill package src is not found in ask-resources.json.');
-                    expect(infoStub.callCount).equal(0);
+                    expect(infoStub.callCount).equal(2);
                     expect(warnStub.callCount).equal(0);
                     done();
                 });
@@ -136,7 +137,7 @@ describe('Commands deploy test - command class test', () => {
                     // verify
                     expect(err.message).equal('The skillMetadata src file ./skillPackage does not exist.');
                     expect(errorStub.args[0][0].message).equal('The skillMetadata src file ./skillPackage does not exist.');
-                    expect(infoStub.callCount).equal(0);
+                    expect(infoStub.callCount).equal(2);
                     expect(warnStub.callCount).equal(0);
                     done();
                 });
@@ -153,7 +154,7 @@ describe('Commands deploy test - command class test', () => {
                     // verify
                     expect(err.message).equal('File invalidPath not exists.');
                     expect(errorStub.callCount).equal(0);
-                    expect(infoStub.callCount).equal(0);
+                    expect(infoStub.callCount).equal(2);
                     expect(warnStub.callCount).equal(1);
                     done();
                 });
@@ -173,7 +174,9 @@ describe('Commands deploy test - command class test', () => {
                     // verify
                     expect(err).equal('error');
                     expect(errorStub.args[0][0]).equal('error');
-                    expect(infoStub.args[0][0]).equal('==================== Deploy Skill Metadata ====================');
+                    expect(infoStub.args[0][0]).equal('Deploy configuration loaded from ask-resources.json');
+                    expect(infoStub.args[1][0]).equal(`Deploy project for profile [${TEST_PROFILE}]\n`);
+                    expect(infoStub.args[2][0]).equal('==================== Deploy Skill Metadata ====================');
                     expect(warnStub.callCount).equal(0);
                     done();
                 });
@@ -190,8 +193,8 @@ describe('Commands deploy test - command class test', () => {
                     // verify
                     expect(err).equal('error');
                     expect(errorStub.args[0][0]).equal('error');
-                    expect(infoStub.args[0][0]).equal('==================== Deploy Skill Metadata ====================');
-                    expect(infoStub.args[1][0].startsWith('Skill ID:')).equal(true);
+                    expect(infoStub.args[2][0]).equal('==================== Deploy Skill Metadata ====================');
+                    expect(infoStub.args[3][0].startsWith('Skill ID:')).equal(true);
                     expect(warnStub.callCount).equal(1);
                     done();
                 });
@@ -208,8 +211,8 @@ describe('Commands deploy test - command class test', () => {
                 instance.handle(TEST_CMD, (err) => {
                     // verify
                     expect(err).equal(undefined);
-                    expect(infoStub.args[0][0]).equal('==================== Deploy Skill Metadata ====================');
-                    expect(infoStub.args[1][0].startsWith('Skill ID:')).equal(true);
+                    expect(infoStub.args[2][0]).equal('==================== Deploy Skill Metadata ====================');
+                    expect(infoStub.args[3][0].startsWith('Skill ID:')).equal(true);
                     expect(errorStub.callCount).equal(0);
                     expect(warnStub.callCount).equal(1);
                     done();
@@ -226,10 +229,10 @@ describe('Commands deploy test - command class test', () => {
                 instance.handle(cmd, (err) => {
                     // verify
                     expect(err).equal(undefined);
-                    expect(infoStub.callCount).equal(3);
-                    expect(infoStub.args[0][0]).equal('==================== Deploy Skill Metadata ====================');
-                    expect(infoStub.args[1][0]).equal('Skill package deployed successfully.');
-                    expect(infoStub.args[2][0].startsWith('Skill ID:')).equal(true);
+                    expect(infoStub.callCount).equal(5);
+                    expect(infoStub.args[2][0]).equal('==================== Deploy Skill Metadata ====================');
+                    expect(infoStub.args[3][0]).equal('Skill package deployed successfully.');
+                    expect(infoStub.args[4][0].startsWith('Skill ID:')).equal(true);
                     expect(warnStub.callCount).equal(0);
                     done();
                 });
@@ -263,10 +266,10 @@ describe('Commands deploy test - command class test', () => {
                     // verify
                     expect(err).equal('error');
                     expect(errorStub.args[0][0]).equal('error');
-                    expect(infoStub.args[0][0]).equal('==================== Deploy Skill Metadata ====================');
-                    expect(infoStub.args[1][0]).equal('Skill package deployed successfully.');
-                    expect(infoStub.args[2][0].startsWith('Skill ID:')).equal(true);
-                    expect(infoStub.args[3][0]).equal('\n==================== Build Skill Code ====================');
+                    expect(infoStub.args[2][0]).equal('==================== Deploy Skill Metadata ====================');
+                    expect(infoStub.args[3][0]).equal('Skill package deployed successfully.');
+                    expect(infoStub.args[4][0].startsWith('Skill ID:')).equal(true);
+                    expect(infoStub.args[5][0]).equal('\n==================== Build Skill Code ====================');
                     expect(warnStub.callCount).equal(0);
                     done();
                 });
@@ -306,13 +309,13 @@ describe('Commands deploy test - command class test', () => {
                 instance.handle(TEST_CMD, (err) => {
                     // verify
                     expect(err).equal(undefined);
-                    expect(infoStub.callCount).equal(6);
-                    expect(infoStub.args[0][0]).equal('==================== Deploy Skill Metadata ====================');
-                    expect(infoStub.args[1][0]).equal('Skill package deployed successfully.');
-                    expect(infoStub.args[2][0].startsWith('Skill ID:')).equal(true);
-                    expect(infoStub.args[3][0]).equal('\n==================== Build Skill Code ====================');
-                    expect(infoStub.args[4][0]).equal('Skill code built successfully.');
-                    expect(infoStub.args[5][0]).equal(`Code for region default+NA built to ${TEST_CODE_BUILD_RESULT[0].build.file} successfully \
+                    expect(infoStub.callCount).equal(8);
+                    expect(infoStub.args[2][0]).equal('==================== Deploy Skill Metadata ====================');
+                    expect(infoStub.args[3][0]).equal('Skill package deployed successfully.');
+                    expect(infoStub.args[4][0].startsWith('Skill ID:')).equal(true);
+                    expect(infoStub.args[5][0]).equal('\n==================== Build Skill Code ====================');
+                    expect(infoStub.args[6][0]).equal('Skill code built successfully.');
+                    expect(infoStub.args[7][0]).equal(`Code for region default+NA built to ${TEST_CODE_BUILD_RESULT[0].build.file} successfully \
 with build flow ${TEST_CODE_BUILD_RESULT[0].buildFlow}.`);
                     expect(warnStub.callCount).equal(0);
                     done();
@@ -337,13 +340,13 @@ with build flow ${TEST_CODE_BUILD_RESULT[0].buildFlow}.`);
                     // verify
                     expect(err).equal(undefined);
                     expect(errorStub.callCount).equal(0);
-                    expect(infoStub.callCount).equal(5);
-                    expect(infoStub.args[0][0]).equal('\n==================== Build Skill Code ====================');
-                    expect(infoStub.args[1][0]).equal('Skill code built successfully.');
-                    expect(infoStub.args[2][0]).equal(`Code for region default+NA built to ${TEST_CODE_BUILD_RESULT[0].build.file} successfully \
+                    expect(infoStub.callCount).equal(7);
+                    expect(infoStub.args[2][0]).equal('\n==================== Build Skill Code ====================');
+                    expect(infoStub.args[3][0]).equal('Skill code built successfully.');
+                    expect(infoStub.args[4][0]).equal(`Code for region default+NA built to ${TEST_CODE_BUILD_RESULT[0].build.file} successfully \
 with build flow ${TEST_CODE_BUILD_RESULT[0].buildFlow}.`);
-                    expect(infoStub.args[3][0]).equal('\n==================== Deploy Skill Infrastructure ====================');
-                    expect(infoStub.args[4][0]).equal('Skill infrastructures deployed successfully through @ask-cli/cfn-deployer.');
+                    expect(infoStub.args[5][0]).equal('\n==================== Deploy Skill Infrastructure ====================');
+                    expect(infoStub.args[6][0]).equal('Skill infrastructures deployed successfully through @ask-cli/cfn-deployer.');
                     expect(warnStub.callCount).equal(0);
                     expect(helper.enableSkill.calledOnce).equal(false);
                     done();
@@ -379,14 +382,14 @@ with build flow ${TEST_CODE_BUILD_RESULT[0].buildFlow}.`);
                     // verify
                     expect(err).equal('error');
                     expect(errorStub.args[0][0]).equal('error');
-                    expect(infoStub.args[0][0]).equal('==================== Deploy Skill Metadata ====================');
-                    expect(infoStub.args[1][0]).equal('Skill package deployed successfully.');
-                    expect(infoStub.args[2][0].startsWith('Skill ID:')).equal(true);
-                    expect(infoStub.args[3][0]).equal('\n==================== Build Skill Code ====================');
-                    expect(infoStub.args[4][0]).equal('Skill code built successfully.');
-                    expect(infoStub.args[5][0]).equal(`Code for region default+NA built to ${TEST_CODE_BUILD_RESULT[0].build.file} successfully \
+                    expect(infoStub.args[2][0]).equal('==================== Deploy Skill Metadata ====================');
+                    expect(infoStub.args[3][0]).equal('Skill package deployed successfully.');
+                    expect(infoStub.args[4][0].startsWith('Skill ID:')).equal(true);
+                    expect(infoStub.args[5][0]).equal('\n==================== Build Skill Code ====================');
+                    expect(infoStub.args[6][0]).equal('Skill code built successfully.');
+                    expect(infoStub.args[7][0]).equal(`Code for region default+NA built to ${TEST_CODE_BUILD_RESULT[0].build.file} successfully \
 with build flow ${TEST_CODE_BUILD_RESULT[0].buildFlow}.`);
-                    expect(infoStub.args[6][0]).equal('\n==================== Deploy Skill Infrastructure ====================');
+                    expect(infoStub.args[8][0]).equal('\n==================== Deploy Skill Infrastructure ====================');
                     expect(warnStub.callCount).equal(0);
                     done();
                 });
@@ -408,16 +411,16 @@ with build flow ${TEST_CODE_BUILD_RESULT[0].buildFlow}.`);
                     // verify
                     expect(err).equal(undefined);
                     expect(errorStub.callCount).equal(0);
-                    expect(infoStub.callCount).equal(8);
-                    expect(infoStub.args[0][0]).equal('==================== Deploy Skill Metadata ====================');
-                    expect(infoStub.args[1][0]).equal('Skill package deployed successfully.');
-                    expect(infoStub.args[2][0].startsWith('Skill ID:')).equal(true);
-                    expect(infoStub.args[3][0]).equal('\n==================== Build Skill Code ====================');
-                    expect(infoStub.args[4][0]).equal('Skill code built successfully.');
-                    expect(infoStub.args[5][0]).equal(`Code for region default+NA built to ${TEST_CODE_BUILD_RESULT[0].build.file} successfully \
+                    expect(infoStub.callCount).equal(10);
+                    expect(infoStub.args[2][0]).equal('==================== Deploy Skill Metadata ====================');
+                    expect(infoStub.args[3][0]).equal('Skill package deployed successfully.');
+                    expect(infoStub.args[4][0].startsWith('Skill ID:')).equal(true);
+                    expect(infoStub.args[5][0]).equal('\n==================== Build Skill Code ====================');
+                    expect(infoStub.args[6][0]).equal('Skill code built successfully.');
+                    expect(infoStub.args[7][0]).equal(`Code for region default+NA built to ${TEST_CODE_BUILD_RESULT[0].build.file} successfully \
 with build flow ${TEST_CODE_BUILD_RESULT[0].buildFlow}.`);
-                    expect(infoStub.args[6][0]).equal('\n==================== Deploy Skill Infrastructure ====================');
-                    expect(infoStub.args[7][0]).equal('Skill infrastructures deployed successfully through @ask-cli/cfn-deployer.');
+                    expect(infoStub.args[8][0]).equal('\n==================== Deploy Skill Infrastructure ====================');
+                    expect(infoStub.args[9][0]).equal('Skill infrastructures deployed successfully through @ask-cli/cfn-deployer.');
                     expect(warnStub.callCount).equal(0);
                     expect(helper.enableSkill.calledOnce).equal(true);
                     done();

--- a/test/unit/commands/deploy/index-test.js
+++ b/test/unit/commands/deploy/index-test.js
@@ -64,7 +64,7 @@ describe('Commands deploy test - command class test', () => {
             pathStub.withArgs(process.cwd(), CONSTANTS.FILE_PATH.ASK_RESOURCES_JSON_CONFIG).returns(FIXTURE_RESOURCES_CONFIG_FILE_PATH);
             pathStub.withArgs(TEST_SKILL_METADATA_SRC, CONSTANTS.FILE_PATH.SKILL_PACKAGE.MANIFEST).returns(FIXTURE_MANIFEST_FILE);
             pathStub.callThrough();
-            // sinon.stub(helper, 'highlightProfile').returns(undefined);
+            // sinon.stub(helper, 'confirmProfile').returns(undefined);
             instance = new DeployCommand(optionModel);
         });
 
@@ -122,7 +122,7 @@ describe('Commands deploy test - command class test', () => {
                 instance.handle(TEST_CMD, (err) => {
                     // verify
                     expect(err.message).equal('Skill package src is not found in ask-resources.json.');
-                    expect(errorStub.args[0][0].message).equal('Skill package src is not found in ask-resources.json.');
+                    expect(errorStub.args[0][0]).equal('Skill package src is not found in ask-resources.json.');
                     expect(infoStub.callCount).equal(2);
                     expect(warnStub.callCount).equal(0);
                     done();
@@ -136,7 +136,7 @@ describe('Commands deploy test - command class test', () => {
                 instance.handle(TEST_CMD, (err) => {
                     // verify
                     expect(err.message).equal('The skillMetadata src file ./skillPackage does not exist.');
-                    expect(errorStub.args[0][0].message).equal('The skillMetadata src file ./skillPackage does not exist.');
+                    expect(errorStub.args[0][0]).equal('The skillMetadata src file ./skillPackage does not exist.');
                     expect(infoStub.callCount).equal(2);
                     expect(warnStub.callCount).equal(0);
                     done();

--- a/test/unit/commands/deploy/index-test.js
+++ b/test/unit/commands/deploy/index-test.js
@@ -64,7 +64,6 @@ describe('Commands deploy test - command class test', () => {
             pathStub.withArgs(process.cwd(), CONSTANTS.FILE_PATH.ASK_RESOURCES_JSON_CONFIG).returns(FIXTURE_RESOURCES_CONFIG_FILE_PATH);
             pathStub.withArgs(TEST_SKILL_METADATA_SRC, CONSTANTS.FILE_PATH.SKILL_PACKAGE.MANIFEST).returns(FIXTURE_MANIFEST_FILE);
             pathStub.callThrough();
-            // sinon.stub(helper, 'confirmProfile').returns(undefined);
             instance = new DeployCommand(optionModel);
         });
 


### PR DESCRIPTION
Happy case
```
$ ask deploy
Deploy configuration loaded from ask-resources.json
Deploy project for profile [default]

==================== Deploy Skill Metadata ====================
...
```

Profile mismatch
```
$ ask deploy -p prod
Deploy configuration loaded from ask-resources.json
[Error]: Profile [prod] does not exist. Please configure it in your ask-resources.json file.
```

Profile doesn't exist
```
$ ask deploy -p def
[Error]: Can't resolve profile [def] as it doesn't exist. Please run "ask configure --profile def" first.
```

This addresses https://github.com/alexa/ask-cli/issues/293