### PR TITLE
fix: issue with different path on windows and mac

### DIFF
--- a/lib/builtins/deploy-delegates/cfn-deployer/index.js
+++ b/lib/builtins/deploy-delegates/cfn-deployer/index.js
@@ -27,7 +27,7 @@ function bootstrap(options, callback) {
         const awsProfile = awsUtil.getAWSProfile(profile);
         const awsDefaultRegion = awsUtil.getCLICompatibleDefaultRegion(awsProfile);
         fs.writeFileSync(templateLocation, templateContent);
-        userConfig.templatePath = `.${path.sep}${path.join('infrastructure', path.basename(workspacePath), SKILL_STACK_PUBLIC_FILE_NAME)}`;
+        userConfig.templatePath = `./${path.posix.join('infrastructure', path.basename(workspacePath), SKILL_STACK_PUBLIC_FILE_NAME)}`;
         updatedUserConfig = R.set(R.lensPath(['awsRegion']), awsDefaultRegion, userConfig);
     } catch (e) {
         return callback(e.message);


### PR DESCRIPTION
fix to always store template path in posix style in ask-resources.json

"templatePath": "./infrastructure/cfn-deployer/skill-stack.yaml"

it works both on windows and mac  when running fs.readFileSync(templatePath, 'utf-8')




