### PR TITLE
fix: display all property when printing error

### DIFF
--- a/lib/view/json-view.js
+++ b/lib/view/json-view.js
@@ -13,7 +13,7 @@ function toString(jsonObject) {
     try {
         // handle issue when Error object serialized to {}
         if (jsonObject instanceof Error) {
-            jsonObject = { message: jsonObject.message, stack: jsonObject.stack };
+            jsonObject = { message: jsonObject.message, stack: jsonObject.stack, detail: jsonObject };
         }
         return JSON.stringify(jsonObject, null, CONSTANTS.CONFIGURATION.JSON_DISPLAY_INDENT);
     } catch (e) {


### PR DESCRIPTION
Fixing issue when some of the error properties are not shown when outputting error to console.

example 
`ask smapi update-skill-manifest -s amzn1.ask.skill.fcb348d9-a177-4891-8e43-5a10d30e3e38 -g development --manifest file:TestSkill.json `

TestSkill.json has properties that violate server side validation.

Before

```
[Error]: {
  "message": "Server cannot process the request due to a client error.",
  "stack": "ServiceError: Server cannot process the request due to a client error.\n    at SkillManagementServiceClient.<anonymous> (/Users/kakuri/Git/ask-cli-v2/node_modules/ask-sdk-model-runtime/dist/index.js:335:31)\n    at step (/Users/kakuri/Git/ask-cli-v2/node_modules/ask-sdk-model-runtime/dist/index.js:58:23)\n    at Object.next (/Users/kakuri/Git/ask-cli-v2/node_modules/ask-sdk-model-runtime/dist/index.js:39:53)\n    at fulfilled (/Users/kakuri/Git/ask-cli-v2/node_modules/ask-sdk-model-runtime/dist/index.js:30:58)\n    at processTicksAndRejections (internal/process/task_queues.js:94:5)"
}
```

After

```
[Error]: {
  "message": "Server cannot process the request due to a client error.",
  "stack": "ServiceError: Server cannot process the request due to a client error.\n    at SkillManagementServiceClient.<anonymous> (/Users/kakuri/Git/ask-cli-v2/node_modules/ask-sdk-model-runtime/dist/index.js:335:31)\n    at step (/Users/kakuri/Git/ask-cli-v2/node_modules/ask-sdk-model-runtime/dist/index.js:58:23)\n    at Object.next (/Users/kakuri/Git/ask-cli-v2/node_modules/ask-sdk-model-runtime/dist/index.js:39:53)\n    at fulfilled (/Users/kakuri/Git/ask-cli-v2/node_modules/ask-sdk-model-runtime/dist/index.js:30:58)\n    at processTicksAndRejections (internal/process/task_queues.js:94:5)",
  "detail": {
    "name": "ServiceError",
    "statusCode": 400,
    "headers": [
      {
        "key": "content-type",
        "value": "application/json"
      },
.....
    ],
    "response": {
      "message": "Skill manifest is not valid.",
      "violations": [
        {
          "code": "INVALID_DATA_TYPE",
          "message": "Instance at property path \"$.manifest.apis.smartHome.protocolVersion\" of type \"integer\" does not match any allowed primitive types [\"string\"].",
          "validationDetails": {
            "allowedDataTypes": [
              "string"
            ],
            "originalInstance": {
              "dataType": "integer",
              "propertyPath": "$.manifest.apis.smartHome.protocolVersion",
              "type": "BODY"
            }
          }
        },
        {
          "code": "INVALID_ENUM_VALUE",
          "message": "String instance at property path \"$.manifest.apis.smartHome.protocolVersion\" has invalid enum value: \"3\". Please refer to public documentation for the list of allowed values.",
          "validationDetails": {
            "originalInstance": {
              "dataType": "string",
              "propertyPath": "$.manifest.apis.smartHome.protocolVersion",
              "type": "BODY",
              "value": "3"
            }
          }
        },
        {
          "code": "INVALID_DATA_TYPE",
          "message": "Instance at property path \"$.manifest.publishingInformation.isAvailableWorldwide\" of type \"string\" does not match any allowed primitive types [\"boolean\"].",
          "validationDetails": {
            "allowedDataTypes": [
              "boolean"
            ],
            "originalInstance": {
              "dataType": "string",
              "propertyPath": "$.manifest.publishingInformation.isAvailableWorldwide",
              "type": "BODY"
            }
          }
        }
      ]
    }
  
```