### PR TITLE
fix: error in metric client when env profile is used and .ask holder …

### DIFF
--- a/lib/clients/metric-client/index.js
+++ b/lib/clients/metric-client/index.js
@@ -1,6 +1,7 @@
 const uuid = require('uuid/v4');
 const axios = require('axios');
 const AppConfig = require('@src/model/app-config');
+const profileHelper = require('@src/utils/profile-helper');
 const { METRICS } = require('@src/utils/constants');
 const pck = require('../../../package.json');
 
@@ -150,6 +151,7 @@ class MetricClient {
     }
 
     _isEnabled() {
+        if (profileHelper.isEnvProfile()) return true;
         if (process.env.ASK_SHARE_USAGE === 'false') return false;
         if (!AppConfig.configFileExists()) return false;
 
@@ -159,6 +161,7 @@ class MetricClient {
 
     _getMachineId() {
         if (!this.enabled) return;
+        if (profileHelper.isEnvProfile()) return 'all_environmental';
         const appConfig = AppConfig.getInstance();
         if (!appConfig.getMachineId()) {
             appConfig.setMachineId(uuid());


### PR DESCRIPTION
Addressing error in https://github.com/alexa/ask-cli/issues/303

Happens when both env profile used and ~/.ask/cli_config file exists.

```
export AWS_ACCESS_KEY_ID="xxx"
export AWS_SECRET_ACCESS_KEY="xxx"
export ASK_REFRESH_TOKEN="xxx"
export ASK_VENDOR_ID="xxx"
```



