### PR TITLE
feat: add reuseEndpointForEvents flag to ask resources

### DIFF
--- a/docs/concepts/Alexa-Skill-Project-Definition.md
+++ b/docs/concepts/Alexa-Skill-Project-Definition.md
@@ -59,6 +59,7 @@ Below shows the example how CLI tracks user's config and the deployment states, 
           "runtime": "{lambdaRuntime}",
           "handler": "{lambdaHandler}",
           "templatePath": "stack.yaml",
+          "reuseEndpointForEvents": true, // sets events endpoint in the skill manifest to equal the skill main endpoint
           "artifactsS3": { // custom s3 configuration to upload skill build artifact (zip, jar,etc)
             "bucketName": "{bucketName}", // custom bucket name to store artifacts
             "bucketKey": "{bucketKey.zip}" // custom bucket object key

--- a/lib/controllers/skill-infrastructure-controller/index.js
+++ b/lib/controllers/skill-infrastructure-controller/index.js
@@ -146,6 +146,10 @@ module.exports = class SkillInfrastructureController {
                 Manifest.getInstance().setApisEndpointByDomainRegion(domain, region, rawDeployResult[region].endpoint);
             });
         });
+        const userConfig = ResourcesConfig.getInstance().getSkillInfraUserConfig(this.profile);
+
+        this._updateEventsEndpoint(userConfig, rawDeployResult.default.endpoint.uri);
+
         Manifest.getInstance().write();
         // 2.compare with current hash result to decide if skill.json file need to be updated
         // (the only possible change in skillMetaSrc during the infra deployment is the skill.json's uri change)
@@ -166,6 +170,17 @@ module.exports = class SkillInfrastructureController {
                 callback();
             });
         });
+    }
+
+    /**
+     * Updates event endpoint if reuseEndpointForEvents is true on user config
+     * @param {object} userConfig user config
+     * @param {String} uri events endpoint
+     */
+    _updateEventsEndpoint(userConfig, uri) {
+        if (userConfig.reuseEndpointForEvents) {
+            Manifest.getInstance().setEventEndpoint(uri);
+        }
     }
 
     /**

--- a/lib/model/manifest.js
+++ b/lib/model/manifest.js
@@ -76,6 +76,14 @@ module.exports = class Manifest extends ConfigFile {
         this.setProperty(['manifest', 'apis', domain], domainObject);
     }
 
+    getEventEndpoint() {
+        return this.getProperty(['manifest', 'events', 'endpoint', 'uri']);
+    }
+
+    setEventEndpoint(uri) {
+        this.setProperty(['manifest', 'events', 'endpoint', 'uri'], uri);
+    }
+
     getApisEndpointByDomainRegion(domain, region) {
         if (region === 'default') {
             return this.getProperty(['manifest', 'apis', domain, 'endpoint']);

--- a/test/unit/controller/skill-infrastructure-controller-test.js
+++ b/test/unit/controller/skill-infrastructure-controller-test.js
@@ -325,7 +325,7 @@ describe('Controller test - skill infrastructure controller test', () => {
         beforeEach(() => {
             new ResourcesConfig(FIXTURE_RESOURCES_CONFIG_FILE_PATH);
             new Manifest(FIXTURE_MANIFEST_FILE_PATH);
-            sinon.stub(fs, 'writeFileSync');
+            sinon.stub(fse, 'writeFileSync');
         });
 
         afterEach(() => {
@@ -517,6 +517,36 @@ describe('Controller test - skill infrastructure controller test', () => {
                 });
                 done();
             });
+        });
+    });
+    describe('# test class method: _updateEventsEndpoint', () => {
+        const lambdaUrl = 'arn:aws:lambda:us-east-1:200074948102:function';
+        let skillInfraController;
+        let setEventEndpointSpy;
+        beforeEach(() => {
+            new Manifest(FIXTURE_MANIFEST_FILE_PATH);
+            skillInfraController = new SkillInfrastructureController(TEST_CONFIGURATION);
+            setEventEndpointSpy = sinon.spy(Manifest.prototype, 'setEventEndpoint');
+        });
+
+        afterEach(() => {
+            sinon.restore();
+        });
+
+        it('| should update events endpoint', () => {
+            const userConfig = { reuseEndpointForEvents: true };
+
+            skillInfraController._updateEventsEndpoint(userConfig, lambdaUrl);
+
+            expect(setEventEndpointSpy.callCount).eq(1);
+        });
+
+        it('| should not update events endpoint', () => {
+            const userConfig = { };
+
+            skillInfraController._updateEventsEndpoint(userConfig, lambdaUrl);
+
+            expect(setEventEndpointSpy.callCount).eq(0);
         });
     });
 

--- a/test/unit/fixture/model/manifest.json
+++ b/test/unit/fixture/model/manifest.json
@@ -55,6 +55,11 @@
         }
       }
     },
+    "events": {
+      "endpoint": {
+        "uri": "TEST_EVENT_URL"
+      }
+    },
     "manifestVersion": "1.0"
   }
 }

--- a/test/unit/fixture/model/regular-proj/ask-resources.json
+++ b/test/unit/fixture/model/regular-proj/ask-resources.json
@@ -22,6 +22,7 @@
           "runtime": "nodejs10.x",
           "handler": "index.handler",
           "template": "./awsStacks/skill-infra.yaml",
+          "reuseEndpointForEvents": true,
           "regionOverrides": {
             "NA": {
               "awsRegion": "us-east-1",

--- a/test/unit/model/manifest-test.js
+++ b/test/unit/model/manifest-test.js
@@ -174,6 +174,12 @@ describe('Model test - manifest file test', () => {
                 }
             },
             {
+                field: 'EventEndpoint',
+                input: [],
+                newValue: 'TEST_EVENT_URL2',
+                oldValue: 'TEST_EVENT_URL'
+            },
+            {
                 field: 'ApisEndpointByDomainRegion',
                 input: ['custom', 'default'],
                 newValue: 'endpoint new default',


### PR DESCRIPTION
add reuseEndpointForEvents flag to ask resources. When the flag is present then the endpoint for the skill also set to be the endpoint for events.
