### PR TITLE
feat: add targetEndpoint property to ask-resources.json

### DIFF
--- a/docs/concepts/Alexa-Skill-Project-Definition.md
+++ b/docs/concepts/Alexa-Skill-Project-Definition.md
@@ -59,6 +59,7 @@ Below shows the example how CLI tracks user's config and the deployment states, 
           "runtime": "{lambdaRuntime}",
           "handler": "{lambdaHandler}",
           "templatePath": "stack.yaml",
+          "targetEndpoint": ["alexaForBusiness", "custom", "flashBriefing", "health", "householdList", "music", "smartHome", "video", "events"], // set the targetEndpoint with the value(s) from https://developer.amazon.com/en-US/docs/alexa/smapi/skill-manifest.html#api-enumeration or events to target events endpoint. Defaults to api endpoints from skill manifest if not specified.
           "artifactsS3": { // custom s3 configuration to upload skill build artifact (zip, jar,etc)
             "bucketName": "{bucketName}", // custom bucket name to store artifacts
             "bucketKey": "{bucketKey.zip}" // custom bucket object key

--- a/lib/builtins/deploy-delegates/cfn-deployer/assets/basic-lambda.yaml
+++ b/lib/builtins/deploy-delegates/cfn-deployer/assets/basic-lambda.yaml
@@ -54,6 +54,13 @@ Resources:
       FunctionName: !GetAtt AlexaSkillFunction.Arn
       Principal: alexa-appkit.amazon.com
       EventSourceToken: !Ref SkillId
+  AlexaSkillFunctionEventPermissionSmartHome:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:invokeFunction
+      FunctionName: !GetAtt AlexaSkillFunction.Arn
+      Principal: alexa-connectedhome.amazon.com
+      EventSourceToken: !Ref SkillId
   AlexaSkillFunctionLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:

--- a/lib/builtins/deploy-delegates/lambda-deployer/helper.js
+++ b/lib/builtins/deploy-delegates/lambda-deployer/helper.js
@@ -6,6 +6,7 @@ const CONSTANTS = require('@src/utils/constants');
 const IAMClient = require('@src/clients/aws-client/iam-client');
 const LambdaClient = require('@src/clients/aws-client/lambda-client');
 const Manifest = require('@src/model/manifest');
+const ResourcesConfig = require('@src/model/resources-config');
 const retryUtils = require('@src/utils/retry-utility');
 const stringUtils = require('@src/utils/string-utils');
 
@@ -194,7 +195,7 @@ function _createLambdaFunction(reporter, lambdaClient, options, callback) {
         }
         const arn = lambdaData.FunctionArn;
         // 2. Grant permissions to use a Lambda function
-        _addEventPermissions(lambdaClient, skillId, arn, (addErr) => {
+        _addEventPermissions(lambdaClient, skillId, arn, profile, (addErr) => {
             if (addErr) {
                 return callback(addErr);
             }
@@ -217,11 +218,11 @@ function _createLambdaFunction(reporter, lambdaClient, options, callback) {
     });
 }
 
-function _addEventPermissions(lambdaClient, skillId, functionArn, callback) {
-    // TODO: to move Manifest outside the deployer logic
-    const domainInfo = Manifest.getInstance().getApis();
-    const domainList = R.keys(domainInfo);
-    async.forEach(domainList, (domain, addCallback) => {
+function _addEventPermissions(lambdaClient, skillId, functionArn, profile, callback) {
+    const targetEndpoints = ResourcesConfig.getInstance().getTargetEndpoints(profile);
+    // for backward compatibility, defaulting to api from skill manifest if targetEndpoints is not defined
+    const domains = targetEndpoints.length ? targetEndpoints : Object.keys(Manifest.getInstance().getApis());
+    async.forEach(domains, (domain, addCallback) => {
         lambdaClient.addAlexaPermissionByDomain(domain, skillId, functionArn, (err) => {
             if (err) {
                 return addCallback(err);

--- a/lib/clients/aws-client/lambda-client.js
+++ b/lib/clients/aws-client/lambda-client.js
@@ -47,6 +47,8 @@ module.exports = class LambdaClient extends AbstractAwsClient {
      */
     addAlexaPermissionByDomain(domain, skillId, functionArn, callback) {
         const params = this._getDomainPermission(domain);
+        if (!params) return callback();
+
         params.FunctionName = functionArn;
         params.EventSourceToken = skillId;
         this.client.addPermission(params, (err, data) => {

--- a/lib/controllers/skill-infrastructure-controller/index.js
+++ b/lib/controllers/skill-infrastructure-controller/index.js
@@ -140,12 +140,20 @@ module.exports = class SkillInfrastructureController {
      * @param {Function} callback (error)
      */
     updateSkillManifestWithDeployResult(rawDeployResult, callback) {
-        // 1.update local skill.json file: update the "uri" in all the existing "apis" for each region
-        R.keys(Manifest.getInstance().getApis()).forEach((domain) => {
+        const targetEndpoints = ResourcesConfig.getInstance().getTargetEndpoints(this.profile);
+        // for backward compatibility, defaulting to api from skill manifest if targetEndpoints is not defined
+        const domains = targetEndpoints.length ? targetEndpoints : Object.keys(Manifest.getInstance().getApis());
+        // 1.update local skill.json file: update the "uri" in all target endpoints for each region
+        domains.forEach((domain) => {
             R.keys(rawDeployResult).forEach((region) => {
-                Manifest.getInstance().setApisEndpointByDomainRegion(domain, region, rawDeployResult[region].endpoint);
+                if (domain === Manifest.endpointTypes.EVENTS) {
+                    Manifest.getInstance().setEventsEndpointByRegion(region, rawDeployResult[region].endpoint);
+                } else {
+                    Manifest.getInstance().setApisEndpointByDomainRegion(domain, region, rawDeployResult[region].endpoint);
+                }
             });
         });
+
         Manifest.getInstance().write();
         // 2.compare with current hash result to decide if skill.json file need to be updated
         // (the only possible change in skillMetaSrc during the infra deployment is the skill.json's uri change)

--- a/lib/model/manifest.js
+++ b/lib/model/manifest.js
@@ -27,6 +27,13 @@ module.exports = class Manifest extends ConfigFile {
         instance = null;
     }
 
+    static get endpointTypes() {
+        return {
+            EVENTS: 'events',
+            APIS: 'apis'
+        };
+    }
+
     /**
      * Skill name is decided by en-US locale's name or the first locale's name if en-US doesn't exist
      */
@@ -61,33 +68,48 @@ module.exports = class Manifest extends ConfigFile {
     }
 
     getApis() {
-        return this.getProperty(['manifest', 'apis']);
+        return this.getProperty(['manifest', Manifest.endpointTypes.APIS]);
     }
 
     setApis(apisObject) {
-        this.setProperty(['manifest', 'apis'], apisObject);
+        this.setProperty(['manifest', Manifest.endpointTypes.APIS], apisObject);
     }
 
     getApisDomain(domain) {
-        return this.getProperty(['manifest', 'apis', domain]);
+        return this.getProperty(['manifest', Manifest.endpointTypes.APIS, domain]);
     }
 
     setApisDomain(domain, domainObject) {
-        this.setProperty(['manifest', 'apis', domain], domainObject);
+        this.setProperty(['manifest', Manifest.endpointTypes.APIS, domain], domainObject);
+    }
+
+    getEventsEndpointByRegion(region) {
+        if (region === 'default') {
+            return this.getProperty(['manifest', Manifest.endpointTypes.EVENTS, 'endpoint']);
+        }
+        return this.getProperty(['manifest', Manifest.endpointTypes.EVENTS, 'regions', region, 'endpoint']);
+    }
+
+    setEventsEndpointByRegion(region, endpointObj) {
+        if (region === 'default') {
+            this.setProperty(['manifest', Manifest.endpointTypes.EVENTS, 'endpoint'], endpointObj);
+        } else {
+            this.setProperty(['manifest', Manifest.endpointTypes.EVENTS, 'regions', region, 'endpoint'], endpointObj);
+        }
     }
 
     getApisEndpointByDomainRegion(domain, region) {
         if (region === 'default') {
-            return this.getProperty(['manifest', 'apis', domain, 'endpoint']);
+            return this.getProperty(['manifest', Manifest.endpointTypes.APIS, domain, 'endpoint']);
         }
-        return this.getProperty(['manifest', 'apis', domain, 'regions', region, 'endpoint']);
+        return this.getProperty(['manifest', Manifest.endpointTypes.APIS, domain, 'regions', region, 'endpoint']);
     }
 
     setApisEndpointByDomainRegion(domain, region, endpointObj) {
         if (region === 'default') {
-            this.setProperty(['manifest', 'apis', domain, 'endpoint'], endpointObj);
+            this.setProperty(['manifest', Manifest.endpointTypes.APIS, domain, 'endpoint'], endpointObj);
         } else {
-            this.setProperty(['manifest', 'apis', domain, 'regions', region, 'endpoint'], endpointObj);
+            this.setProperty(['manifest', Manifest.endpointTypes.APIS, domain, 'regions', region, 'endpoint'], endpointObj);
         }
     }
 };

--- a/lib/model/resources-config/ask-resources.js
+++ b/lib/model/resources-config/ask-resources.js
@@ -85,6 +85,10 @@ module.exports = class AskResources extends ConfigFile {
     setSkillInfraUserConfig(profile, userConfig) {
         this.setProperty(['profiles', profile, 'skillInfrastructure', 'userConfig'], userConfig);
     }
+
+    getTargetEndpoint(profile) {
+        return this.getProperty(['profiles', profile, 'skillInfrastructure', 'userConfig', 'targetEndpoint']) || [];
+    }
 };
 
 module.exports.BASE = BASE;

--- a/lib/model/resources-config/index.js
+++ b/lib/model/resources-config/index.js
@@ -113,6 +113,10 @@ module.exports = class ResourcesConfig {
         return AskStates.getInstance().getCodeBuildByRegion(this.projectRootPath, codeSrc);
     }
 
+    getTargetEndpoints(profile) {
+        return AskResources.getInstance().getTargetEndpoint(profile);
+    }
+
     // Group for the "skillInfrastructure"
     getSkillInfraType(profile) {
         return AskResources.getInstance().getSkillInfraType(profile);

--- a/test/unit/clients/aws-client/lambda-client-test.js
+++ b/test/unit/clients/aws-client/lambda-client-test.js
@@ -132,6 +132,18 @@ describe('Clients test - lambda client test', () => {
                 done();
             });
         });
+
+        it('| iamClient add Alexa permission by domain no permission needed for domain, expect undefined return.', (done) => {
+            // setup
+            const lambdaClient = new LambdaClient(TEST_CONFIGURATION);
+            const TEST_DOMAIN = 'non-existing';
+            // call
+            lambdaClient.addAlexaPermissionByDomain(TEST_DOMAIN, TEST_SKILL_ID, TEST_FUNCTION_ARN, (err) => {
+                // verify
+                expect(err).equal(undefined);
+                done();
+            });
+        });
     });
 
     describe('# function getFunction tests', () => {

--- a/test/unit/controller/skill-infrastructure-controller-test.js
+++ b/test/unit/controller/skill-infrastructure-controller-test.js
@@ -325,7 +325,7 @@ describe('Controller test - skill infrastructure controller test', () => {
         beforeEach(() => {
             new ResourcesConfig(FIXTURE_RESOURCES_CONFIG_FILE_PATH);
             new Manifest(FIXTURE_MANIFEST_FILE_PATH);
-            sinon.stub(fs, 'writeFileSync');
+            sinon.stub(fse, 'writeFileSync');
         });
 
         afterEach(() => {
@@ -387,11 +387,62 @@ describe('Controller test - skill infrastructure controller test', () => {
             sinon.stub(AuthorizationController.prototype, 'tokenRefreshAndRead').callsArgWith(1);
             sinon.stub(hashUtils, 'getHash').callsArgWith(1, null, 'TEST_HASH');
             sinon.stub(SkillInfrastructureController.prototype, '_ensureSkillManifestGotUpdated').callsArgWith(0);
+            const setEventsEndpointByRegionSpy = sinon.spy(Manifest.prototype, 'setEventsEndpointByRegion');
+            const setApisEndpointByDomainRegionSpy = sinon.spy(Manifest.prototype, 'setApisEndpointByDomainRegion');
+
             // call
             skillInfraController.updateSkillManifestWithDeployResult(TEST_DEPLOY_RESULT, (err, res) => {
                 // verify
                 expect(res).equal(undefined);
                 expect(err).equal(undefined);
+                expect(setEventsEndpointByRegionSpy.callCount).eq(2);
+                expect(setApisEndpointByDomainRegionSpy.callCount).eq(4);
+                expect(Manifest.getInstance().getApisEndpointByDomainRegion('custom', 'default').url).equal('TEST_URL1');
+                expect(Manifest.getInstance().getApisEndpointByDomainRegion('custom', 'EU').url).equal('TEST_URL2');
+                expect(ResourcesConfig.getInstance().getSkillMetaLastDeployHash(TEST_PROFILE)).equal('TEST_HASH');
+                done();
+            });
+        });
+
+        it('| manifest update correctly without events endpoint, expect success message and new hash set', (done) => {
+            // setup
+            sinon.stub(AuthorizationController.prototype, 'tokenRefreshAndRead').callsArgWith(1);
+            sinon.stub(hashUtils, 'getHash').callsArgWith(1, null, 'TEST_HASH');
+            sinon.stub(SkillInfrastructureController.prototype, '_ensureSkillManifestGotUpdated').callsArgWith(0);
+            sinon.stub(ResourcesConfig.prototype, 'getTargetEndpoints').returns(['custom', 'smartHome']);
+            const setEventsEndpointByRegionSpy = sinon.spy(Manifest.prototype, 'setEventsEndpointByRegion');
+            const setApisEndpointByDomainRegionSpy = sinon.spy(Manifest.prototype, 'setApisEndpointByDomainRegion');
+
+            // call
+            skillInfraController.updateSkillManifestWithDeployResult(TEST_DEPLOY_RESULT, (err, res) => {
+                // verify
+                expect(res).equal(undefined);
+                expect(err).equal(undefined);
+                expect(setEventsEndpointByRegionSpy.callCount).eq(0);
+                expect(setApisEndpointByDomainRegionSpy.callCount).eq(4);
+                expect(Manifest.getInstance().getApisEndpointByDomainRegion('custom', 'default').url).equal('TEST_URL1');
+                expect(Manifest.getInstance().getApisEndpointByDomainRegion('custom', 'EU').url).equal('TEST_URL2');
+                expect(ResourcesConfig.getInstance().getSkillMetaLastDeployHash(TEST_PROFILE)).equal('TEST_HASH');
+                done();
+            });
+        });
+
+        it('| manifest update when target endpoints is not set, expect success message and new hash set', (done) => {
+            // setup
+            sinon.stub(AuthorizationController.prototype, 'tokenRefreshAndRead').callsArgWith(1);
+            sinon.stub(hashUtils, 'getHash').callsArgWith(1, null, 'TEST_HASH');
+            sinon.stub(SkillInfrastructureController.prototype, '_ensureSkillManifestGotUpdated').callsArgWith(0);
+            sinon.stub(ResourcesConfig.prototype, 'getTargetEndpoints').returns([]);
+            const setEventsEndpointByRegionSpy = sinon.spy(Manifest.prototype, 'setEventsEndpointByRegion');
+            const setApisEndpointByDomainRegionSpy = sinon.spy(Manifest.prototype, 'setApisEndpointByDomainRegion');
+
+            // call
+            skillInfraController.updateSkillManifestWithDeployResult(TEST_DEPLOY_RESULT, (err, res) => {
+                // verify
+                expect(res).equal(undefined);
+                expect(err).equal(undefined);
+                expect(setEventsEndpointByRegionSpy.callCount).eq(0);
+                expect(setApisEndpointByDomainRegionSpy.callCount).eq(2);
                 expect(Manifest.getInstance().getApisEndpointByDomainRegion('custom', 'default').url).equal('TEST_URL1');
                 expect(Manifest.getInstance().getApisEndpointByDomainRegion('custom', 'EU').url).equal('TEST_URL2');
                 expect(ResourcesConfig.getInstance().getSkillMetaLastDeployHash(TEST_PROFILE)).equal('TEST_HASH');

--- a/test/unit/fixture/model/manifest.json
+++ b/test/unit/fixture/model/manifest.json
@@ -55,6 +55,11 @@
         }
       }
     },
+    "events": {
+      "endpoint": {
+        "uri": "TEST_EVENT_URL"
+      }
+    },
     "manifestVersion": "1.0"
   }
 }

--- a/test/unit/fixture/model/regular-proj/ask-resources-min.json
+++ b/test/unit/fixture/model/regular-proj/ask-resources-min.json
@@ -1,0 +1,23 @@
+{
+  "askcliResourcesobjectVersion": "1.0",
+  "profiles": {
+    "default": {
+      "skillMetadata": {
+        "src": "./skillPackage"
+      },
+      "code": {
+        "default": {
+          "src": "./awsStack/lambda-NA/src"
+        }
+      },
+      "skillInfrastructure": {
+        "type": "@ask-cli/cfn-deployer",
+        "userConfig": {
+          "runtime": "nodejs10.x",
+          "handler": "index.handler",
+          "template": "./awsStacks/skill-infra.yaml"
+        }
+      }
+    }
+  }
+}

--- a/test/unit/fixture/model/regular-proj/ask-resources.json
+++ b/test/unit/fixture/model/regular-proj/ask-resources.json
@@ -22,6 +22,11 @@
           "runtime": "nodejs10.x",
           "handler": "index.handler",
           "template": "./awsStacks/skill-infra.yaml",
+          "targetEndpoint": [
+            "custom",
+            "events",
+            "smartHome"
+          ],
           "regionOverrides": {
             "NA": {
               "awsRegion": "us-east-1",


### PR DESCRIPTION
add targetEndpoint property to ask-resources.json.

Tested with CFN and Lambda deployer. If lambda/skill already exists, the permission for new skill type (smart home for example) need to be added manually. If creating fresh, it should all work.

Test
"targetEndpoint": ["custom","smartHome", "events"]
CF Deployer
```
ask deploy
Deploy configuration loaded from ask-resources.json
Deploy project for profile [default]

==================== Deploy Skill Metadata ====================
[Warn]: The hash of current skill package folder does not change compared to the last deploy hash result, CLI will skip the deploy of skill package.
Skill ID: amzn1.ask.skill.4f5eecb6-1069-4bb4-9299-927f213c30fd

==================== Build Skill Code ====================
Skill code built successfully.
Code for region default built to /Users/kakuri/test/tend/tendcf/.ask/lambda/build.zip successfully with build flow NodeJsNpmBuildFlow.

==================== Deploy Skill Infrastructure ====================
  ✔ Deploy Alexa skill infrastructure for region "default"
Skill infrastructures deployed successfully through @ask-cli/cfn-deployer.

==================== Enable Skill ====================
[Warn]: CliWarn: Skill with multiple api domains cannot be enabled. Skip the enable process.
```

Lambda Deployer
```
ask deploy
Deploy configuration loaded from ask-resources.json
Deploy project for profile [default]

==================== Deploy Skill Metadata ====================
[Warn]: The hash of current skill package folder does not change compared to the last deploy hash result, CLI will skip the deploy of skill package.
Skill ID: amzn1.ask.skill.376ca5de-ad84-4e66-8f7e-e6d6b7401f36

==================== Build Skill Code ====================
Skill code built successfully.
Code for region default built to /Users/kakuri/test/tend/.ask/lambda/build.zip successfully with build flow NodeJsNpmBuildFlow.

==================== Deploy Skill Infrastructure ====================
  ✔ Deploy Alexa skill infrastructure for region "default"
Skill infrastructures deployed successfully through @ask-cli/lambda-deployer.

==================== Enable Skill ====================
[Warn]: CliWarn: Skill with multiple api domains cannot be enabled. Skip the enable process.
```

