### PR TITLE
feat: local debugging support with file watcher

### DIFF
--- a/bin/ask.js
+++ b/bin/ask.js
@@ -15,6 +15,7 @@ require('@src/commands/deploy').createCommand(commander);
 require('@src/commands/new').createCommand(commander);
 require('@src/commands/init').createCommand(commander);
 require('@src/commands/dialog').createCommand(commander);
+require('@src/commands/run').createCommand(commander);
 
 commander
     .description('Command Line Interface for Alexa Skill Kit')
@@ -24,7 +25,8 @@ commander
     .version(require('../package.json').version)
     .parse(process.argv);
 
-const ALLOWED_ASK_ARGV_2 = ['configure', 'deploy', 'new', 'init', 'dialog', 'smapi', 'skill', 'util', 'help', '-v', '--version', '-h', '--help'];
+const ALLOWED_ASK_ARGV_2 = ['configure', 'deploy', 'new', 'init', 'dialog', 'smapi', 'skill', 'util', 'help', '-v',
+    '--version', '-h', '--help', 'run'];
 if (process.argv[2] && ALLOWED_ASK_ARGV_2.indexOf(process.argv[2]) === -1) {
     console.log('Command not recognized. Please run "ask" to check the user instructions.');
     process.exit(1);

--- a/docs/concepts/Run-Command.md
+++ b/docs/concepts/Run-Command.md
@@ -1,0 +1,71 @@
+# RUN COMMAND
+
+`ask run` allows developers to start a local instance of their skill code project as the skill endpoint.
+Automatically re-routes development requests and responses between the Alexa service and your local instance.
+
+## PRE-REQUISITES
+
+1. The command relies on the ask-sdk-local-debug package to be installed in your skill code package.
+    Instructions for installing the dependency per SDK
+    * [Java](https://github.com/alexa/alexa-skills-kit-sdk-for-java/blob/2.0.x/ask-sdk-local-debug/README.md)
+    * [Nodejs](https://github.com/alexa/alexa-skills-kit-sdk-for-nodejs/blob/2.0.x/ask-sdk-local-debug/README.md)
+    * [Python](https://github.com/alexa/alexa-skills-kit-sdk-for-python/blob/master/ask-sdk-local-debug/README.rst)
+2. The command needs to be run from within the skill package. We rely on the ask-resources and ask-states file for information on starting the local debugging session.
+3. The command only supports skills in the development stage only.
+4. Please make sure you have deployed the skill once to make sure skill-id exists.
+
+**STRUCTURE OF RUN COMMAND:**
+
+`ask run [--debug-port <debug-port>]
+         [--wait-for-attach]
+         [--watch]
+         [--region <region>]
+         [-p | --profile <profile>]
+         [--debug]
+         [-h | --help]` 
+
+**OPTIONS DESCRIPTION:**
+
+**debug-port**: Optional. Port at which the debugging process will run.
+
+**wait-for-attach**: Optional. Waits for debugging inspector to attach. The default port for the process is 5000.
+
+**watch**: Optional. Uses nodemon to monitor changes and automatically restart the run session.
+
+**region**: Optional. Sets the run region for the session. Accepted values are - [EU, FE, NA]. Defaults to NA. To know more about which
+                             region is right for you refer -
+                             https://developer.amazon.com/en-US/docs/alexa/ask-toolkit/vs-code-testing-simulator.html#prepare
+
+**profile**: Optional. Specify a profile name to be used. Defaults to use `default` as the profile name, if this option or environmental variable `ASK_DEFAULT_PROFILE` is not set.
+
+**debug**: Optional. Show debug messages.
+
+
+## MODES SUPPORTED BY RUN COMMAND
+
+1. **Run Mode**: In this mode you can simply run the command - `ask run` and this will kick start the process that converts your workspace into your skill's endpoint.
+
+<p align="center">
+  <img align="center" src="https://ask-cli-static-content.s3-us-west-2.amazonaws.com/document-assets/v2-ask-run-runMode.gif?" height="300" />
+</p>
+
+2. **Debug Mode**: In this mode you can attach a debugging inspector of your favorite IDE on to the specified debug port and start leveraging your IDEs powerful debugging experience.
+                   To use this mode, simply run `ask run --wait-for-attach` and the process will wait for an inspector to be attached on the default debug port - 5000. You can also 
+                   change the debugging port by using the switch `--debug-port`.
+                   
+<p align="center">
+  <img align="center" src="https://ask-cli-static-content.s3-us-west-2.amazonaws.com/document-assets/v2-ask-run-debugMode.gif" height="300" />
+</p>
+
+3. **File watcher Mode**: In this mode, you can activate the nodemon file watcher. As you make changes to the skill code, nodemon will restart the process. To use this, just add the switch 
+                          `--watch` to your run command like so - `ask run --watch`. The file watcher feature can be coupled with both run and debug modes.
+                          
+ Vscode resources for debugging on a port
+  * [Java](https://github.com/microsoft/vscode-java-debug#use)
+  * [Nodejs](https://code.visualstudio.com/docs/nodejs/nodejs-debugging#_setting-up-an-attach-configuration)
+  * [Python](https://code.visualstudio.com/docs/python/debugging#_command-line-debugging)
+
+<p align="center">
+  <img align="center" src="https://ask-cli-static-content.s3-us-west-2.amazonaws.com/document-assets/v2-ask-run-watchMode.gif?" height="300" />
+</p>
+

--- a/lib/commands/option-model.json
+++ b/lib/commands/option-model.json
@@ -7,7 +7,7 @@
   },
   "debug": {
     "name": "debug",
-    "description": "Enables the ASK CLI  to show debug messages in the output of the command.",
+    "description": "Enables the ASK CLI to show debug messages in the output of the command.",
     "alias": null,
     "stringInput": "NONE"
   },
@@ -163,5 +163,32 @@
     "name": "keywords",
     "description": "Keywords can be description of tasks, task name or tags in task definition.\n[MULTIPLE]: Values can be separated by comma.",
     "stringInput": "OPTIONAL"
+  },
+  "debug-port": {
+    "name": "debug-port",
+    "description": "Port at which the debug process will run.",
+    "stringInput": "REQUIRED",
+    "rule": [{
+      "type": "INTEGER"
+    }]
+  },
+  "wait-for-attach": {
+    "name": "wait-for-attach",
+    "description": "Waits for debugging inspector to attach. The default port for the process is 5000.",
+    "stringInput": "NONE"
+  },
+  "region": {
+    "name": "region",
+    "description": "Sets the run region for the session. Accepted values are - [EU, FE, NA]. Defaults to NA. To know more about which region is right for you refer - https://developer.amazon.com/en-US/docs/alexa/ask-toolkit/vs-code-testing-simulator.html#prepare",
+    "stringInput": "REQUIRED",
+    "rule": [{
+      "type": "ENUM",
+      "values": ["NA", "FE", "EU"]
+    }]
+  },
+  "watch": {
+    "name": "watch",
+    "description": "Uses nodemon to monitor changes and automatically restart the run session.",
+    "stringInput": "NONE"
   }
 }

--- a/lib/commands/run/helper.js
+++ b/lib/commands/run/helper.js
@@ -1,0 +1,91 @@
+const fs = require('fs');
+const ResourcesConfig = require('@src/model/resources-config');
+const CONSTANTS = require('@src/utils/constants');
+const stringUtils = require('@src/utils/string-utils');
+const CliError = require('@src/exceptions/cli-error');
+const NodejsRunFlow = require('./run-flow/nodejs-run');
+const PythonRunFlow = require('./run-flow/python-run');
+const JavaRunFlow = require('./run-flow/java-run');
+
+const RUN_FLOWS = [
+    JavaRunFlow,
+    NodejsRunFlow,
+    PythonRunFlow
+];
+
+module.exports = {
+    getHostedSkillInvocationInfo,
+    getNonHostedSkillInvocationInfo,
+    getSkillCodeFolderName,
+    getNormalisedRuntime,
+    selectRunFlowClass,
+    getSkillFlowInstance
+};
+
+function getHostedSkillInvocationInfo(runtime) {
+    return CONSTANTS.HOSTED_SKILL.RUN.INVOCATION_INFO[runtime];
+}
+
+function getNonHostedSkillInvocationInfo(runtime, handler, skillCodeFolderName) {
+    if (!stringUtils.isNonBlankString(runtime)) {
+        throw new CliError('Missing runtime info in '
+            + `resource file ${CONSTANTS.FILE_PATH.ASK_RESOURCES_JSON_CONFIG}.`);
+    }
+    if (!stringUtils.isNonBlankString(handler)) {
+        throw new CliError('Missing handler info '
+            + `in resource file ${CONSTANTS.FILE_PATH.ASK_RESOURCES_JSON_CONFIG}.`);
+    }
+    if (runtime === CONSTANTS.RUNTIME.JAVA) {
+        return { handlerName: handler, skillCodeFolderName };
+    }
+    const handlerInfo = handler.split('.');
+    const handlerName = handlerInfo.pop();
+    const skillFileName = handlerInfo.pop();
+    return { handlerName, skillFileName, skillCodeFolderName };
+}
+
+function getSkillCodeFolderName(profile, skillCodeRegion) {
+    const userRegionSkillCodeFolderName = ResourcesConfig.getInstance().getCodeSrcByRegion(profile, skillCodeRegion);
+    const skillCodeFolderName = ((!stringUtils.isNonBlankString(userRegionSkillCodeFolderName))
+        && (userRegionSkillCodeFolderName !== CONSTANTS.ALEXA.REGION.DEFAULT))
+        ? ResourcesConfig.getInstance().getCodeSrcByRegion(profile, CONSTANTS.ALEXA.REGION.DEFAULT) : userRegionSkillCodeFolderName;
+    if (!stringUtils.isNonBlankString(skillCodeFolderName)) {
+        throw new CliError(`Invalid code setting in region ${skillCodeRegion}. "src" must be set if you want to run `
+            + 'the skill code with skill package.');
+    }
+    if (!fs.existsSync(skillCodeFolderName)) {
+        throw new CliError(`Invalid code setting in region ${skillCodeRegion}.`
+            + ` File doesn't exist for code src: ${skillCodeFolderName}.`);
+    }
+    return skillCodeFolderName;
+}
+
+function getNormalisedRuntime(runtime) {
+    if (runtime.includes(CONSTANTS.RUNTIME.NODE)) {
+        return CONSTANTS.RUNTIME.NODE;
+    }
+    if (runtime.includes(CONSTANTS.RUNTIME.PYTHON)) {
+        return CONSTANTS.RUNTIME.PYTHON;
+    }
+    if (runtime.includes(CONSTANTS.RUNTIME.JAVA)) {
+        return CONSTANTS.RUNTIME.JAVA;
+    }
+    throw new CliError(`Runtime - ${runtime} is not supported.`);
+}
+
+function selectRunFlowClass(runtime) {
+    return RUN_FLOWS.find(flow => flow.canHandle(runtime));
+}
+
+function getSkillFlowInstance(runtime, skillInvocationInfo, waitForAttach, debugPort, token, skillId, runRegion, watch) {
+    const RunFlow = this.selectRunFlowClass(runtime);
+    return new RunFlow({
+        skillInvocationInfo,
+        waitForAttach,
+        debugPort,
+        token,
+        skillId,
+        runRegion,
+        watch
+    });
+}

--- a/lib/commands/run/index.js
+++ b/lib/commands/run/index.js
@@ -1,0 +1,156 @@
+const path = require('path');
+const SmapiClient = require('@src/clients/smapi-client');
+const { AbstractCommand } = require('@src/commands/abstract-command');
+const optionModel = require('@src/commands/option-model');
+const AuthorizationController = require('@src/controllers/authorization-controller');
+const ResourcesConfig = require('@src/model/resources-config');
+const CONSTANTS = require('@src/utils/constants');
+const profileHelper = require('@src/utils/profile-helper');
+const jsonView = require('@src/view/json-view');
+const stringUtils = require('@src/utils/string-utils');
+const Messenger = require('@src/view/messenger');
+const CliError = require('@src/exceptions/cli-error');
+const helper = require('./helper');
+
+class RunCommand extends AbstractCommand {
+    name() {
+        return 'run';
+    }
+
+    description() {
+        return 'Starts a local instance of your project as the skill endpoint.'
+            + ' Automatically re-routes development requests and responses between the Alexa service and your local instance.';
+    }
+
+    requiredOptions() {
+        return [];
+    }
+
+    optionalOptions() {
+        return ['debug-port', 'wait-for-attach', 'watch', 'region', 'profile', 'debug'];
+    }
+
+    handle(cmd, cb) {
+        const debugPort = cmd.debugPort || CONSTANTS.RUN.DEFAULT_DEBUG_PORT;
+        const skillCodeRegion = cmd.region || CONSTANTS.ALEXA.REGION.NA;
+        const runRegion = cmd.region || CONSTANTS.ALEXA.REGION.NA;
+        const watch = cmd.watch || false;
+        let skillId, profile;
+
+        try {
+            profile = profileHelper.runtimeProfile(cmd.profile);
+            new ResourcesConfig(path.join(process.cwd(), CONSTANTS.FILE_PATH.ASK_RESOURCES_JSON_CONFIG));
+            skillId = ResourcesConfig.getInstance().getSkillId(profile);
+            if (!stringUtils.isNonBlankString(skillId)) {
+                throw new CliError(`Failed to obtain skill-id for the given profile - ${profile}`
+                    + '. Please deploy you skill project first.');
+            }
+        } catch (error) {
+            Messenger.getInstance().error(error);
+            cb(error);
+        }
+
+        this._getAccessTokenForProfile(profile, cmd.debug, (tokenErr, token) => {
+            if (tokenErr) {
+                Messenger.getInstance().error(tokenErr);
+                return cb(tokenErr);
+            }
+            this._getSkillRunFlow(skillId, profile, skillCodeRegion, cmd.waitForAttach, watch, cmd.debug, debugPort, token,
+                runRegion, (err, runFlowInstance) => {
+                    if (err) {
+                        Messenger.getInstance().error(err);
+                        return cb(err);
+                    }
+                    Messenger.getInstance()
+                        .info('\n*****Once the session is successfully started, '
+                            + 'you can use `ask dialog` to make simulation requests to your local skill code*****\n');
+                    if (cmd.waitForAttach) {
+                        Messenger.getInstance()
+                            .info(`\n*****Debugging session will wait until inspector is attached at port - ${debugPort}*****\n`);
+                    }
+                    runFlowInstance.execCommand();
+                });
+        });
+    }
+
+    _getAccessTokenForProfile(profile, debug, callback) {
+        const authorizationController = new AuthorizationController({
+            auth_client_type: 'LWA',
+            doDebug: debug
+        });
+        authorizationController.tokenRefreshAndRead(profile, (tokenErr, token) => {
+            if (tokenErr) {
+                return callback(tokenErr);
+            }
+            callback(null, token);
+        });
+    }
+
+    _getHostedSkillRuntime(smapiClient, skillId, callback) {
+        smapiClient.skill.alexaHosted.getAlexaHostedSkillMetadata(skillId, (err, response) => {
+            if (err) {
+                return callback(err);
+            }
+            if (response.statusCode >= 300) {
+                const error = jsonView.toString(response.body);
+                return callback(error);
+            }
+            try {
+                const { runtime } = response.body.alexaHosted;
+                if (!stringUtils.isNonBlankString(runtime)) {
+                    throw new CliError(`Unable to determine runtime of the hosted skill - ${skillId}`);
+                }
+                callback(null, helper.getNormalisedRuntime(runtime));
+            } catch (error) {
+                return callback(error);
+            }
+        });
+    }
+
+    _getSkillRunFlow(skillId, profile, skillCodeRegion, waitForAttach, watch, debug, debugPort, token, runRegion, callback) {
+        let skillFlowInstance;
+        if (this._filterAlexaHostedSkill(profile)) {
+            const smapiClient = new SmapiClient({
+                profile,
+                doDebug: debug
+            });
+            this._getHostedSkillRuntime(smapiClient, skillId, (err, runtime) => {
+                if (err) {
+                    return callback(err);
+                }
+                try {
+                    skillFlowInstance = helper.getSkillFlowInstance(runtime, helper.getHostedSkillInvocationInfo(runtime),
+                        waitForAttach, debugPort, token, skillId, runRegion, watch);
+                } catch (error) {
+                    return callback(error);
+                }
+                callback(null, skillFlowInstance);
+            });
+        } else {
+            try {
+                const skillCodeFolderName = helper.getSkillCodeFolderName(profile, skillCodeRegion);
+                Messenger.getInstance().info(`Skill code folder name select for the run session: ${skillCodeFolderName}`);
+                const userConfig = ResourcesConfig.getInstance().getSkillInfraUserConfig(profile);
+                if (!userConfig) {
+                    return callback(new CliError('Failed to obtain userConfig from project '
+                        + `resource file ${CONSTANTS.FILE_PATH.ASK_RESOURCES_JSON_CONFIG}`));
+                }
+                const { runtime, handler } = userConfig;
+                const normalisedRuntime = helper.getNormalisedRuntime(runtime);
+                skillFlowInstance = helper.getSkillFlowInstance(normalisedRuntime,
+                    helper.getNonHostedSkillInvocationInfo(normalisedRuntime, handler, skillCodeFolderName),
+                    waitForAttach, debugPort, token, skillId, runRegion, watch);
+            } catch (err) {
+                return callback(err);
+            }
+            callback(null, skillFlowInstance);
+        }
+    }
+
+    _filterAlexaHostedSkill(profile) {
+        return (ResourcesConfig.getInstance().getSkillInfraType(profile) === CONSTANTS.DEPLOYER_TYPE.HOSTED.NAME);
+    }
+}
+
+module.exports = RunCommand;
+module.exports.createCommand = new RunCommand(optionModel).createCommand();

--- a/lib/commands/run/run-flow/abstract-run-flow.js
+++ b/lib/commands/run/run-flow/abstract-run-flow.js
@@ -1,0 +1,17 @@
+const nodemon = require('nodemon');
+
+class AbstractRunFlow {
+    constructor(execConfig) {
+        this.execConfig = execConfig;
+    }
+
+    execCommand() {
+        nodemon(this.execConfig);
+    }
+
+    getExecConfig() {
+        return this.execConfig;
+    }
+}
+
+module.exports = AbstractRunFlow;

--- a/lib/commands/run/run-flow/java-run.js
+++ b/lib/commands/run/run-flow/java-run.js
@@ -1,0 +1,27 @@
+const CONSTANTS = require('@src/utils/constants');
+const AbstractRunFlow = require('./abstract-run-flow');
+
+class JavaRunFlow extends AbstractRunFlow {
+    static canHandle(runtime) {
+        return runtime === CONSTANTS.RUNTIME.JAVA;
+    }
+
+    constructor({ skillInvocationInfo, waitForAttach, debugPort, token, skillId, runRegion, watch }) {
+        let execCmd = `cd ${skillInvocationInfo.skillCodeFolderName}; mvn exec:exec -Dexec.executable=java -Dexec.args=`
+        + '"-classpath %classpath com.amazon.ask.localdebug.LocalDebuggerInvoker '
+        + `--accessToken ${token} --skillId ${skillId} --skillStreamHandlerClass ${skillInvocationInfo.handlerName} --region ${runRegion}"`;
+        if (waitForAttach) {
+            execCmd = `cd ${skillInvocationInfo.skillCodeFolderName}; mvn exec:exec -Dexec.executable=java -Dexec.args=`
+            + `"-classpath %classpath -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=${debugPort} `
+            + 'com.amazon.ask.localdebug.LocalDebuggerInvoker '
+            + `--accessToken ${token} --skillId ${skillId} --region ${runRegion} --skillStreamHandlerClass ${skillInvocationInfo.handlerName}"`;
+        }
+        super({
+            exec: execCmd,
+            ext: 'java, xml',
+            watch: watch ? `${skillInvocationInfo.skillCodeFolderName}` : watch
+        });
+    }
+}
+
+module.exports = JavaRunFlow;

--- a/lib/commands/run/run-flow/nodejs-run.js
+++ b/lib/commands/run/run-flow/nodejs-run.js
@@ -1,0 +1,34 @@
+const path = require('path');
+const fs = require('fs');
+const CONSTANTS = require('@src/utils/constants');
+const CliError = require('@src/exceptions/cli-error');
+const AbstractRunFlow = require('./abstract-run-flow');
+
+class NodejsRunFlow extends AbstractRunFlow {
+    static canHandle(runtime) {
+        return runtime === CONSTANTS.RUNTIME.NODE;
+    }
+
+    constructor({ skillInvocationInfo, waitForAttach, debugPort, token, skillId, runRegion, watch }) {
+        const skillFolderPath = path.join(process.cwd(), skillInvocationInfo.skillCodeFolderName);
+        const script = path.join(skillFolderPath, CONSTANTS.RUN.NODE.SCRIPT_LOCATION);
+        if (!fs.existsSync(script)) {
+            throw new CliError('ask-sdk-local-debug cannot be found. Please install ask-sdk-local-debug to your skill code project. '
+                + 'Refer https://www.npmjs.com/package/ask-sdk-local-debug for more info.');
+        }
+        const execMap = waitForAttach ? {
+            js: `node --inspect-brk=${debugPort}`,
+        } : undefined;
+        super({
+            execMap,
+            script,
+            args: ['--accessToken', `"${token}"`, '--skillId', skillId,
+                '--handlerName', skillInvocationInfo.handlerName,
+                '--skillEntryFile', path.join(skillFolderPath, `${skillInvocationInfo.skillFileName}.js`),
+                '--region', runRegion],
+            watch: watch ? `${skillInvocationInfo.skillCodeFolderName}` : watch
+        });
+    }
+}
+
+module.exports = NodejsRunFlow;

--- a/lib/commands/run/run-flow/python-run.js
+++ b/lib/commands/run/run-flow/python-run.js
@@ -1,0 +1,45 @@
+const childprocess = require('child_process');
+const path = require('path');
+const fs = require('fs');
+const CONSTANTS = require('@src/utils/constants');
+const CliError = require('@src/exceptions/cli-error');
+const AbstractRunFlow = require('./abstract-run-flow');
+
+class PythonRunFlow extends AbstractRunFlow {
+    static canHandle(runtime) {
+        return runtime === CONSTANTS.RUNTIME.PYTHON;
+    }
+
+    constructor({ skillInvocationInfo, waitForAttach, debugPort, token, skillId, runRegion, watch }) {
+        const sitePkgLocationsStr = childprocess.execSync('python3 -c "import site; import json; print(json.dumps(site.getsitepackages()))"')
+            .toString();
+        const sitePkgLocations = JSON.parse(sitePkgLocationsStr);
+        const localDebuggerPath = sitePkgLocations
+            .map(location => path.join(location, CONSTANTS.RUN.PYTHON.SCRIPT_LOCATION))
+            .find(location => fs.existsSync(location));
+        if (!fs.existsSync(localDebuggerPath)) {
+            throw new CliError('ask-sdk-local-debug cannot be found. Please install ask-sdk-local-debug to your skill code project. '
+            + 'Refer https://pypi.org/project/ask-sdk-local-debug, for more info.');
+        }
+        if (waitForAttach) {
+            childprocess.execSync('python3 -m pip install debugpy', { stdio: 'inherit' });
+        }
+        const execMap = waitForAttach ? {
+            py: `python3 -m debugpy --listen ${debugPort} --wait-for-client`,
+        } : {
+            py: 'python3'
+        };
+        super({
+            execMap,
+            script: localDebuggerPath,
+            args: ['--accessToken', `"${token}"`, '--skillId', skillId,
+                '--skillHandler', skillInvocationInfo.handlerName,
+                '--skillFilePath', path.join(`${skillInvocationInfo.skillCodeFolderName}`, `${skillInvocationInfo.skillFileName}.py`),
+                '--region', runRegion],
+            ext: 'py,json,txt',
+            watch: watch ? `${skillInvocationInfo.skillCodeFolderName}` : watch
+        });
+    }
+}
+
+module.exports = PythonRunFlow;

--- a/lib/utils/constants.js
+++ b/lib/utils/constants.js
@@ -1,3 +1,5 @@
+const path = require('path');
+
 module.exports.APPLICATION_NAME = 'ask-cli';
 module.exports.NPM_REGISTRY_URL_BASE = 'http://registry.npmjs.org';
 
@@ -88,6 +90,18 @@ module.exports.HOSTED_SKILL = {
             PRE_PUSH: 'pre-push'
         }
     },
+    RUN: {
+        INVOCATION_INFO: {
+            node: { skillCodeFolderName: 'lambda',
+                handlerName: 'handler',
+                skillFileName: 'index' },
+            python: {
+                skillCodeFolderName: 'lambda',
+                handlerName: 'lambda_handler',
+                skillFileName: 'lambda_function'
+            }
+        }
+    }
 };
 
 module.exports.SKILL = {
@@ -451,4 +465,20 @@ module.exports.LOCALHOST_PORT = '9090';
 
 module.exports.FILE_PERMISSION = {
     USER_READ_WRITE: '0600'
+};
+
+module.exports.RUN = {
+    DEFAULT_DEBUG_PORT: '5000',
+    NODE: {
+        SCRIPT_LOCATION: path.join('node_modules', 'ask-sdk-local-debug', 'dist', 'LocalDebuggerInvoker.js')
+    },
+    PYTHON: {
+        SCRIPT_LOCATION: path.join('ask_sdk_local_debug, local_debugger_invoker.py')
+    }
+};
+
+module.exports.RUNTIME = {
+    NODE: 'node',
+    PYTHON: 'python',
+    JAVA: 'java'
 };

--- a/package.json
+++ b/package.json
@@ -69,7 +69,8 @@
     "simple-git": "^1.82.0",
     "tmp": "^0.1.0",
     "uuid": "^3.4.0",
-    "valid-url": "^1.0.9"
+    "valid-url": "^1.0.9",
+    "nodemon": "^2.0.4"
   },
   "devDependencies": {
     "@babel/cli": "^7.12.1",

--- a/test/unit/commands/run/helper-test.js
+++ b/test/unit/commands/run/helper-test.js
@@ -1,0 +1,138 @@
+const { expect } = require('chai');
+const fs = require('fs');
+const sinon = require('sinon');
+const helper = require('@src/commands/run/helper');
+const CONSTANTS = require('@src/utils/constants');
+const NodejsRunFlow = require('@src/commands/run/run-flow/nodejs-run');
+const PythonRunFlow = require('@src/commands/run/run-flow/python-run');
+const JavaRunFlow = require('@src/commands/run/run-flow/java-run');
+const ResourcesConfig = require('@src/model/resources-config');
+
+describe('Commands Run - helper test', () => {
+    describe('getHostedSkillInvocationInfo test', () => {
+        it('| validate Node hosted skill invocation info', () => {
+            const hostedSkillInvocationInfo = helper.getHostedSkillInvocationInfo(CONSTANTS.RUNTIME.NODE);
+            expect(hostedSkillInvocationInfo.skillCodeFolderName).eq('lambda');
+            expect(hostedSkillInvocationInfo.handlerName).eq('handler');
+            expect(hostedSkillInvocationInfo.skillFileName).eq('index');
+        });
+
+        it('| validate Python hosted skill invocation info', () => {
+            const hostedSkillInvocationInfo = helper.getHostedSkillInvocationInfo(CONSTANTS.RUNTIME.PYTHON);
+            expect(hostedSkillInvocationInfo.skillCodeFolderName).eq('lambda');
+            expect(hostedSkillInvocationInfo.handlerName).eq('lambda_handler');
+            expect(hostedSkillInvocationInfo.skillFileName).eq('lambda_function');
+        });
+
+        it('| Invalid hosted skill runtime info', () => {
+            const hostedSkillInvocationInfo = helper.getHostedSkillInvocationInfo(CONSTANTS.RUNTIME.JAVA);
+            expect(hostedSkillInvocationInfo).eq(undefined);
+        });
+    });
+
+    describe('getNonHostedSkillInvocationInfo test', () => {
+        it('| validate Node non hosted skill invocation info', () => {
+            const nonHostedSkillInvocationInfo = helper
+                .getNonHostedSkillInvocationInfo(CONSTANTS.RUNTIME.NODE, 'fooFileName.fooHandler', 'fooSkillCodeFolderName');
+            expect(nonHostedSkillInvocationInfo.handlerName).eq('fooHandler');
+            expect(nonHostedSkillInvocationInfo.skillFileName).eq('fooFileName');
+            expect(nonHostedSkillInvocationInfo.skillCodeFolderName).eq('fooSkillCodeFolderName');
+        });
+        it('| validate Python non hosted skill invocation info', () => {
+            const nonHostedSkillInvocationInfo = helper
+                .getNonHostedSkillInvocationInfo(CONSTANTS.RUNTIME.PYTHON, 'fooFileName.fooHandler', 'fooSkillCodeFolderName');
+            expect(nonHostedSkillInvocationInfo.handlerName).eq('fooHandler');
+            expect(nonHostedSkillInvocationInfo.skillFileName).eq('fooFileName');
+            expect(nonHostedSkillInvocationInfo.skillCodeFolderName).eq('fooSkillCodeFolderName');
+        });
+        it('| validate Java non hosted skill invocation info', () => {
+            const nonHostedSkillInvocationInfo = helper
+                .getNonHostedSkillInvocationInfo(CONSTANTS.RUNTIME.JAVA, 'fooHandler', 'fooSkillCodeFolderName');
+            expect(nonHostedSkillInvocationInfo.handlerName).eq('fooHandler');
+            expect(nonHostedSkillInvocationInfo.skillCodeFolderName).eq('fooSkillCodeFolderName');
+        });
+        it('| empty runtime', () => {
+            expect(() => helper
+                .getNonHostedSkillInvocationInfo('', '', '')).to.throw('Missing runtime info in '
+                + `resource file ${CONSTANTS.FILE_PATH.ASK_RESOURCES_JSON_CONFIG}.`);
+        });
+        it('| empty handler', () => {
+            expect(() => helper
+                .getNonHostedSkillInvocationInfo(CONSTANTS.RUNTIME.JAVA, '', '')).to.throw('Missing handler info in '
+                + `resource file ${CONSTANTS.FILE_PATH.ASK_RESOURCES_JSON_CONFIG}.`);
+        });
+    });
+
+    describe('getNormalisedRuntime test', () => {
+        it('| normalised runtime for nodejs', () => {
+            expect(helper.getNormalisedRuntime('nodejs12.x')).eq(CONSTANTS.RUNTIME.NODE);
+        });
+        it('| normalised runtime for python', () => {
+            expect(helper.getNormalisedRuntime('python3.8')).eq(CONSTANTS.RUNTIME.PYTHON);
+        });
+        it('| normalised runtime for java', () => {
+            expect(helper.getNormalisedRuntime('java11')).eq(CONSTANTS.RUNTIME.JAVA);
+        });
+        it('| unsupported runtime', () => {
+            expect(() => helper.getNormalisedRuntime('foo')).to.throw('Runtime - foo is not supported');
+        });
+    });
+
+    describe('selectRunFlowClass test', () => {
+        it('| java run flow test', () => {
+            expect(helper.selectRunFlowClass(CONSTANTS.RUNTIME.JAVA)).eq(JavaRunFlow);
+        });
+        it('| python run flow test', () => {
+            expect(helper.selectRunFlowClass(CONSTANTS.RUNTIME.PYTHON)).eq(PythonRunFlow);
+        });
+        it('| nodejs run flow test', () => {
+            expect(helper.selectRunFlowClass(CONSTANTS.RUNTIME.NODE)).eq(NodejsRunFlow);
+        });
+        it('| unsupported run flow test', () => {
+            expect(helper.selectRunFlowClass('foo')).eq(undefined);
+        });
+    });
+
+    describe('getSkillCodeFolderName test', () => {
+        afterEach(() => {
+            sinon.restore();
+        });
+
+        it('| skill code folder value exists for user provided region in resources file', () => {
+            sinon.stub(ResourcesConfig.prototype, 'getCodeSrcByRegion').returns('fooFolder');
+            sinon.stub(fs, 'existsSync').returns(true);
+            expect(helper.getSkillCodeFolderName('foo', CONSTANTS.ALEXA.REGION.NA)).eq('fooFolder');
+        });
+
+        it('| skill code folder value does not for user provided region, default exists in resources file', () => {
+            sinon.stub(ResourcesConfig.prototype, 'getCodeSrcByRegion').withArgs('foo', CONSTANTS.ALEXA.REGION.NA).returns('')
+                .withArgs('foo', CONSTANTS.ALEXA.REGION.DEFAULT)
+                .returns('fooFolder');
+            sinon.stub(fs, 'existsSync').returns(true);
+            expect(helper.getSkillCodeFolderName('foo', CONSTANTS.ALEXA.REGION.NA)).eq('fooFolder');
+        });
+
+        it('| skill code folder value does not exist for user provided region or default in resources file', () => {
+            sinon.stub(ResourcesConfig.prototype, 'getCodeSrcByRegion').returns('');
+            sinon.stub(fs, 'existsSync').returns(true);
+            expect(() => helper.getSkillCodeFolderName('foo', CONSTANTS.ALEXA.REGION.NA))
+                .to.throw('Invalid code setting in region NA. "src" must be set if you want to run the skill code with skill package.');
+        });
+
+        it('| skill code folder does not exist', () => {
+            sinon.stub(ResourcesConfig.prototype, 'getCodeSrcByRegion').returns('fooFolder');
+            sinon.stub(fs, 'existsSync').returns(false);
+            expect(() => helper.getSkillCodeFolderName('foo', CONSTANTS.ALEXA.REGION.NA))
+                .to.throw('Invalid code setting in region NA. File doesn\'t exist for code src: fooFolder.');
+        });
+    });
+
+    describe('getSkillFlowInstance test', () => {
+        it('| create skill flow instance test, error case', () => {
+            expect(() => helper.getSkillFlowInstance(CONSTANTS.RUNTIME.NODE, { skillCodeFolderName: 'fooSkillCodeFolderName' },
+                true, CONSTANTS.RUN.DEFAULT_DEBUG_PORT, 'fooToken',
+                'fooSkillId', CONSTANTS.ALEXA.REGION.NA, false).to.throw('ask-sdk-local-debug cannot be found. Please install '
+                + 'ask-sdk-local-debug to your skill code project. Refer https://www.npmjs.com/package/ask-sdk-local-debug for more info'));
+        });
+    });
+});

--- a/test/unit/commands/run/index-test.js
+++ b/test/unit/commands/run/index-test.js
@@ -1,0 +1,261 @@
+const { expect } = require('chai');
+const path = require('path');
+const sinon = require('sinon');
+const AuthorizationController = require('@src/controllers/authorization-controller');
+const RunCommand = require('@src/commands/run');
+const optionModel = require('@src/commands/option-model');
+const Messenger = require('@src/view/messenger');
+const ResourcesConfig = require('@src/model/resources-config');
+const profileHelper = require('@src/utils/profile-helper');
+const CONSTANTS = require('@src/utils/constants');
+const helper = require('@src/commands/run/helper');
+const SmapiClient = require('@src/clients/smapi-client');
+
+const TEST_PROFILE = 'default';
+const TEST_CMD = {
+    profile: TEST_PROFILE
+};
+const RESOURCE_CONFIG_FIXTURE_PATH = path.join(process.cwd(), 'test', 'unit', 'fixture', 'model', 'regular-proj');
+const INVALID_RESOURCES_CONFIG_JSON_PATH = path.join(RESOURCE_CONFIG_FIXTURE_PATH, 'random-json-config.json');
+const VALID_RESOURCES_CONFIG_JSON_PATH = path.join(RESOURCE_CONFIG_FIXTURE_PATH, 'ask-resources.json');
+
+describe('Commands Run test - command class test', () => {
+    const TEST_ERROR = 'error';
+    let errorStub;
+    let infoStub;
+    beforeEach(() => {
+        errorStub = sinon.stub();
+        infoStub = sinon.stub();
+        sinon.stub(Messenger, 'getInstance').returns({
+            error: errorStub,
+            info: infoStub
+        });
+        sinon.stub(AuthorizationController.prototype, 'tokenRefreshAndRead').yields();
+    });
+
+    afterEach(() => {
+        sinon.restore();
+    });
+
+    it('| validate command information is set correctly', () => {
+        const instance = new RunCommand(optionModel);
+        expect(instance.name()).eq('run');
+        expect(instance.description()).eq('Starts a local instance of your project as the skill endpoint.'
+            + ' Automatically re-routes development requests and responses between the Alexa service and your local instance.');
+        expect(instance.requiredOptions()).deep.eq([]);
+        expect(instance.optionalOptions())
+            .deep.eq(['debug-port', 'wait-for-attach', 'watch', 'region', 'profile', 'debug']);
+    });
+    describe('# validate command handle', () => {
+        let instance;
+
+        beforeEach(() => {
+            instance = new RunCommand(optionModel);
+        });
+
+        afterEach(() => {
+            sinon.restore();
+        });
+
+        it('| no resources config file found', (done) => {
+            // setup
+            const TEST_CMD_WITH_VALUES = {};
+            sinon.stub(profileHelper, 'runtimeProfile').returns(TEST_PROFILE);
+            sinon.stub(path, 'join').returns('fooPath');
+            // call
+            instance.handle(TEST_CMD_WITH_VALUES, (err) => {
+                // verify
+                expect(err.message)
+                    .equal('File fooPath not exists. If this is a skill project managed by v1 ask-cli, '
+                        + 'please run \'ask util upgrade-project\' then try the command again.');
+                done();
+            });
+        });
+
+        it('| unable to fetch skillId from resources config file', (done) => {
+            // setup
+            const TEST_CMD_WITH_VALUES = {};
+            sinon.stub(profileHelper, 'runtimeProfile').returns(TEST_PROFILE);
+            sinon.stub(path, 'join').returns(INVALID_RESOURCES_CONFIG_JSON_PATH);
+            // call
+            instance.handle(TEST_CMD_WITH_VALUES, (err) => {
+                // verify
+                expect(err.message)
+                    .equal(`Failed to obtain skill-id for the given profile - ${TEST_PROFILE}. Please deploy you skill project first.`);
+                done();
+            });
+        });
+
+        it('| error while getting access token', (done) => {
+            // setup
+            sinon.stub(profileHelper, 'runtimeProfile').returns(TEST_PROFILE);
+            sinon.stub(path, 'join').returns(VALID_RESOURCES_CONFIG_JSON_PATH);
+            sinon.stub(ResourcesConfig.prototype, 'getSkillId').returns('TestSkillId');
+            sinon.stub(RunCommand.prototype, '_getAccessTokenForProfile').yields(new Error(TEST_ERROR));
+
+            // call
+            instance.handle(TEST_CMD, (err) => {
+                // verify
+                expect(errorStub.args[0][0].message).eq(TEST_ERROR);
+                expect(err.message).eq(TEST_ERROR);
+                done();
+            });
+        });
+
+        it('| error while getting debug flow', (done) => {
+            // setup
+            sinon.stub(profileHelper, 'runtimeProfile').returns(TEST_PROFILE);
+            sinon.stub(path, 'join').returns(VALID_RESOURCES_CONFIG_JSON_PATH);
+            sinon.stub(ResourcesConfig.prototype, 'getSkillId').returns('TestSkillId');
+            sinon.stub(RunCommand.prototype, '_getAccessTokenForProfile').yields(null, {});
+            sinon.stub(RunCommand.prototype, '_getSkillRunFlow').yields(new Error(TEST_ERROR));
+            // call
+            instance.handle(TEST_CMD, (err) => {
+                // verify
+                expect(errorStub.args[0][0].message).eq(TEST_ERROR);
+                expect(err.message).eq(TEST_ERROR);
+                done();
+            });
+        });
+    });
+    describe('_getSkillRunFlow test', () => {
+        let instance;
+
+        beforeEach(() => {
+            instance = new RunCommand(optionModel);
+        });
+
+        afterEach(() => {
+            sinon.restore();
+        });
+
+        describe('run flow for non-hosted skill', () => {
+            beforeEach(() => {
+                sinon.stub(ResourcesConfig.prototype, 'getSkillInfraType').returns(CONSTANTS.DEPLOYER_TYPE.CFN.NAME);
+            });
+            afterEach(() => {
+                sinon.restore();
+            });
+            it('| getSkillCodeFolderName error', (done) => {
+                sinon.stub(helper, 'getSkillCodeFolderName').throws(new Error(TEST_ERROR));
+
+                instance._getSkillRunFlow('fooSkillId', 'fooProfile', CONSTANTS.ALEXA.REGION.DEFAULT, false, false,
+                    false, CONSTANTS.RUN.DEFAULT_DEBUG_PORT, 'fooToken', CONSTANTS.ALEXA.REGION.NA, (err) => {
+                        // verify
+                        expect(err.message).eq(TEST_ERROR);
+                        done();
+                    });
+            });
+
+            it('| no user config', (done) => {
+                sinon.stub(helper, 'getSkillCodeFolderName').returns('fooSkillFolderName');
+                sinon.stub(ResourcesConfig.prototype, 'getSkillInfraUserConfig').returns(undefined);
+
+                instance._getSkillRunFlow('fooSkillId', 'fooProfile', CONSTANTS.ALEXA.REGION.DEFAULT, false, false,
+                    false, CONSTANTS.RUN.DEFAULT_DEBUG_PORT, 'fooToken', CONSTANTS.ALEXA.REGION.NA, (err) => {
+                        // verify
+                        expect(err.message).eq('Failed to obtain userConfig from project '
+                            + `resource file ${CONSTANTS.FILE_PATH.ASK_RESOURCES_JSON_CONFIG}`);
+                        done();
+                    });
+            });
+
+            it('| empty user config', (done) => {
+                sinon.stub(helper, 'getSkillCodeFolderName').returns('fooSkillFolderName');
+                sinon.stub(ResourcesConfig.prototype, 'getSkillInfraUserConfig').returns({});
+
+                instance._getSkillRunFlow('fooSkillId', 'fooProfile', CONSTANTS.ALEXA.REGION.DEFAULT, false, false,
+                    false, CONSTANTS.RUN.DEFAULT_DEBUG_PORT, 'fooToken', CONSTANTS.ALEXA.REGION.NA, (err) => {
+                        // verify
+                        expect(err.message).eq('Cannot read property \'includes\' of undefined');
+                        done();
+                    });
+            });
+
+            it('| error in getting skill flow instance', (done) => {
+                sinon.stub(helper, 'getSkillCodeFolderName').returns('fooSkillFolderName');
+                sinon.stub(ResourcesConfig.prototype, 'getSkillInfraUserConfig').returns({ runtime: CONSTANTS.RUNTIME.JAVA, handler: 'fooHandler' });
+                sinon.stub(helper, 'getSkillFlowInstance').throws(new Error(TEST_ERROR));
+
+                instance._getSkillRunFlow('fooSkillId', 'fooProfile', CONSTANTS.ALEXA.REGION.DEFAULT, false, false,
+                    false, CONSTANTS.RUN.DEFAULT_DEBUG_PORT, 'fooToken', CONSTANTS.ALEXA.REGION.NA, (err) => {
+                        // verify
+                        expect(err.message).eq(TEST_ERROR);
+                        done();
+                    });
+            });
+        });
+        describe('run flow for hosted skill', () => {
+            beforeEach(() => {
+                sinon.stub(ResourcesConfig.prototype, 'getSkillInfraType').returns(CONSTANTS.DEPLOYER_TYPE.HOSTED.NAME);
+            });
+
+            it('| error in getting hosted skill runtime', (done) => {
+                sinon.stub(RunCommand.prototype, '_getHostedSkillRuntime').yields(new Error(TEST_ERROR));
+
+                instance._getSkillRunFlow('fooSkillId', 'fooProfile', CONSTANTS.ALEXA.REGION.DEFAULT, false, false,
+                    false, CONSTANTS.RUN.DEFAULT_DEBUG_PORT, 'fooToken', CONSTANTS.ALEXA.REGION.NA, (err) => {
+                        // verify
+                        expect(err.message).eq(TEST_ERROR);
+                        done();
+                    });
+            });
+
+            it('| error in getting skill flow instance', (done) => {
+                sinon.stub(RunCommand.prototype, '_getHostedSkillRuntime').yields(null, 'fooRuntime');
+                sinon.stub(helper, 'getSkillFlowInstance').throws(new Error(TEST_ERROR));
+
+                instance._getSkillRunFlow('fooSkillId', 'fooProfile', CONSTANTS.ALEXA.REGION.DEFAULT, false, false,
+                    false, CONSTANTS.RUN.DEFAULT_DEBUG_PORT, 'fooToken', CONSTANTS.ALEXA.REGION.NA, (err) => {
+                        // verify
+                        expect(err.message).eq(TEST_ERROR);
+                        done();
+                    });
+            });
+        });
+    });
+
+    describe('_getHostedSkillRuntime test', () => {
+        let instance;
+
+        beforeEach(() => {
+            instance = new RunCommand(optionModel);
+        });
+        afterEach(() => {
+            sinon.restore();
+        });
+        const smapiClient = new SmapiClient({
+            TEST_PROFILE,
+            doDebug: false
+        });
+        it('| getAlexaHostedSkillMetadata error', (done) => {
+            sinon.stub(smapiClient.skill.alexaHosted, 'getAlexaHostedSkillMetadata').yields(new Error(TEST_ERROR));
+            instance._getHostedSkillRuntime(smapiClient, 'fooSkillId', (err) => {
+                expect(err.message).eq(TEST_ERROR);
+                done();
+            });
+        });
+
+        it('| getAlexaHostedSkillMetadata empty response', (done) => {
+            sinon.stub(smapiClient.skill.alexaHosted, 'getAlexaHostedSkillMetadata').yields(null, {});
+            instance._getHostedSkillRuntime(smapiClient, 'fooSkillId', (err) => {
+                expect(err.message).eq('Cannot read property \'alexaHosted\' of undefined');
+                done();
+            });
+        });
+
+        it('| getAlexaHostedSkillMetadata empty runtime value', (done) => {
+            sinon.stub(smapiClient.skill.alexaHosted, 'getAlexaHostedSkillMetadata').yields(null, {
+                body: {
+                    alexaHosted: {
+                        runtime: ''
+                    }
+                }
+            });
+            instance._getHostedSkillRuntime(smapiClient, 'fooSkillId', (err) => {
+                expect(err.message).eq('Unable to determine runtime of the hosted skill - fooSkillId');
+                done();
+            });
+        });
+    });
+});

--- a/test/unit/commands/run/run-flow/java-run-test.js
+++ b/test/unit/commands/run/run-flow/java-run-test.js
@@ -1,0 +1,43 @@
+const { expect } = require('chai');
+const JavaRunFlow = require('@src/commands/run/run-flow/java-run');
+const CONSTANTS = require('@src/utils/constants');
+
+describe('Java run flow test', () => {
+    const skillInvocationInfo = {
+        skillCodeFolderName: 'fooFolder',
+        handlerName: 'fooHandler'
+    };
+    it('| validate nodemon config, run mode', () => {
+        const runFlow = new JavaRunFlow({ skillInvocationInfo,
+            waitForAttach: false,
+            debugPort: CONSTANTS.RUN.DEFAULT_DEBUG_PORT,
+            token: 'fooToken',
+            skillId: 'fooSkill',
+            runRegion: CONSTANTS.ALEXA.REGION.NA,
+            watch: false });
+        const nodemonConfig = runFlow.getExecConfig();
+        expect(nodemonConfig.exec).eq('cd fooFolder;'
+            + ' mvn exec:exec -Dexec.executable=java '
+            + '-Dexec.args="-classpath %classpath com.amazon.ask.localdebug.LocalDebuggerInvoker '
+            + '--accessToken fooToken --skillId fooSkill --skillStreamHandlerClass fooHandler --region NA"');
+        expect(nodemonConfig.ext).eq('java, xml');
+        expect(nodemonConfig.watch).eq(false);
+    });
+    it('| validate nodemon config, debug mode, watch enabled', () => {
+        const runFlow = new JavaRunFlow({ skillInvocationInfo,
+            waitForAttach: true,
+            debugPort: CONSTANTS.RUN.DEFAULT_DEBUG_PORT,
+            token: 'fooToken',
+            skillId: 'fooSkill',
+            runRegion: CONSTANTS.ALEXA.REGION.NA,
+            watch: true });
+        const nodemonConfig = runFlow.getExecConfig();
+        expect(nodemonConfig.exec).eq('cd fooFolder; '
+            + 'mvn exec:exec -Dexec.executable=java '
+            + '-Dexec.args="-classpath %classpath -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5000 '
+            + 'com.amazon.ask.localdebug.LocalDebuggerInvoker --accessToken fooToken --skillId fooSkill '
+            + '--region NA --skillStreamHandlerClass fooHandler"');
+        expect(nodemonConfig.ext).eq('java, xml');
+        expect(nodemonConfig.watch).eq('fooFolder');
+    });
+});

--- a/test/unit/commands/run/run-flow/nodejs-run-test.js
+++ b/test/unit/commands/run/run-flow/nodejs-run-test.js
@@ -1,0 +1,86 @@
+const { expect } = require('chai');
+const path = require('path');
+const fs = require('fs');
+const sinon = require('sinon');
+const NodejsRunFlow = require('@src/commands/run/run-flow/nodejs-run');
+const CONSTANTS = require('@src/utils/constants');
+
+describe('Node run flow test', () => {
+    const skillInvocationInfo = {
+        skillCodeFolderName: 'fooFolder',
+        handlerName: 'fooHandler',
+        skillFileName: 'fooFileName'
+    };
+    afterEach(() => {
+        sinon.restore();
+    });
+    it('| validate nodemon config, run mode', () => {
+        sinon.stub(fs, 'existsSync').returns(true);
+        const runFlow = new NodejsRunFlow({ skillInvocationInfo,
+            waitForAttach: false,
+            debugPort: CONSTANTS.RUN.DEFAULT_DEBUG_PORT,
+            token: 'fooToken',
+            skillId: 'fooSkill',
+            runRegion: CONSTANTS.ALEXA.REGION.NA,
+            watch: false });
+        const nodemonConfig = runFlow.getExecConfig();
+        expect(nodemonConfig.execMap).eq(undefined);
+        expect(nodemonConfig.script).eq(path.join(process.cwd(), 'fooFolder', CONSTANTS.RUN.NODE.SCRIPT_LOCATION));
+        expect(nodemonConfig.args).to.deep.equal([
+            '--accessToken',
+            '"fooToken"',
+            '--skillId',
+            'fooSkill',
+            '--handlerName',
+            'fooHandler',
+            '--skillEntryFile',
+            path.join(process.cwd(), 'fooFolder', 'fooFileName.js'),
+            '--region',
+            CONSTANTS.ALEXA.REGION.NA
+        ]);
+        expect(nodemonConfig.watch).eq(false);
+    });
+    it('| validate nodemon config, debug mode, watch enabled', () => {
+        sinon.stub(fs, 'existsSync').returns(true);
+        const runFlow = new NodejsRunFlow({ skillInvocationInfo,
+            waitForAttach: true,
+            debugPort: CONSTANTS.RUN.DEFAULT_DEBUG_PORT,
+            token: 'fooToken',
+            skillId: 'fooSkill',
+            runRegion: CONSTANTS.ALEXA.REGION.NA,
+            watch: true });
+        const nodemonConfig = runFlow.getExecConfig();
+        expect(nodemonConfig.execMap).to.deep.equal({
+            js: `node --inspect-brk=${CONSTANTS.RUN.DEFAULT_DEBUG_PORT}`
+        });
+        expect(nodemonConfig.script).eq(path.join(process.cwd(), 'fooFolder', CONSTANTS.RUN.NODE.SCRIPT_LOCATION));
+        expect(nodemonConfig.args).to.deep.equal([
+            '--accessToken',
+            '"fooToken"',
+            '--skillId',
+            'fooSkill',
+            '--handlerName',
+            'fooHandler',
+            '--skillEntryFile',
+            path.join(process.cwd(), 'fooFolder', 'fooFileName.js'),
+            '--region',
+            CONSTANTS.ALEXA.REGION.NA
+        ]);
+        expect(nodemonConfig.watch).eq('fooFolder');
+    });
+    it('| ask-sdk-local-debug has not been installed', () => {
+        sinon.stub(fs, 'existsSync').returns(false);
+        try {
+            new NodejsRunFlow({ skillInvocationInfo,
+                waitForAttach: true,
+                debugPort: CONSTANTS.RUN.DEFAULT_DEBUG_PORT,
+                token: 'fooToken',
+                skillId: 'fooSkill',
+                runRegion: CONSTANTS.ALEXA.REGION.NA,
+                watch: true });
+        } catch (err) {
+            expect(err.message).eq('ask-sdk-local-debug cannot be found. Please install ask-sdk-local-debug to your skill code project. '
+                + 'Refer https://www.npmjs.com/package/ask-sdk-local-debug for more info.');
+        }
+    });
+});

--- a/test/unit/commands/run/run-flow/python-run-test.js
+++ b/test/unit/commands/run/run-flow/python-run-test.js
@@ -1,0 +1,111 @@
+const { expect } = require('chai');
+const path = require('path');
+const fs = require('fs');
+const sinon = require('sinon');
+const childProcess = require('child_process');
+const PythonRunFlow = require('@src/commands/run/run-flow/python-run');
+const CONSTANTS = require('@src/utils/constants');
+
+describe('Python run flow test', () => {
+    const skillPackagePath = 'fooPythonPath';
+    const pythonDebugPath = path.join(skillPackagePath, CONSTANTS.RUN.PYTHON.SCRIPT_LOCATION);
+    const skillInvocationInfo = {
+        skillCodeFolderName: 'fooFolder',
+        handlerName: 'fooHandler',
+        skillFileName: 'fooFileName'
+    };
+    beforeEach(() => {
+        sinon.stub(childProcess, 'execSync').withArgs('python3 -c "import site; import json; print(json.dumps(site.getsitepackages()))"')
+            .returns('')
+            .withArgs('python3 -m pip install debugpy', { stdio: 'inherit' })
+            .returns('');
+        sinon.stub(JSON, 'parse').returns([
+            skillPackagePath
+        ]);
+    });
+    afterEach(() => {
+        sinon.restore();
+    });
+    it('| validate nodemon config, run mode', () => {
+        sinon.stub(fs, 'existsSync').withArgs(skillPackagePath)
+            .returns(true)
+            .withArgs(pythonDebugPath)
+            .returns(true);
+        const runFlow = new PythonRunFlow({ skillInvocationInfo,
+            waitForAttach: false,
+            debugPort: CONSTANTS.RUN.DEFAULT_DEBUG_PORT,
+            token: 'fooToken',
+            skillId: 'fooSkill',
+            runRegion: CONSTANTS.ALEXA.REGION.NA,
+            watch: false });
+        const nodemonConfig = runFlow.getExecConfig();
+        expect(nodemonConfig.execMap).to.deep.equal({
+            py: 'python3'
+        });
+        expect(nodemonConfig.script).eq(pythonDebugPath);
+        expect(nodemonConfig.args).to.deep.equal([
+            '--accessToken',
+            '"fooToken"',
+            '--skillId',
+            'fooSkill',
+            '--skillHandler',
+            'fooHandler',
+            '--skillFilePath',
+            path.join('fooFolder', 'fooFileName.py'),
+            '--region',
+            CONSTANTS.ALEXA.REGION.NA
+        ]);
+        expect(nodemonConfig.watch).eq(false);
+        expect(nodemonConfig.ext).eq('py,json,txt');
+    });
+    it('| validate nodemon config, debug mode, watch enabled', () => {
+        sinon.stub(fs, 'existsSync').withArgs(skillPackagePath)
+            .returns(true)
+            .withArgs(pythonDebugPath)
+            .returns(true);
+        const runFlow = new PythonRunFlow({ skillInvocationInfo,
+            waitForAttach: true,
+            debugPort: CONSTANTS.RUN.DEFAULT_DEBUG_PORT,
+            token: 'fooToken',
+            skillId: 'fooSkill',
+            runRegion: CONSTANTS.ALEXA.REGION.NA,
+            watch: true });
+        const nodemonConfig = runFlow.getExecConfig();
+        expect(nodemonConfig.execMap).to.deep.equal({
+            py: `python3 -m debugpy --listen ${CONSTANTS.RUN.DEFAULT_DEBUG_PORT} --wait-for-client`
+        });
+        expect(nodemonConfig.script).eq(path.join('fooPythonPath', CONSTANTS.RUN.PYTHON.SCRIPT_LOCATION));
+        expect(nodemonConfig.args).to.deep.equal([
+            '--accessToken',
+            '"fooToken"',
+            '--skillId',
+            'fooSkill',
+            '--skillHandler',
+            'fooHandler',
+            '--skillFilePath',
+            path.join('fooFolder', 'fooFileName.py'),
+            '--region',
+            CONSTANTS.ALEXA.REGION.NA
+        ]);
+        expect(nodemonConfig.watch).eq('fooFolder');
+        expect(nodemonConfig.ext).eq('py,json,txt');
+    });
+    it('| ask-sdk-local-debug has not been installed', () => {
+        sinon.stub(fs, 'existsSync').withArgs(skillPackagePath)
+            .returns(true)
+            .withArgs(pythonDebugPath)
+            .returns(false);
+        try {
+            new PythonRunFlow({ skillInvocationInfo,
+                waitForAttach: true,
+                debugPort: CONSTANTS.RUN.DEFAULT_DEBUG_PORT,
+                token: 'fooToken',
+                skillId: 'fooSkill',
+                runRegion: CONSTANTS.ALEXA.REGION.NA,
+                watch: true });
+        } catch (err) {
+            expect(err.message).eq('ask-sdk-local-debug cannot be found. Please install ask-sdk-local-debug to your skill code project. '
+                + 'Refer https://pypi.org/project/ask-sdk-local-debug, for more info.');
+        }
+    });
+});

--- a/test/unit/run-test.js
+++ b/test/unit/run-test.js
@@ -124,6 +124,12 @@ process.env.ASK_SHARE_USAGE = false;
     '@test/unit/utils/hash-utils-test',
     '@test/unit/utils/retry-utility-test',
     '@test/unit/utils/local-host-server-test',
+    // command - run
+    '@test/unit/commands/run/index-test',
+    '@test/unit/commands/run/helper-test',
+    '@test/unit/commands/run/run-flow/java-run-test',
+    '@test/unit/commands/run/run-flow/nodejs-run-test',
+    '@test/unit/commands/run/run-flow/python-run-test'
 ].forEach((testFile) => {
     // eslint-disable-next-line global-require
     require(testFile);


### PR DESCRIPTION
*Adding support to initiate local debugging process from the ASK CLI. *

1. Functionality will be support for Node, Python and Java skills.  Support for both hosted and non-hosted skill variant are provided. Works for non-hosted skills as long as the `ask-resources.json` contains the necessary info - skill id, skill code folder, runtime and handler name.

2. The feature also comes equipped with nodemon that restarts the debugging process when files in the workspace are modified. This is available for all 3 languages.

3. The user will be expected to add the `ask-sdk-local-debug` dependencies on to their skill code.

4. For Python, inorder to support attachment on an inspector, a debugger provided by microsoft - [`debugpy`](https://github.com/microsoft/debugpy) is used. 

**Using the command**
 
The command is called `debug` (Subject to change).

The command accepts the following 5 optional params
1. `skill-id` - The user can choose to supply the skill Id. Otherwise the info is obtained from the `ask-resources.json`.
2. `profile` - The user can choose to supply the profile name. Default is `default`.
3. `debug-port` - The user can choose to supply the debug port, if they wanted to attach an inspector. Default port is 5000.
4. `wait-for-attach` - Boolean flag that the user can set if they wanted the debug process to wait till an inspector is attached.
5. `skillCodeRegion` - The skill code region for which the skill code folder will be fetched from the `ask-resources.json`.  Default is `default`.

The command can be run in 2 modes
1. Run as a process.
2. Run as a process and debug using an inspector.

Ran sanity tests on Hosted skills in python and node runtime in both the modes.

Ran sanity tests on Nonhosted skills type in python, node and java in both the modes.
