### PR TITLE
fix: smapi - pass {} by default when non of the in body params specified

### DIFF
--- a/lib/commands/smapi/smapi-command-handler.js
+++ b/lib/commands/smapi/smapi-command-handler.js
@@ -48,6 +48,10 @@ const _loadValue = (param, value) => {
 
 const _mapToParams = (optionsValues, flatParamsMap, commanderToApiCustomizationMap) => {
     const res = {};
+    const bodyParam = Array.from(flatParamsMap.values()).find(p => p.rootName);
+    if (bodyParam) {
+        res[bodyParam.rootName] = {};
+    }
     Object.keys(optionsValues).forEach(key => {
         const apiName = commanderToApiCustomizationMap.get(key) || key;
         const param = flatParamsMap.get(standardize(apiName));
@@ -57,9 +61,6 @@ const _mapToParams = (optionsValues, flatParamsMap, commanderToApiCustomizationM
             value = param.isNumber ? Number(value) : value;
             value = param.isBoolean ? Boolean(value) : value;
             if (param.rootName) {
-                if (!res[param.rootName]) {
-                    res[param.rootName] = {};
-                }
                 let mergeObject = {};
                 mergeObject[param.bodyPath] = _loadValue(param, value);
                 mergeObject = unflatten(mergeObject, BODY_PATH_DELIMITER);

--- a/lib/view/json-view.js
+++ b/lib/view/json-view.js
@@ -11,6 +11,10 @@ module.exports = {
  */
 function toString(jsonObject) {
     try {
+        // handle issue when Error object serialized to {}
+        if (jsonObject instanceof Error) {
+            jsonObject = { message: jsonObject.message, stack: jsonObject.stack };
+        }
         return JSON.stringify(jsonObject, null, CONSTANTS.CONFIGURATION.JSON_DISPLAY_INDENT);
     } catch (e) {
         return e.toString();

--- a/test/unit/commands/smapi/smapi-command-handler-test.js
+++ b/test/unit/commands/smapi/smapi-command-handler-test.js
@@ -159,7 +159,7 @@ describe('Smapi test - smapiCommandHandler function', () => {
                 skillId,
                 someNonPopulatedProperty: null,
                 someArray: null,
-                simulationsApiRequest: null })}\n`]);
+                simulationsApiRequest: {} })}\n`]);
         expect(messengerStub.args[3]).eql(['INFO', 'Response:']);
         expect(messengerStub.args[4]).eql(['INFO', jsonView.toString(fakeResponse)]);
     });


### PR DESCRIPTION
1) fixing outputting error instead of {}. happens when ask smapi model throws unexpected error. for example the api endpoint is not available.
2) by default sending at least {} for body param to fix potential edge case when body param is required but all props inside of it are not required.
