### PR TITLE
fix: failure in smapiClient for createCatalogUpload method

### DIFF
--- a/lib/clients/smapi-client/resources/catalog.js
+++ b/lib/clients/smapi-client/resources/catalog.js
@@ -69,10 +69,10 @@ module.exports = (smapiHandle) => {
         );
     }
 
-    function createCatalogUpload(catalogId, numberOfParts, callback) {
+    function createCatalogUpload(catalogId, numberOfUploadParts, callback) {
         const url = `catalogs/${catalogId}/uploads`;
         const payload = {
-            numberOfParts
+            numberOfUploadParts
         };
         smapiHandle(
             CONSTANTS.SMAPI.API_NAME.UPLOAD_CATALOG,

--- a/test/unit/clients/smapi-client-test/resources/catalog.js
+++ b/test/unit/clients/smapi-client-test/resources/catalog.js
@@ -24,7 +24,7 @@ module.exports = (smapiClient) => {
         const TEST_CATALOG_TYPE = 'type';
         const TEST_CATALOG_USAGE = 'usage';
         const TEST_CATALOG_TITLE = 'title';
-        const TEST_NUMBER_OF_PARTS = 'numberOfParts';
+        const TEST_NUMBER_OF_PARTS = 'numberOfUploadParts';
         const TEST_PART_ETAG_LIST = ['list1', 'list2'];
         const TEST_PROFILE = 'testProfile';
         const TEST_ACCESS_TOKEN = 'access_token';
@@ -145,7 +145,7 @@ module.exports = (smapiClient) => {
                         authorization: TEST_ACCESS_TOKEN
                     },
                     body: {
-                        numberOfParts: TEST_NUMBER_OF_PARTS
+                        numberOfUploadParts: TEST_NUMBER_OF_PARTS
                     },
                     json: true
                 }


### PR DESCRIPTION
Fix the failure in the `ask smapi upload-catalog` command when multi-parts upload happens