### PR TITLE
Log error on auth failure.

### DIFF
--- a/lib/clients/lwa-auth-code-client/index.js
+++ b/lib/clients/lwa-auth-code-client/index.js
@@ -10,6 +10,7 @@ const CONSTANTS = require('@src/utils/constants');
 const providerChainUtils = require('@src/utils/provider-chain-utils');
 const stringUtils = require('@src/utils/string-utils');
 const jsonView = require('@src/view/json-view');
+const CliError = require('@src/exceptions/cli-error');
 
 module.exports = class LWAAuthCodeClient {
     constructor(config) {
@@ -41,6 +42,9 @@ module.exports = class LWAAuthCodeClient {
                 return callback(err);
             }
             const tokenBody = R.clone(response.body);
+            if(tokenBody.error){
+            return callback(new CliError(tokenBody.error));
+            }
             tokenBody.expires_at = this._getExpiresAt(tokenBody.expires_in).toISOString();
             callback(null, tokenBody);
         });
@@ -79,6 +83,9 @@ module.exports = class LWAAuthCodeClient {
             }
 
             const tokenBody = R.clone(response.body);
+            if(tokenBody.error){
+               return callback(new CliError(tokenBody.error));
+                }
             tokenBody.expires_at = this._getExpiresAt(expiresIn).toISOString();
             callback(null, tokenBody);
         });

--- a/lib/clients/lwa-auth-code-client/index.js
+++ b/lib/clients/lwa-auth-code-client/index.js
@@ -42,8 +42,8 @@ module.exports = class LWAAuthCodeClient {
                 return callback(err);
             }
             const tokenBody = R.clone(response.body);
-            if(tokenBody.error){
-            return callback(new CliError(tokenBody.error));
+            if (tokenBody.error) {
+                return callback(new CliError(tokenBody.error));
             }
             tokenBody.expires_at = this._getExpiresAt(tokenBody.expires_in).toISOString();
             callback(null, tokenBody);
@@ -83,9 +83,9 @@ module.exports = class LWAAuthCodeClient {
             }
 
             const tokenBody = R.clone(response.body);
-            if(tokenBody.error){
-               return callback(new CliError(tokenBody.error));
-                }
+            if (tokenBody.error) {
+                return callback(new CliError(tokenBody.error));
+            }
             tokenBody.expires_at = this._getExpiresAt(expiresIn).toISOString();
             callback(null, tokenBody);
         });


### PR DESCRIPTION
```ask util generate-lwa-tokens```

When generating lwa-tokens. In case of the invalid client. `tokenBody.expires_in` will be undefined which causes `RangeError: Invalid time`. 

So here legit error is thrown back in case of an invalid client.

