### PR TITLE
chore: skip release commit on master branch from github actions

### DIFF
--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -7,7 +7,8 @@ on:
 
 jobs:
   build:
-
+    if: "!(endsWith(github.ref,'/master') && contains(github.event.head_commit.message, 'chore(release)'))"
+ 
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
skipping functional test on master branch for release commit to prevent duplicate run during the release.