### PR TITLE
fix: issue when generate-lwa-tokens fails when scopes not specified w…

### DIFF
--- a/lib/commands/util/generate-lwa-tokens/index.js
+++ b/lib/commands/util/generate-lwa-tokens/index.js
@@ -28,7 +28,7 @@ class GenerateLwaTokensCommand extends AbstractCommand {
             auth_client_type: 'LWA',
             clientId: cmd.clientId,
             clientConfirmation: cmd.clientConfirmation,
-            scope: cmd.scopes,
+            scope: cmd.scopes || CONSTANTS.LWA.DEFAULT_PUBLIC_SCOPES,
             doDebug: cmd.debug
         }; // redirect_url must be pre-set depending on the CLI mode and with the trusted domain
 

--- a/lib/utils/constants.js
+++ b/lib/utils/constants.js
@@ -399,11 +399,14 @@ const SCOPES_CATALOG_READWRITE = 'alexa::ask:catalogs:readwrite';
 const SCOPES_SUBSCRIPTIONS = 'alexa::ask:subscriptions';
 const SCOPES_SKILLS_DEBUG = 'alexa::ask:skills:debug';
 
+const DEFAULT_PUBLIC_SCOPES = `${SCOPES_SKILLS_READWRITE} ${SCOPES_MODELS_READWRITE} ${SCOPES_SKILLS_TEST} ${SCOPES_CATALOG_READ}`
+        + ` ${SCOPES_CATALOG_READWRITE} ${SCOPES_SUBSCRIPTIONS}`;
+
 module.exports.LWA = {
     S3_RESPONSE_PARSER_URL: 'https://ask-cli-static-content.s3-us-west-2.amazonaws.com/html/ask-cli-no-browser.html',
     DEFAULT_STATE: 'Ask-SkillModel-ReadWrite',
-    DEFAULT_SCOPES: `${SCOPES_SKILLS_READWRITE} ${SCOPES_MODELS_READWRITE} ${SCOPES_SKILLS_TEST} ${SCOPES_CATALOG_READ}`
-        + ` ${SCOPES_CATALOG_READWRITE} ${SCOPES_SUBSCRIPTIONS} ${SCOPES_SKILLS_DEBUG}`,
+    DEFAULT_PUBLIC_SCOPES,
+    DEFAULT_SCOPES: `${DEFAULT_PUBLIC_SCOPES} ${SCOPES_SKILLS_DEBUG}`,
     SIGNIN_URL: 'https://www.amazon.com/ap/signin',
     // Below are the details for the ask-cli's default LWA client which is used internally if another client is not provided by the users.
     // Use of this client outside of the CLI is unauthorized and unsupported by Amazon.


### PR DESCRIPTION
Steps to reproduce

1) Go to https://developer.amazon.com/loginwithamazon/console/site/lwa/overview.html

2) Get client id and client secret

3) run command


```
ask util generate-lwa-tokens --client-id amzn1.application-oa2-client.ca4c0069371c4354a1e668c61eb14348 --client-confirmation 1a0eec32c02a8cf88cf930debed58ed0f75772ef4932a8e32de34a129cfb6c0a
```
 the command would fail with confusing error message.

scopes need to specified explicitly since 'alexa::ask:skills:debug' is not available publically.