### PR TITLE
fix: not overwrite custom url in manifest with lambda arn

### DIFF
--- a/lib/controllers/skill-infrastructure-controller/index.js
+++ b/lib/controllers/skill-infrastructure-controller/index.js
@@ -10,6 +10,7 @@ const hashUtils = require('@src/utils/hash-utils');
 const stringUtils = require('@src/utils/string-utils');
 const SpinnerView = require('@src/view/spinner-view');
 const profileHelper = require('@src/utils/profile-helper');
+const urlUtils = require('@src/utils/url-utils');
 
 const DeployDelegate = require('./deploy-delegate');
 
@@ -143,7 +144,11 @@ module.exports = class SkillInfrastructureController {
         // 1.update local skill.json file: update the "uri" in all the existing "apis" for each region
         R.keys(Manifest.getInstance().getApis()).forEach((domain) => {
             R.keys(rawDeployResult).forEach((region) => {
-                Manifest.getInstance().setApisEndpointByDomainRegion(domain, region, rawDeployResult[region].endpoint);
+                const endpoint = Manifest.getInstance().getApisEndpointByDomainRegion(domain, region);
+                const uri = R.path(['uri'], endpoint);
+                if (!uri || urlUtils.isLambdaArn(uri)) {
+                    Manifest.getInstance().setApisEndpointByDomainRegion(domain, region, rawDeployResult[region].endpoint);
+                }
             });
         });
         Manifest.getInstance().write();

--- a/test/unit/controller/skill-infrastructure-controller-test.js
+++ b/test/unit/controller/skill-infrastructure-controller-test.js
@@ -308,15 +308,17 @@ describe('Controller test - skill infrastructure controller test', () => {
     });
 
     describe('# test class method: updateSkillManifestWithDeployResult', () => {
+        const testUrl1 = 'arn:aws:lambda:us-east-1:200074948102:function:test';
+        const testUrl2 = 'TEST_URL2';
         const TEST_DEPLOY_RESULT = {
             default: {
                 endpoint: {
-                    url: 'TEST_URL1'
+                    uri: testUrl1
                 }
             },
             EU: {
                 endpoint: {
-                    url: 'TEST_URL2'
+                    uri: testUrl2
                 }
             }
         };
@@ -344,8 +346,8 @@ describe('Controller test - skill infrastructure controller test', () => {
                 expect(res).equal(undefined);
                 expect(err).equal('hash error');
                 expect(hashUtils.getHash.args[0][0]).equal(ResourcesConfig.getInstance().getSkillMetaSrc(TEST_PROFILE));
-                expect(Manifest.getInstance().getApisEndpointByDomainRegion('custom', 'default').url).equal('TEST_URL1');
-                expect(Manifest.getInstance().getApisEndpointByDomainRegion('custom', 'EU').url).equal('TEST_URL2');
+                expect(Manifest.getInstance().getApisEndpointByDomainRegion('custom', 'default').uri).equal(testUrl1);
+                expect(Manifest.getInstance().getApisEndpointByDomainRegion('custom', 'EU').uri).equal(testUrl2);
                 done();
             });
         });
@@ -360,8 +362,8 @@ describe('Controller test - skill infrastructure controller test', () => {
                 // verify
                 expect(res).equal(undefined);
                 expect(err).equal(undefined);
-                expect(Manifest.getInstance().getApisEndpointByDomainRegion('custom', 'default').url).equal('TEST_URL1');
-                expect(Manifest.getInstance().getApisEndpointByDomainRegion('custom', 'EU').url).equal('TEST_URL2');
+                expect(Manifest.getInstance().getApisEndpointByDomainRegion('custom', 'default').uri).equal(testUrl1);
+                expect(Manifest.getInstance().getApisEndpointByDomainRegion('custom', 'EU').uri).equal(testUrl2);
                 done();
             });
         });
@@ -376,14 +378,15 @@ describe('Controller test - skill infrastructure controller test', () => {
                 // verify
                 expect(res).equal(undefined);
                 expect(err).equal('update error');
-                expect(Manifest.getInstance().getApisEndpointByDomainRegion('custom', 'default').url).equal('TEST_URL1');
-                expect(Manifest.getInstance().getApisEndpointByDomainRegion('custom', 'EU').url).equal('TEST_URL2');
+                expect(Manifest.getInstance().getApisEndpointByDomainRegion('custom', 'default').uri).equal(testUrl1);
+                expect(Manifest.getInstance().getApisEndpointByDomainRegion('custom', 'EU').uri).equal(testUrl2);
                 done();
             });
         });
 
         it('| manifest update correctly, expect success message and new hash set', (done) => {
             // setup
+            const setEndpointSpy = sinon.spy(Manifest.prototype, 'setApisEndpointByDomainRegion');
             sinon.stub(AuthorizationController.prototype, 'tokenRefreshAndRead').callsArgWith(1);
             sinon.stub(hashUtils, 'getHash').callsArgWith(1, null, 'TEST_HASH');
             sinon.stub(SkillInfrastructureController.prototype, '_ensureSkillManifestGotUpdated').callsArgWith(0);
@@ -392,8 +395,10 @@ describe('Controller test - skill infrastructure controller test', () => {
                 // verify
                 expect(res).equal(undefined);
                 expect(err).equal(undefined);
-                expect(Manifest.getInstance().getApisEndpointByDomainRegion('custom', 'default').url).equal('TEST_URL1');
-                expect(Manifest.getInstance().getApisEndpointByDomainRegion('custom', 'EU').url).equal('TEST_URL2');
+                expect(setEndpointSpy.callCount).equal(1);
+                expect(setEndpointSpy.args[0][2].uri).equal(testUrl1);
+                expect(Manifest.getInstance().getApisEndpointByDomainRegion('custom', 'default').uri).equal(testUrl1);
+                expect(Manifest.getInstance().getApisEndpointByDomainRegion('custom', 'EU').uri).equal(testUrl2);
                 expect(ResourcesConfig.getInstance().getSkillMetaLastDeployHash(TEST_PROFILE)).equal('TEST_HASH');
                 done();
             });

--- a/test/unit/fixture/model/manifest.json
+++ b/test/unit/fixture/model/manifest.json
@@ -39,7 +39,7 @@
     "apis": {
       "custom": {
         "endpoint": {
-          "url": "TEST_URL1"
+          "uri": "arn:aws:lambda:us-east-1:200074948102:function:test"
         },
         "interfaces": [
           {
@@ -49,7 +49,7 @@
         "regions": {
           "EU": {
             "endpoint": {
-              "url": "TEST_URL2"
+              "uri": "TEST_URL2"
             }
           }
         }

--- a/test/unit/model/manifest-test.js
+++ b/test/unit/model/manifest-test.js
@@ -138,7 +138,7 @@ describe('Model test - manifest file test', () => {
                 oldValue: {
                     custom: {
                         endpoint: {
-                            url: 'TEST_URL1'
+                            uri: 'arn:aws:lambda:us-east-1:200074948102:function:test'
                         },
                         interfaces: [{
                             type: 'VIDEO_APP'
@@ -146,7 +146,7 @@ describe('Model test - manifest file test', () => {
                         regions: {
                             EU: {
                                 endpoint: {
-                                    url: 'TEST_URL2'
+                                    uri: 'TEST_URL2'
                                 }
                             }
                         }
@@ -159,7 +159,7 @@ describe('Model test - manifest file test', () => {
                 newValue: 'apisDomain new',
                 oldValue: {
                     endpoint: {
-                        url: 'TEST_URL1'
+                        uri: 'arn:aws:lambda:us-east-1:200074948102:function:test'
                     },
                     interfaces: [{
                         type: 'VIDEO_APP'
@@ -167,7 +167,7 @@ describe('Model test - manifest file test', () => {
                     regions: {
                         EU: {
                             endpoint: {
-                                url: 'TEST_URL2'
+                                uri: 'TEST_URL2'
                             }
                         }
                     }
@@ -178,7 +178,7 @@ describe('Model test - manifest file test', () => {
                 input: ['custom', 'default'],
                 newValue: 'endpoint new default',
                 oldValue: {
-                    url: 'TEST_URL1'
+                    uri: 'arn:aws:lambda:us-east-1:200074948102:function:test'
                 }
             },
             {
@@ -186,7 +186,7 @@ describe('Model test - manifest file test', () => {
                 input: ['custom', 'EU'],
                 newValue: 'endpoint new EU',
                 oldValue: {
-                    url: 'TEST_URL2'
+                    uri: 'TEST_URL2'
                 }
             }
         ].forEach(({


### PR DESCRIPTION
Fixing issue https://github.com/alexa/ask-cli/issues/215

**Change**
If existing uri in skill.json not lambda arn, we will not update it since it is a custom uri.

**Testing**

Tested by creating and deploying skill with following skill.json

```
...
"apis": {
      "smartHome": {
        "endpoint": {
          "uri": "arn:aws:lambda:us-east-1:200074948102:function:ask-skill-sample-nodejs-he-default-default-1605287625952"
        }
      },
      "custom": {
        "endpoint": {
          "sslCertificateType": "Trusted",
          "uri": "https://api.domain.com"
        }
      }
    }
...
```


