### PR TITLE
fix: shorten profile name lambda function name generation

### DIFF
--- a/lib/clients/aws-client/lambda-client.js
+++ b/lib/clients/aws-client/lambda-client.js
@@ -147,7 +147,7 @@ module.exports = class LambdaClient extends AbstractAwsClient {
      */
     _generateFunctionName(skillName, profile, alexaRegion) {
         const validSkillName = stringUtils.filterNonAlphanumeric(skillName.toLowerCase()).substring(0, 22);
-        const validProfile = stringUtils.filterNonAlphanumeric(profile.toLowerCase());
+        const validProfile = stringUtils.filterNonAlphanumeric(profile.toLowerCase()).substring(0, 15);
         const shortRegionName = alexaRegion.replace(/-/g, '');
         return `ask-${validSkillName}-${validProfile}-${shortRegionName}-${Date.now()}`;
     }


### PR DESCRIPTION
fix when profile name is too long. it breaks deploy when generated lambda name is too long. cherry picked from https://github.com/alexa/ask-cli/pull/245
