### PR TITLE
chore: improve error message when config file is not found

### DIFF
--- a/lib/model/abstract-config-file.js
+++ b/lib/model/abstract-config-file.js
@@ -49,6 +49,7 @@ module.exports = class ConfigFile {
         this.path = filePath;
         this.content = null;
         this.fileType = null;
+        this.fileNotFoundHintMessage = '';
     }
 
     /**
@@ -104,7 +105,7 @@ module.exports = class ConfigFile {
     _validateFilePath() {
         // check existence
         if (!fs.existsSync(this.path)) {
-            throw new CliFileNotFoundError(`File ${this.path} not exists.`);
+            throw new CliFileNotFoundError(`File ${this.path} not exists.${this.fileNotFoundHintMessage}`);
         }
         // check access permission
         try {

--- a/lib/model/resources-config/ask-resources.js
+++ b/lib/model/resources-config/ask-resources.js
@@ -8,6 +8,9 @@ const BASE = {
     profiles: {}
 };
 
+const FILE_NOT_FOUND_HINT_MESSAGE = ' If this is a skill project managed by v1 ask-cli, '
++ 'please run \'ask util upgrade-project\' then try the command again.';
+
 module.exports = class AskResources extends ConfigFile {
     /**
      * Constructor for AskResources class
@@ -20,6 +23,7 @@ module.exports = class AskResources extends ConfigFile {
         }
         // init by calling super() if instance not exists
         super(filePath);
+        this.fileNotFoundHintMessage = FILE_NOT_FOUND_HINT_MESSAGE;
         this.read();
         instance = this;
     }

--- a/test/unit/commands/deploy/index-test.js
+++ b/test/unit/commands/deploy/index-test.js
@@ -92,7 +92,8 @@ describe('Commands deploy test - command class test', () => {
                 // call
                 instance.handle(TEST_CMD, (err) => {
                     // verify
-                    expect(err.message).equal('File invalidPath not exists.');
+                    expect(err.message).includes('File invalidPath not exists.');
+                    expect(err.message).includes('please run \'ask util upgrade-project\'');
                     expect(errorStub.callCount).equal(0);
                     expect(infoStub.callCount).equal(0);
                     expect(warnStub.callCount).equal(1);

--- a/test/unit/commands/new/helper-test.js
+++ b/test/unit/commands/new/helper-test.js
@@ -159,7 +159,8 @@ describe('Commands new test - helper test', () => {
                 helper.loadSkillProjectModel(TEST_SKILL_FOLDER_NAME, TEST_PROFILE);
             } catch (e) {
                 // verify
-                expect(e.message).equal(`File ${FIXTURE_RESOURCES_CONFIG_FILE_PATH} not exists.`);
+                expect(e.message).includes(`File ${FIXTURE_RESOURCES_CONFIG_FILE_PATH} not exists.`);
+                expect(e.message).includes('please run \'ask util upgrade-project\'');
             }
         });
 


### PR DESCRIPTION
Addressing https://github.com/alexa/ask-cli/issues/348

Adding additional info to the error message

Before
```
ask deploy
[Warn]: File /Users/kakuri/test/lmtest/ask-resources.json not exists.
```

After
```
ask deploy
[Warn]: File /Users/kakuri/test/lmtest/ask-resources.json not exists. If this is a skill project managed by v1 ask-cli, please run 'ask util upgrade-project' then try the command again.
```

