### PR TITLE
feat: support sourceLambda field for lambda-deployer to use existing Lambda

### DIFF
--- a/docs/concepts/Deploy-Command.md
+++ b/docs/concepts/Deploy-Command.md
@@ -65,7 +65,7 @@ Deployer is the module that serve for any unique serverless deploy mechanism. De
 
 ---
 
-Below are the built-in deployers that CLI provides to help developers deploy their customized logic to the AWS services:
+Below are the built-in deployers that CLI provides to help developers deploy their backend using the AWS services:
 
 #### @ask-cli/lambda-deployer
 This deployer is managing Lambda services by using the default settings to create/retrieve the IAM Role for the skill application, create/update the Lambda function with minimum required permissions and event trigger. Below shows the details of what this deployer does:
@@ -78,6 +78,13 @@ This deployer is managing Lambda services by using the default settings to creat
   3. Deploy Lambda function.
      * If Lambda ARN is not present, the deployer will create the Lambda function by adding the event trigger.
      * If Lambda ARN is present, the deloyer will update the Lambda function's code and configuration.
+
+Supported parameters in `userConfig`:
+* awsRegion
+* runtime: Please see [AWS Lambda runtimes](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html) for more details.
+* handler: The entry point for the Lambda function in your code.
+* sourceLambda: You can set the `userConfig.sourceLambda.arn` to specify an existing Lambda ARN to reuse. This will be the target Lambda function when you deploy.
+* regionalOverrides: You can set `regionalOverrides.{region}.{anyPropertiesAbove}` to override the parameters for a certain region.
 
 #### @ask-cli/cfn-deployer
 This deployer is implementing the idea of **Code as Infra** by using AWS CloudFormation. By using the CloudFormation template as the recipe, skill applications with similar infrastructure settings can simply share or extend existing template files. CloudFormation service also manages auto-rollback when a failure happens. Below shows the details of what this deployer does:
@@ -92,6 +99,13 @@ This deployer is implementing the idea of **Code as Infra** by using AWS CloudFo
      * If the `lastDeployHash` doesn't change for the source skillCode, the deployer will not upload the code to S3, and thus no new version will be created.
   3. Based on the presense of stackId, the deployer will create/update AWS CloudFormation stack for each region. The creation of a stack usually takes some time as new infrastructures are being provisioned; while the update of a stack resource is much faster as the update is executed based on the changeset. Please read more about the [CloudFormation update](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html).
   4. Polling stack status and real-time display the latest event message. Provide detailed resource-level reason message if any deployment of resource fails.
+
+Supported parameters in `userConfig`:
+* awsRegion
+* runtime: Please see [AWS Lambda runtimes](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html) for more details. Value of this field will be passed to *LambdaRuntime* in the stack.
+* handler: The entry point for the Lambda function in your code. Value of this field will be passed to *LambdaHandler* in the stack
+* templatePath: The stack file path that you wish to deploy with.
+* regionalOverrides: You can set `regionalOverrides.{region}.{anyPropertiesAbove}` to override the parameters for a certain region.
 
 ## Other Concepts
 

--- a/lib/builtins/deploy-delegates/lambda-deployer/helper.js
+++ b/lib/builtins/deploy-delegates/lambda-deployer/helper.js
@@ -18,12 +18,12 @@ module.exports = {
 function loadLambdaInformation(reporter, loadLambdaConfig, callback) {
     const { awsProfile, awsRegion, alexaRegion, deployState, userConfig, ignoreHash } = loadLambdaConfig;
     const lambdaClient = new LambdaClient({ awsProfile, awsRegion });
-    // check if user sets userConfig with "basedOn" field to reuse existing Lambda
-    const basedOnLambdaArn = alexaRegion === 'default' ? R.view(R.lensPath(['basedOn', 'lambda', 'arn']), userConfig)
-        : R.view(R.lensPath(['regionalOverrides', alexaRegion, 'basedOn', 'lambda', 'arn']), userConfig);
-    if (stringUtils.isNonBlankString(basedOnLambdaArn)) {
-        return _loadLambdaFromUserConfigBasedOn(reporter, lambdaClient, basedOnLambdaArn, (loadErr, basedOnLambdaData) => {
-            callback(loadErr, loadErr ? undefined : basedOnLambdaData);
+    // check if user sets userConfig with "sourceLambda" field to reuse existing Lambda
+    const sourceLambdaArn = alexaRegion === 'default' ? R.view(R.lensPath(['sourceLambda', 'arn']), userConfig)
+        : R.view(R.lensPath(['regionalOverrides', alexaRegion, 'sourceLambda', 'arn']), userConfig);
+    if (stringUtils.isNonBlankString(sourceLambdaArn)) {
+        return _loadLambdaFromUserConfigSource(reporter, lambdaClient, sourceLambdaArn, (loadErr, sourceLambdaData) => {
+            callback(loadErr, loadErr ? undefined : sourceLambdaData);
         });
     }
 
@@ -66,14 +66,14 @@ To ignore this error run "ask deploy --ignore-hash".`);
     });
 }
 
-function _loadLambdaFromUserConfigBasedOn(reporter, lambdaClient, basedOnLambdaArn, callback) {
-    lambdaClient.getFunction(basedOnLambdaArn, (err, data) => {
+function _loadLambdaFromUserConfigSource(reporter, lambdaClient, sourceLambdaArn, callback) {
+    lambdaClient.getFunction(sourceLambdaArn, (err, data) => {
         if (err) {
-            return callback(`Failed to load the Lambda (${basedOnLambdaArn}) specified in "basedOn". ${err}`);
+            return callback(`Failed to load the Lambda (${sourceLambdaArn}) specified in "sourceLambda". ${err}`);
         }
         const iamRole = data.Configuration.Role;
         const lambda = {
-            arn: basedOnLambdaArn,
+            arn: sourceLambdaArn,
             revisionId: data.Configuration.RevisionId,
             lastModified: data.Configuration.LastModified
         };

--- a/lib/builtins/deploy-delegates/lambda-deployer/helper.js
+++ b/lib/builtins/deploy-delegates/lambda-deployer/helper.js
@@ -10,56 +10,86 @@ const retryUtils = require('@src/utils/retry-utility');
 const stringUtils = require('@src/utils/string-utils');
 
 module.exports = {
-    validateLambdaDeployState,
+    loadLambdaInformation,
     deployIAMRole,
     deployLambdaFunction
 };
 
-function validateLambdaDeployState(reporter, awsProfile, awsRegion, currentRegionDeployState, ignoreHash, callback) {
-    const lambdaData = currentRegionDeployState.lambda;
-    if (R.isNil(lambdaData) || R.isEmpty(lambdaData) || R.isNil(lambdaData.arn)) {
-        return callback(null, { updatedDeployState: currentRegionDeployState });
-    }
-    reporter.updateStatus('Validating the deploy state of existing Lambda function...');
-    let updatedDeployState;
+function loadLambdaInformation(reporter, loadLambdaConfig, callback) {
+    const { awsProfile, awsRegion, alexaRegion, deployState, userConfig, ignoreHash } = loadLambdaConfig;
     const lambdaClient = new LambdaClient({ awsProfile, awsRegion });
-    const lambdaArn = lambdaData.arn;
+    // check if user sets userConfig with "basedOn" field to reuse existing Lambda
+    const basedOnLambdaArn = alexaRegion === 'default' ? R.view(R.lensPath(['basedOn', 'lambda', 'arn']), userConfig)
+        : R.view(R.lensPath(['regionalOverrides', alexaRegion, 'basedOn', 'lambda', 'arn']), userConfig);
+    if (stringUtils.isNonBlankString(basedOnLambdaArn)) {
+        return _loadLambdaFromUserConfigBasedOn(reporter, lambdaClient, basedOnLambdaArn, (loadErr, basedOnLambdaData) => {
+            callback(loadErr, loadErr ? undefined : basedOnLambdaData);
+        });
+    }
+
+    // Lambda does not exist in deployState
+    const lambdaArn = R.view(R.lensPath(['lambda', 'arn']), deployState);
+    if (R.isNil(lambdaArn)) {
+        return callback(null, {});
+    }
+
+    // Lambda exists, validate the deploy states
+    reporter.updateStatus('Validating the deploy state of existing Lambda function...');
     lambdaClient.getFunction(lambdaArn, (err, data) => {
         if (err) {
             return callback(err);
         }
         // 1. check IAM role arn
-        const localIAMRole = currentRegionDeployState.iamRole;
+        const localIAMRole = deployState.iamRole;
         const remoteIAMRole = data.Configuration.Role;
         if (stringUtils.isNonBlankString(localIAMRole) && !R.equals(localIAMRole, remoteIAMRole)) {
-            return callback(`The IAM role for Lambda ARN (${lambdaArn}) should be ${remoteIAMRole}, but found ${localIAMRole}. \
+            return callback(`The IAM role for Lambda ARN (${lambdaArn}) should be "${remoteIAMRole}", but found "${localIAMRole}". \
 Please solve this IAM role mismatch and re-deploy again. To ignore this error run "ask deploy --ignore-hash".`);
         }
-        updatedDeployState = R.set(R.lensPath(['iamRole']), remoteIAMRole, currentRegionDeployState);
         // 2. check revision id
-        const localRevisionId = lambdaData.revisionId;
+        const localRevisionId = deployState.lambda.revisionId;
         const remoteRevisionId = data.Configuration.RevisionId;
         if (stringUtils.isNonBlankString(localRevisionId) && !R.equals(localRevisionId, remoteRevisionId) && !ignoreHash) {
             return callback(`The current revisionId (The revision ID for Lambda ARN (${lambdaArn}) should be ${remoteRevisionId}, \
 but found ${localRevisionId}. Please solve this revision mismatch and re-deploy again. \
 To ignore this error run "ask deploy --ignore-hash".`);
         }
-        updatedDeployState = R.set(R.lensPath(['lambda', 'revisionId']), remoteRevisionId, updatedDeployState);
-        // 3. add lastModified
-        const lastModified = data.Configuration.LastModified;
-        updatedDeployState = R.set(R.lensPath(['lambda', 'lastModified']), lastModified, updatedDeployState);
-        callback(null, { updatedDeployState });
+        // 3. return the loaded Lambda data
+        callback(null, {
+            iamRole: remoteIAMRole,
+            lambda: {
+                arn: lambdaArn,
+                revisionId: remoteRevisionId,
+                lastModified: data.Configuration.LastModified
+            }
+        });
     });
 }
 
-function deployIAMRole(reporter, awsProfile, alexaRegion, skillName, awsRegion, deployState, callback) {
+function _loadLambdaFromUserConfigBasedOn(reporter, lambdaClient, basedOnLambdaArn, callback) {
+    lambdaClient.getFunction(basedOnLambdaArn, (err, data) => {
+        if (err) {
+            return callback(`Failed to load the Lambda (${basedOnLambdaArn}) specified in "basedOn". ${err}`);
+        }
+        const iamRole = data.Configuration.Role;
+        const lambda = {
+            arn: basedOnLambdaArn,
+            revisionId: data.Configuration.RevisionId,
+            lastModified: data.Configuration.LastModified
+        };
+        callback(undefined, { iamRole, lambda });
+    });
+}
+
+function deployIAMRole(reporter, deployIAMConfig, callback) {
+    const { awsProfile, alexaRegion, skillName, awsRegion, deployState } = deployIAMConfig;
     const iamClient = new IAMClient({ awsProfile, awsRegion });
     const roleArn = deployState.iamRole;
     if (R.isNil(roleArn) || R.isEmpty(roleArn)) {
         reporter.updateStatus('No IAM role exists. Creating an IAM role...');
         _createIAMRole(reporter, iamClient, skillName, (roleErr, iamRoleArn) => {
             if (roleErr) {
-                return callback(roleErr);
+                return callback(`Failed to create IAM role before deploying Lambda. ${roleErr}`);
             }
             callback(null, iamRoleArn);
         });
@@ -69,7 +99,7 @@ function deployIAMRole(reporter, awsProfile, alexaRegion, skillName, awsRegion, 
                 if (roleErr.code === 'NoSuchEntity') {
                     callback(`The IAM role is not found. Please check if your IAM role from region ${alexaRegion} is valid.`);
                 } else {
-                    callback(roleErr);
+                    callback(`Failed to retrieve IAM role (${roleArn}) for Lambda. ${roleErr}`);
                 }
             } else {
                 reporter.updateStatus(`Current IAM role : "${roleArn}"...`);
@@ -96,10 +126,10 @@ function _createIAMRole(reporter, iamClient, skillName, callback) {
 }
 
 function deployLambdaFunction(reporter, options, callback) {
-    const { profile, awsProfile, alexaRegion, awsRegion, skillId, skillName, code, iamRoleArn, userConfig, currentRegionDeployState } = options;
+    const { profile, awsProfile, alexaRegion, awsRegion, skillId, skillName, code, iamRoleArn, userConfig, deployState } = options;
     const lambdaClient = new LambdaClient({ awsProfile, awsRegion });
     const zipFilePath = code.codeBuild;
-    if (R.isNil(currentRegionDeployState.lambda) || R.isEmpty(currentRegionDeployState.lambda)) {
+    if (R.isNil(deployState.lambda) || R.isEmpty(deployState.lambda)) {
         reporter.updateStatus('No Lambda information exists. Creating a lambda function...');
         const createLambdaOptions = {
             profile,
@@ -117,11 +147,11 @@ function deployLambdaFunction(reporter, options, callback) {
             callback(null, lambdaResources);
         });
     } else {
-        reporter.updateStatus(`Updating current Lambda function with ARN ${currentRegionDeployState.lambda.arn}...`);
+        reporter.updateStatus(`Updating current Lambda function with ARN ${deployState.lambda.arn}...`);
         const updateLambdaOptions = {
             zipFilePath,
             userConfig,
-            currentRegionDeployState
+            deployState
         };
         _updateLambdaFunction(reporter, lambdaClient, updateLambdaOptions, (lambdaErr, lambdaResources) => {
             if (lambdaErr) {
@@ -203,10 +233,10 @@ function _addEventPermissions(lambdaClient, skillId, functionArn, callback) {
 }
 
 function _updateLambdaFunction(reporter, lambdaClient, options, callback) {
-    const { zipFilePath, userConfig, currentRegionDeployState } = options;
+    const { zipFilePath, userConfig, deployState } = options;
     const zipFile = fs.readFileSync(zipFilePath);
-    const functionName = currentRegionDeployState.lambda.arn;
-    let { revisionId } = currentRegionDeployState.lambda;
+    const functionName = deployState.lambda.arn;
+    let { revisionId } = deployState.lambda;
     lambdaClient.updateFunctionCode(zipFile, functionName, revisionId, (codeErr, codeData) => {
         if (codeErr) {
             return callback(codeErr);

--- a/lib/builtins/deploy-delegates/lambda-deployer/helper.js
+++ b/lib/builtins/deploy-delegates/lambda-deployer/helper.js
@@ -15,12 +15,13 @@ module.exports = {
     deployLambdaFunction
 };
 
+// TODO: use Error class
 function loadLambdaInformation(reporter, loadLambdaConfig, callback) {
     const { awsProfile, awsRegion, alexaRegion, deployState, userConfig, ignoreHash } = loadLambdaConfig;
     const lambdaClient = new LambdaClient({ awsProfile, awsRegion });
     // check if user sets userConfig with "sourceLambda" field to reuse existing Lambda
-    const sourceLambdaArn = alexaRegion === 'default' ? R.view(R.lensPath(['sourceLambda', 'arn']), userConfig)
-        : R.view(R.lensPath(['regionalOverrides', alexaRegion, 'sourceLambda', 'arn']), userConfig);
+    const sourceLambdaArn = alexaRegion === 'default' ? R.path(['sourceLambda', 'arn'], userConfig)
+        : R.path(['regionalOverrides', alexaRegion, 'sourceLambda', 'arn'], userConfig);
     if (stringUtils.isNonBlankString(sourceLambdaArn)) {
         return _loadLambdaFromUserConfigSource(reporter, lambdaClient, sourceLambdaArn, (loadErr, sourceLambdaData) => {
             callback(loadErr, loadErr ? undefined : sourceLambdaData);
@@ -28,7 +29,7 @@ function loadLambdaInformation(reporter, loadLambdaConfig, callback) {
     }
 
     // Lambda does not exist in deployState
-    const lambdaArn = R.view(R.lensPath(['lambda', 'arn']), deployState);
+    const lambdaArn = R.path(['lambda', 'arn'], deployState);
     if (R.isNil(lambdaArn)) {
         return callback(null, {});
     }

--- a/lib/builtins/deploy-delegates/lambda-deployer/index.js
+++ b/lib/builtins/deploy-delegates/lambda-deployer/index.js
@@ -47,8 +47,7 @@ function invoke(reporter, options, callback) {
         deployState[alexaRegion] = currentRegionDeployState;
     }
     // parse AWS region to use
-    let awsRegion = alexaRegion === 'default' ? userConfig.awsRegion
-        : R.view(R.lensPath(['regionalOverrides', alexaRegion, 'awsRegion']), userConfig);
+    let awsRegion = alexaRegion === 'default' ? userConfig.awsRegion : R.path(['regionalOverrides', alexaRegion, 'awsRegion'], userConfig);
     awsRegion = awsRegion || alexaAwsRegionMap[alexaRegion];
     if (!stringUtils.isNonBlankString(awsRegion)) {
         return callback(`Unsupported Alexa region: ${alexaRegion}. Please check your region name or use "regionalOverrides" to specify AWS region.`);

--- a/lib/builtins/deploy-delegates/lambda-deployer/index.js
+++ b/lib/builtins/deploy-delegates/lambda-deployer/index.js
@@ -46,6 +46,7 @@ function invoke(reporter, options, callback) {
         currentRegionDeployState = {};
         deployState[alexaRegion] = currentRegionDeployState;
     }
+    // parse AWS region to use
     let awsRegion = alexaRegion === 'default' ? userConfig.awsRegion
         : R.view(R.lensPath(['regionalOverrides', alexaRegion, 'awsRegion']), userConfig);
     awsRegion = awsRegion || alexaAwsRegionMap[alexaRegion];
@@ -53,16 +54,28 @@ function invoke(reporter, options, callback) {
         return callback(`Unsupported Alexa region: ${alexaRegion}. Please check your region name or use "regionalOverrides" to specify AWS region.`);
     }
 
-    helper.validateLambdaDeployState(reporter, awsProfile, awsRegion, currentRegionDeployState, ignoreHash, (validationErr, validationData) => {
-        if (validationErr) {
-            return callback(validationErr);
+    // load Lambda info from either existing deployState or userConfig's basedOn
+    const loadLambdaConfig = { awsProfile, awsRegion, alexaRegion, ignoreHash, deployState: currentRegionDeployState, userConfig };
+    helper.loadLambdaInformation(reporter, loadLambdaConfig, (loadLambdaErr, lambdaData) => {
+        if (loadLambdaErr) {
+            return callback(loadLambdaErr);
         }
-        currentRegionDeployState = validationData.updatedDeployState;
-        helper.deployIAMRole(reporter, awsProfile, alexaRegion, skillName, awsRegion, currentRegionDeployState, (iamErr, iamRoleArn) => {
+        currentRegionDeployState.lambda = lambdaData.lambda;
+        currentRegionDeployState.iamRole = lambdaData.iamRole;
+        // create/update deploy for IAM role
+        const deployIAMConfig = {
+            awsProfile,
+            awsRegion,
+            alexaRegion,
+            skillName,
+            deployState: currentRegionDeployState
+        };
+        helper.deployIAMRole(reporter, deployIAMConfig, (iamErr, iamRoleArn) => {
             if (iamErr) {
                 return callback(iamErr);
             }
             deployState[alexaRegion].iamRole = iamRoleArn;
+            // create/update deploy for Lambda
             const deployLambdaConfig = {
                 profile,
                 awsProfile,
@@ -73,7 +86,7 @@ function invoke(reporter, options, callback) {
                 code,
                 iamRoleArn,
                 userConfig,
-                currentRegionDeployState
+                deployState: currentRegionDeployState
             };
             helper.deployLambdaFunction(reporter, deployLambdaConfig, (lambdaErr, lambdaResult) => {
                 // 1.fatal error happens in Lambda deployment and nothing need to record additionally

--- a/lib/builtins/deploy-delegates/lambda-deployer/index.js
+++ b/lib/builtins/deploy-delegates/lambda-deployer/index.js
@@ -54,7 +54,7 @@ function invoke(reporter, options, callback) {
         return callback(`Unsupported Alexa region: ${alexaRegion}. Please check your region name or use "regionalOverrides" to specify AWS region.`);
     }
 
-    // load Lambda info from either existing deployState or userConfig's basedOn
+    // load Lambda info from either existing deployState or userConfig's sourceLambda
     const loadLambdaConfig = { awsProfile, awsRegion, alexaRegion, ignoreHash, deployState: currentRegionDeployState, userConfig };
     helper.loadLambdaInformation(reporter, loadLambdaConfig, (loadLambdaErr, lambdaData) => {
         if (loadLambdaErr) {

--- a/test/unit/builtins/lambda-deployer/helper-test.js
+++ b/test/unit/builtins/lambda-deployer/helper-test.js
@@ -43,13 +43,11 @@ describe('Builtins test - lambda-deployer helper.js test', () => {
                 revisionId: TEST_LOCAL_REVISION_ID
             }
         };
-        const TEST_USER_CONFIG_WITH_BASEDON = {
+        const TEST_USER_CONFIG_WITH_SOURCELAMBDA = {
             regionalOverrides: {
                 [TEST_ALEXA_REGION_NON_DEFAULT]: {
-                    basedOn: {
-                        lambda: {
-                            arn: TEST_LAMBDA_ARN
-                        }
+                    sourceLambda: {
+                        arn: TEST_LAMBDA_ARN
                     }
                 }
             }
@@ -83,13 +81,13 @@ describe('Builtins test - lambda-deployer helper.js test', () => {
             userConfig: {}
         };
 
-        const TEST_LOAD_LAMBDA_OPTION_WITH_BASEDON = {
+        const TEST_LOAD_LAMBDA_OPTION_WITH_SOURCELAMBDA = {
             awsProfile: TEST_AWS_PROFILE,
             awsRegion: TEST_AWS_REGION,
             alexaRegion: TEST_ALEXA_REGION_NON_DEFAULT,
             ignoreHash: true,
             deployState: TEST_LOCAL_DEPLOY_STATE,
-            userConfig: TEST_USER_CONFIG_WITH_BASEDON
+            userConfig: TEST_USER_CONFIG_WITH_SOURCELAMBDA
         };
 
         afterEach(() => {
@@ -194,20 +192,20 @@ Please solve this revision mismatch and re-deploy again. To ignore this error ru
             });
         });
 
-        it('| using Lambda arn from basedOn, getFunction return error, expect error called back', (done) => {
+        it('| using Lambda arn from sourceLambda, getFunction return error, expect error called back', (done) => {
             // setup
             const GET_FUNC_ERR = 'get func err';
             sinon.stub(LambdaClient.prototype, 'getFunction').callsArgWith(1, GET_FUNC_ERR);
             // call
-            helper.loadLambdaInformation(REPORTER, TEST_LOAD_LAMBDA_OPTION_WITH_BASEDON, (err, data) => {
+            helper.loadLambdaInformation(REPORTER, TEST_LOAD_LAMBDA_OPTION_WITH_SOURCELAMBDA, (err, data) => {
                 // verify
-                expect(err).equal(`Failed to load the Lambda (${TEST_LAMBDA_ARN}) specified in "basedOn". ${GET_FUNC_ERR}`);
+                expect(err).equal(`Failed to load the Lambda (${TEST_LAMBDA_ARN}) specified in "sourceLambda". ${GET_FUNC_ERR}`);
                 expect(data).equal(undefined);
                 done();
             });
         });
 
-        it('| using Lambda arn from basedOn, getFunction request passes, expect lambda data returned', (done) => {
+        it('| using Lambda arn from sourceLambda, getFunction request passes, expect lambda data returned', (done) => {
             // setup
             const TEST_REMOTE_DEPLOY_STATE = {
                 Configuration: {
@@ -217,7 +215,7 @@ Please solve this revision mismatch and re-deploy again. To ignore this error ru
             };
             sinon.stub(LambdaClient.prototype, 'getFunction').callsArgWith(1, null, TEST_REMOTE_DEPLOY_STATE);
             // call
-            helper.loadLambdaInformation(REPORTER, TEST_LOAD_LAMBDA_OPTION_WITH_BASEDON, (err, data) => {
+            helper.loadLambdaInformation(REPORTER, TEST_LOAD_LAMBDA_OPTION_WITH_SOURCELAMBDA, (err, data) => {
                 // verify
                 expect(data.iamRole).equal(TEST_REMOTE_IAM_ROLE);
                 expect(data.lambda.revisionId).equal(TEST_REMOTE_REVISION_ID);

--- a/test/unit/builtins/lambda-deployer/index-test.js
+++ b/test/unit/builtins/lambda-deployer/index-test.js
@@ -55,7 +55,8 @@ describe('Builtins test - lambda-deployer index.js test', () => {
             deployState: {}
         };
         const TEST_VALIDATED_DEPLOY_STATE = {
-            updatedDeployState: {}
+            lambda: {},
+            iamRole: {}
         };
 
         afterEach(() => {
@@ -101,9 +102,9 @@ Please run "ask configure" to re-configure your porfile.`;
 
         it('| alexaRegion is set correctly, validate Lambda deploy state fails, expect an error return', (done) => {
             // setup
-            const TEST_ERROR = 'validateLambdaDeployState error message';
+            const TEST_ERROR = 'loadLambdaInformation error message';
             sinon.stub(awsUtil, 'getAWSProfile').withArgs(TEST_PROFILE).returns(TEST_PROFILE);
-            sinon.stub(helper, 'validateLambdaDeployState').callsArgWith(5, TEST_ERROR);
+            sinon.stub(helper, 'loadLambdaInformation').callsArgWith(2, TEST_ERROR);
             // call
             lambdaDeployer.invoke(REPORTER, TEST_OPTIONS, (err) => {
                 // verify
@@ -116,8 +117,8 @@ Please run "ask configure" to re-configure your porfile.`;
             // setup
             const TEST_ERROR = 'IAMRole error message';
             sinon.stub(awsUtil, 'getAWSProfile').withArgs(TEST_PROFILE).returns(TEST_PROFILE);
-            sinon.stub(helper, 'validateLambdaDeployState').callsArgWith(5, null, TEST_VALIDATED_DEPLOY_STATE);
-            sinon.stub(helper, 'deployIAMRole').callsArgWith(6, TEST_ERROR);
+            sinon.stub(helper, 'loadLambdaInformation').callsArgWith(2, null, TEST_VALIDATED_DEPLOY_STATE);
+            sinon.stub(helper, 'deployIAMRole').callsArgWith(2, TEST_ERROR);
             // call
             lambdaDeployer.invoke(REPORTER, TEST_OPTIONS, (err) => {
                 // verify
@@ -131,8 +132,8 @@ Please run "ask configure" to re-configure your porfile.`;
             const TEST_ERROR = 'LambdaFunction error message';
             const TEST_ERROR_MESSAGE_RESPONSE = `The lambda deploy failed for Alexa region "default": ${TEST_ERROR}`;
             sinon.stub(awsUtil, 'getAWSProfile').withArgs(TEST_PROFILE).returns(TEST_PROFILE);
-            sinon.stub(helper, 'validateLambdaDeployState').callsArgWith(5, null, TEST_VALIDATED_DEPLOY_STATE);
-            sinon.stub(helper, 'deployIAMRole').callsArgWith(6, null, TEST_IAM_ROLE_ARN);
+            sinon.stub(helper, 'loadLambdaInformation').callsArgWith(2, null, TEST_VALIDATED_DEPLOY_STATE);
+            sinon.stub(helper, 'deployIAMRole').callsArgWith(2, null, TEST_IAM_ROLE_ARN);
             sinon.stub(helper, 'deployLambdaFunction').callsArgWith(2, TEST_ERROR);
             // call
             lambdaDeployer.invoke(REPORTER, TEST_OPTIONS, (err, data) => {
@@ -148,8 +149,8 @@ Please run "ask configure" to re-configure your porfile.`;
             const TEST_ERROR = 'LambdaFunction error message';
             const TEST_ERROR_MESSAGE_RESPONSE = `The lambda deploy failed for Alexa region "default": ${TEST_ERROR}`;
             sinon.stub(awsUtil, 'getAWSProfile').withArgs(TEST_PROFILE).returns(TEST_PROFILE);
-            sinon.stub(helper, 'validateLambdaDeployState').callsArgWith(5, null, TEST_VALIDATED_DEPLOY_STATE);
-            sinon.stub(helper, 'deployIAMRole').callsArgWith(6, null, TEST_IAM_ROLE_ARN);
+            sinon.stub(helper, 'loadLambdaInformation').callsArgWith(2, null, TEST_VALIDATED_DEPLOY_STATE);
+            sinon.stub(helper, 'deployIAMRole').callsArgWith(2, null, TEST_IAM_ROLE_ARN);
             sinon.stub(helper, 'deployLambdaFunction').callsArgWith(2, TEST_ERROR);
             // call
             lambdaDeployer.invoke(REPORTER, TEST_OPTIONS, (err, data) => {
@@ -178,8 +179,8 @@ with output Lambda ARN: ${LAMBDA_ARN}.`;
                 lambdaResponse: LAMDBA_RESPONSE
             };
             sinon.stub(awsUtil, 'getAWSProfile').withArgs(TEST_PROFILE).returns(TEST_PROFILE);
-            sinon.stub(helper, 'validateLambdaDeployState').callsArgWith(5, null, TEST_VALIDATED_DEPLOY_STATE);
-            sinon.stub(helper, 'deployIAMRole').callsArgWith(6, null, TEST_IAM_ROLE_ARN);
+            sinon.stub(helper, 'loadLambdaInformation').callsArgWith(2, null, TEST_VALIDATED_DEPLOY_STATE);
+            sinon.stub(helper, 'deployIAMRole').callsArgWith(2, null, TEST_IAM_ROLE_ARN);
             sinon.stub(helper, 'deployLambdaFunction').callsArgWith(2, null, TEST_LAMBDA_RESULT);
             // call
             lambdaDeployer.invoke(REPORTER, TEST_OPTIONS, (err, res) => {
@@ -213,15 +214,15 @@ with output Lambda ARN: ${LAMBDA_ARN}.`;
                 lambdaResponse: {}
             };
             sinon.stub(awsUtil, 'getAWSProfile').withArgs(TEST_PROFILE).returns(TEST_PROFILE);
-            sinon.stub(helper, 'validateLambdaDeployState').callsArgWith(5, null, TEST_VALIDATED_DEPLOY_STATE);
-            sinon.stub(helper, 'deployIAMRole').callsArgWith(6, null, TEST_IAM_ROLE_ARN);
+            sinon.stub(helper, 'loadLambdaInformation').callsArgWith(2, null, TEST_VALIDATED_DEPLOY_STATE);
+            sinon.stub(helper, 'deployIAMRole').callsArgWith(2, null, TEST_IAM_ROLE_ARN);
             sinon.stub(helper, 'deployLambdaFunction').callsArgWith(2, null, TEST_LAMBDA_RESULT);
             // call
             lambdaDeployer.invoke(REPORTER, TEST_OPTIONS_WITHOUT_AWS_REGION, (err) => {
                 // verify
                 expect(err).equal(null);
-                expect(helper.validateLambdaDeployState.args[0][2]).equal(USER_CONFIG_AWS_REGION);
-                expect(helper.deployIAMRole.args[0][4]).equal(USER_CONFIG_AWS_REGION);
+                expect(helper.loadLambdaInformation.args[0][1].awsRegion).equal(USER_CONFIG_AWS_REGION);
+                expect(helper.deployIAMRole.args[0][1].awsRegion).equal(USER_CONFIG_AWS_REGION);
                 done();
             });
         });
@@ -240,15 +241,15 @@ with output Lambda ARN: ${LAMBDA_ARN}.`;
             };
             const LAMDBA_RESULT = {};
             sinon.stub(awsUtil, 'getAWSProfile').withArgs(TEST_PROFILE).returns(TEST_PROFILE);
-            sinon.stub(helper, 'validateLambdaDeployState').callsArgWith(5, null, TEST_VALIDATED_DEPLOY_STATE);
-            sinon.stub(helper, 'deployIAMRole').callsArgWith(6, null, TEST_IAM_ROLE_ARN);
+            sinon.stub(helper, 'loadLambdaInformation').callsArgWith(2, null, TEST_VALIDATED_DEPLOY_STATE);
+            sinon.stub(helper, 'deployIAMRole').callsArgWith(2, null, TEST_IAM_ROLE_ARN);
             sinon.stub(helper, 'deployLambdaFunction').callsArgWith(2, null, LAMDBA_RESULT);
             // call
             lambdaDeployer.invoke(REPORTER, TEST_OPTIONS_WITHOUT_AWS_REGION, (err) => {
                 // verify
                 expect(err).equal(null);
-                expect(helper.validateLambdaDeployState.args[0][2]).equal(MAPPING_ALEXA_DEFAULT_AWS_REGION);
-                expect(helper.deployIAMRole.args[0][4]).equal(MAPPING_ALEXA_DEFAULT_AWS_REGION);
+                expect(helper.loadLambdaInformation.args[0][1].awsRegion).equal(MAPPING_ALEXA_DEFAULT_AWS_REGION);
+                expect(helper.deployIAMRole.args[0][1].awsRegion).equal(MAPPING_ALEXA_DEFAULT_AWS_REGION);
                 done();
             });
         });
@@ -274,15 +275,15 @@ with output Lambda ARN: ${LAMBDA_ARN}.`;
             };
             const LAMDBA_RESULT = {};
             sinon.stub(awsUtil, 'getAWSProfile').withArgs(TEST_PROFILE).returns(TEST_PROFILE);
-            sinon.stub(helper, 'validateLambdaDeployState').callsArgWith(5, null, TEST_VALIDATED_DEPLOY_STATE);
-            sinon.stub(helper, 'deployIAMRole').callsArgWith(6, null, TEST_IAM_ROLE_ARN);
+            sinon.stub(helper, 'loadLambdaInformation').callsArgWith(2, null, TEST_VALIDATED_DEPLOY_STATE);
+            sinon.stub(helper, 'deployIAMRole').callsArgWith(2, null, TEST_IAM_ROLE_ARN);
             sinon.stub(helper, 'deployLambdaFunction').callsArgWith(2, null, LAMDBA_RESULT);
             // call
             lambdaDeployer.invoke(REPORTER, TEST_OPTIONS_WITHOUT_EU_REGION, (err) => {
                 // verify
                 expect(err).equal(null);
-                expect(helper.validateLambdaDeployState.args[0][2]).equal(USER_CONFIG_AWS_REGION);
-                expect(helper.deployIAMRole.args[0][4]).equal(USER_CONFIG_AWS_REGION);
+                expect(helper.loadLambdaInformation.args[0][1].awsRegion).equal(USER_CONFIG_AWS_REGION);
+                expect(helper.deployIAMRole.args[0][1].awsRegion).equal(USER_CONFIG_AWS_REGION);
                 done();
             });
         });
@@ -303,15 +304,15 @@ with output Lambda ARN: ${LAMBDA_ARN}.`;
             };
             const LAMDBA_RESULT = {};
             sinon.stub(awsUtil, 'getAWSProfile').withArgs(TEST_PROFILE).returns(TEST_PROFILE);
-            sinon.stub(helper, 'validateLambdaDeployState').callsArgWith(5, null, TEST_VALIDATED_DEPLOY_STATE);
-            sinon.stub(helper, 'deployIAMRole').callsArgWith(6, null, TEST_IAM_ROLE_ARN);
+            sinon.stub(helper, 'loadLambdaInformation').callsArgWith(2, null, TEST_VALIDATED_DEPLOY_STATE);
+            sinon.stub(helper, 'deployIAMRole').callsArgWith(2, null, TEST_IAM_ROLE_ARN);
             sinon.stub(helper, 'deployLambdaFunction').callsArgWith(2, null, LAMDBA_RESULT);
             // call
             lambdaDeployer.invoke(REPORTER, TEST_OPTIONS_WITHOUT_AWS_REGION, (err) => {
                 // verify
                 expect(err).equal(null);
-                expect(helper.validateLambdaDeployState.args[0][2]).equal(MAPPING_ALEXA_EU_AWS_REGION);
-                expect(helper.deployIAMRole.args[0][4]).equal(MAPPING_ALEXA_EU_AWS_REGION);
+                expect(helper.loadLambdaInformation.args[0][1].awsRegion).equal(MAPPING_ALEXA_EU_AWS_REGION);
+                expect(helper.deployIAMRole.args[0][1].awsRegion).equal(MAPPING_ALEXA_EU_AWS_REGION);
                 done();
             });
         });


### PR DESCRIPTION
This commit addresses the feature requests from https://github.com/alexa/ask-cli/issues/166 and the partial feature request from https://github.com/alexa/ask-cli/issues/283.

### Summary
Introduce `userConfig.basedOn` into the skillInfrastructure JSON object in ask-resources.json. User can provide `basedOn.lambda.arn` to let ask-cli target the deployment to the existing Lambda ARN.

### Usage preview
```JSON
{
  "skillInfrastructure":{
    "userConfig":{
      "basedOn":{
        "lambda":{
          "arn":"arn:aws:lambda:us-east-1:12345:function:ask-function"
        }
      },
      "runtime":"nodejs10.x",
      "handler":"index.handler",
      "awsRegion":"us-east-1",
      "regionalOverrides":{
        "FE":{
          "basedOn":{
            "lambda":{
              "arn":"arn:aws:lambda:us-west-2:12345:function:ask-function"
            }
          }
        }
      }
    },
    "type":"@ask-cli/lambda-deployer"
  }
}
```

### Edge cases testing
1. When setting `basedOn.lambda.arn = "randomArn"` for default region, and FE region using regionalOverrides, the non-existing Lambda error will be displayed:
```
$ ask deploy
==================== Deploy Skill Metadata ====================
...
==================== Build Skill Code ====================
...
==================== Deploy Skill Infrastructure ====================
  ✖ Deploy Alexa skill infrastructure for region "default"
  ✔ Deploy Alexa skill infrastructure for region "EU"
  ✖ Deploy Alexa skill infrastructure for region "FE"
[Error]: CliError: Failed to load the Lambda (arn) specified in "basedOn". ResourceNotFoundException: Function not found: arn:aws:lambda:us-west-2:############:function:randomArn
Failed to load the Lambda (arn) specified in "basedOn". ResourceNotFoundException: Function not found: arn:aws:lambda:us-east-1:############:function:randomArn
```

2. When setting full Lambda ARN with a wrong AWS region (the example below set `us-east-1` LambdaARN to Alexa's region "FE"):
```
ask deploy
==================== Deploy Skill Metadata ====================
...
==================== Build Skill Code ====================
...
==================== Deploy Skill Infrastructure ====================
  ✔ Deploy Alexa skill infrastructure for region "default"
  ✔ Deploy Alexa skill infrastructure for region "EU"
  ✖ Deploy Alexa skill infrastructure for region "FE"
[Error]: CliError: Failed to load the Lambda (arn:aws:lambda:us-east-1:######:function:ask-existingLambda) specified in "basedOn". ResourceNotFoundException: Functions from 'us-east-1' are not reachable in this region ('us-west-2')
```


3. Reuse Lambda ARN but the trigger (which is linked to the skillId) doesn't match:
```
ask deploy
==================== Deploy Skill Metadata ====================
[Warn]: The hash of current skill package folder does not change compared to the last deploy hash result, CLI will skip the deploy of skill package.
Skill ID: amzn1.ask.skill.12345

==================== Build Skill Code ====================
...

==================== Deploy Skill Infrastructure ====================
  ✔ Deploy Alexa skill infrastructure for region "default"
  ✔ Deploy Alexa skill infrastructure for region "EU"
  ✔ Deploy Alexa skill infrastructure for region "FE"
[Error]: {
  "skill": {
    "resources": [
      {
        "action": "UPDATE",
        "errors": [
          {
            "message": "The trigger setting for the Lambda arn:aws:lambda:us-east-1:#####:function:ask-function is invalid."
          }
        ],
        "name": "Manifest",
        "status": "FAILED"
      }
    ],
    "skillId": "amzn1.ask.skill.12345"
  },
  "status": "FAILED"
}
```