### PR TITLE
feat: add support for configurable s3 to cfn-deployer with basedOn

### DIFF
--- a/lib/builtins/deploy-delegates/cfn-deployer/helper.js
+++ b/lib/builtins/deploy-delegates/cfn-deployer/helper.js
@@ -1,5 +1,6 @@
 const R = require('ramda');
 const fs = require('fs');
+const path = require('path');
 
 const CloudformationClient = require('@src/clients/aws-client/cloudformation-client');
 const S3Client = require('@src/clients/aws-client/s3-client');
@@ -20,6 +21,7 @@ module.exports = {
 };
 
 function getAwsInformation(awsProfile, alexaRegion, userConfig, deployState) {
+    // for AWS region
     let awsRegion = alexaRegion === 'default' ? userConfig.awsRegion
         : R.view(R.lensPath(['regionalOverrides', alexaRegion, 'awsRegion']), userConfig);
     awsRegion = awsRegion || alexaAwsRegionMap[alexaRegion];
@@ -27,15 +29,30 @@ function getAwsInformation(awsProfile, alexaRegion, userConfig, deployState) {
         throw `Unsupported Alexa region: ${alexaRegion}. Please check your region name or use "regionalOverrides" to specify AWS region.`;
     }
 
+    // for AWS CFN template path
     const templatePath = R.view(R.lensPath(['regionalOverrides', alexaRegion, 'templatePath']), userConfig) || userConfig.templatePath;
     if (!stringUtils.isNonBlankString(templatePath)) {
         throw 'The template path in userConfig must be provided.';
     }
 
-    const bucketName = R.view(R.lensPath(['s3', 'bucket']), deployState) || S3Client.generateBucketName(awsProfile, awsRegion);
-    const bucketObjectVersion = R.view(R.lensPath(['s3', 'objectVersion']), deployState);
+    // for AWS s3 bucket
+    const { bucketName, bucketKey, bucketObjectVersion } = _resolveS3Bucket(awsProfile, alexaRegion, awsRegion, userConfig, deployState);
+    return { awsRegion, templatePath, bucketName, bucketKey, bucketObjectVersion };
+}
 
-    return { awsRegion, templatePath, bucketName, bucketObjectVersion };
+function _resolveS3Bucket(awsProfile, alexaRegion, awsRegion, userConfig, deployState) {
+    const basedOn = R.view(R.lensPath(['regionalOverrides', alexaRegion, 'basedOn']), userConfig) || userConfig.basedOn;
+    let bucketName, bucketKey, bucketObjectVersion;
+    if (basedOn && basedOn.s3 && basedOn.s3.bucketName) {
+        bucketName = basedOn.s3.bucketName;
+        if (basedOn.s3.bucketKey) {
+            bucketKey = basedOn.s3.bucketKey;
+        }
+    } else {
+        bucketName = R.view(R.lensPath(['s3', 'bucket']), deployState) || S3Client.generateBucketName(awsProfile, awsRegion);
+        bucketObjectVersion = R.view(R.lensPath(['s3', 'objectVersion']), deployState);
+    }
+    return { bucketName, bucketKey, bucketObjectVersion };
 }
 
 function uploadArtifacts(reporter, options, callback) {
@@ -61,7 +78,7 @@ function deployStack(reporter, options, callback) {
 
     let templateContents, cloudformationClient;
     try {
-        templateContents = fs.readFileSync(templatePath, 'utf-8');
+        templateContents = fs.readFileSync(path.join(process.cwd(), templatePath), 'utf-8');
         cloudformationClient = new CloudformationClient({ awsProfile, awsRegion });
     } catch (preErr) {
         return callback(preErr);

--- a/lib/builtins/deploy-delegates/cfn-deployer/index.js
+++ b/lib/builtins/deploy-delegates/cfn-deployer/index.js
@@ -63,9 +63,13 @@ function invoke(reporter, options, callback) {
 
     let uploadArtifactsConfig, deployStackConfig;
     try {
-        const { awsRegion, templatePath, bucketName, bucketObjectVersion } = helper
-            .getAwsInformation(awsProfile, alexaRegion, userConfig, currentRegionDeployState);
-        const bucketKey = `endpoint/${path.basename(code.codeBuild)}`;
+        const {
+            awsRegion,
+            templatePath,
+            bucketName,
+            bucketKey = `endpoint/${path.basename(code.codeBuild)}`,
+            bucketObjectVersion
+        } = helper.getAwsInformation(awsProfile, alexaRegion, userConfig, currentRegionDeployState);
         uploadArtifactsConfig = {
             awsProfile,
             awsRegion,


### PR DESCRIPTION
This commit addresses the feature requests from https://github.com/alexa/ask-cli/issues/174.

### Summary
Introduce `userConfig.basedOn` into the skillInfrastructure JSON object in ask-resources.json. User can provide `basedOn.s3` to let ask-cli target the deployment to the existing s3 bucket. 

### Usage preview
``` JSON
{
  "skillInfrastructure":{
    "type":"@ask-cli/cfn-deployer",
    "userConfig":{
      "basedOn":{
        "s3":{
          "bucketName":"bucketName",
          "bucketKey":"bucketKey"
        }
      },
      "runtime":"python3.7",
      "handler":"hello_world.handler",
      "templatePath":"./infrastructure/cfn-deployer/skill-stack.yaml",
      "awsRegion":"us-east-1"
    }
  }
}
```
