### PR TITLE
fix: removing restriction for replay file to have .json extension

### DIFF
--- a/lib/commands/dialog/index.js
+++ b/lib/commands/dialog/index.js
@@ -78,7 +78,12 @@ class DialogCommand extends AbstractCommand {
         let userInputs;
         const smapiClient = new SmapiClient({ profile, doDebug: debug });
         if (cmd.replay) {
-            const dialogReplayConfig = new DialogReplayFile(cmd.replay);
+            let dialogReplayConfig;
+            try {
+                dialogReplayConfig = new DialogReplayFile(cmd.replay);
+            } catch (err) {
+                return callback(err);
+            }
             skillId = dialogReplayConfig.getSkillId();
             if (!stringUtils.isNonBlankString(skillId)) {
                 return process.nextTick(callback(new CliError('Replay file must contain skillId')));

--- a/lib/commands/option-model.json
+++ b/lib/commands/option-model.json
@@ -43,13 +43,9 @@
   },
   "replay": {
     "name": "replay",
-    "description": "Specify a replay file to simulate dialog with Alexa",
+    "description": "Specify a replay file (JSON file) to simulate dialog with Alexa",
     "alias": "r",
-    "stringInput": "REQUIRED",
-    "rule": [{
-      "type": "REGEX",
-      "regex": "^[./]?[\\w\\-. /]+\\.(json)"
-    }]
+    "stringInput": "REQUIRED"
   },
   "save-skill-io": {
     "name": "save-skill-io",

--- a/lib/commands/option-model.json
+++ b/lib/commands/option-model.json
@@ -37,7 +37,7 @@
   },
   "skill-id": {
     "name": "skill-id",
-    "description": "The skill ID.",
+    "description": "Skill id",
     "alias": "s",
     "stringInput": "REQUIRED"
   },
@@ -64,7 +64,7 @@
   },
   "stage": {
     "name": "stage",
-    "description": "Stage for skill.",
+    "description": "Skill stage",
     "alias": "g",
     "stringInput": "REQUIRED",
     "rule": [{

--- a/lib/controllers/dialog-controller/index.js
+++ b/lib/controllers/dialog-controller/index.js
@@ -1,7 +1,6 @@
 const chalk = require('chalk');
 const fs = require('fs-extra');
 const R = require('ramda');
-const path = require('path');
 
 const stringUtils = require('@src/utils/string-utils');
 const Messenger = require('@src/view/messenger');
@@ -102,12 +101,7 @@ module.exports = class DialogController extends SkillSimulationController {
         const filePath = recordArgsList[0];
         const appendQuitArgument = recordArgsList[1];
         let shouldAppendQuit = false;
-        const JSON_FILE_EXTENSION = '.json';
 
-        if (path.extname(filePath).toLowerCase() !== JSON_FILE_EXTENSION) {
-            Messenger.getInstance().warn(`File should be of type '${JSON_FILE_EXTENSION}'`);
-            return {};
-        }
         if (stringUtils.isNonBlankString(appendQuitArgument)) {
             if (appendQuitArgument !== '--append-quit') {
                 Messenger.getInstance().warn(`Unable to validate arguments: "${appendQuitArgument}". ${RECORD_FORMAT}`);

--- a/lib/model/dialog-replay-file.js
+++ b/lib/model/dialog-replay-file.js
@@ -1,9 +1,7 @@
 const fs = require('fs-extra');
-const path = require('path');
 const R = require('ramda');
 
 const CliFileNotFoundError = require('@src/exceptions/cli-file-not-found-error');
-const yaml = require('@src/model/yaml-parser');
 const jsonView = require('@src/view/json-view');
 
 module.exports = class DialogReplayFile {
@@ -59,20 +57,12 @@ module.exports = class DialogReplayFile {
      * @param {String} filePath path to the given file.
      */
     readFileContent(filePath) {
-        let fileType;
         try {
-            fileType = path.extname(filePath).toLowerCase();
             this.doesFileExist(filePath);
             fs.accessSync(filePath, fs.constants.R_OK);
-            if (fileType === '.json') {
-                return JSON.parse(fs.readFileSync(filePath, 'utf-8'));
-            }
-            if (fileType === '.yaml' || fileType === '.yml') {
-                return yaml.load(filePath);
-            }
-            throw new Error('ASK CLI does not support this file type.');
+            return fs.readJsonSync(filePath);
         } catch (error) {
-            throw `Failed to parse ${fileType} file ${filePath}.\n${error.message}`;
+            throw `Failed to parse file: ${filePath}.\n${error.message}`;
         }
     }
 
@@ -86,14 +76,7 @@ module.exports = class DialogReplayFile {
         try {
             this.doesFileExist(filePath);
             fs.accessSync(filePath, fs.constants.W_OK);
-            const fileType = path.extname(filePath).toLowerCase();
-            if (fileType === '.json') {
-                fs.writeFileSync(filePath, jsonView.toString(content), 'utf-8');
-            } else if (fileType === '.yaml' || fileType === '.yml') {
-                yaml.dump(filePath, content);
-            } else {
-                throw new Error('ASK CLI does not support this file type.');
-            }
+            fs.writeFileSync(filePath, jsonView.toString(content), 'utf-8');
         } catch (error) {
             throw `Failed to write to file ${filePath}.\n${error.message}`;
         }

--- a/test/unit/commands/dialog/index-test.js
+++ b/test/unit/commands/dialog/index-test.js
@@ -4,6 +4,7 @@ const path = require('path');
 
 const AuthorizationController = require('@src/controllers/authorization-controller');
 const DialogCommand = require('@src/commands/dialog');
+const DialogReplayFile = require('@src/model/dialog-replay-file');
 const helper = require('@src/commands/dialog/helper');
 const httpClient = require('@src/clients/http-client');
 const InteractiveMode = require('@src/commands/dialog/interactive-mode');
@@ -216,6 +217,23 @@ describe('Commands Dialog test - command class test', () => {
                     expect(config.skillId).equal('amzn1.ask.skill.1234567890');
                     expect(config.stage).equal('development');
                     expect(config.userInputs).deep.equal(['hello', 'world']);
+                    done();
+                });
+            });
+
+            it('| returns error when initialization of DialogReplayFile fails', (done) => {
+                // setup
+                const TEST_CMD_WITH_VALUES = {
+                    stage: '',
+                    replay: DIALOG_REPLAY_FILE_JSON_PATH
+                };
+                const error = 'error';
+                sinon.stub(profileHelper, 'runtimeProfile').returns(TEST_PROFILE);
+                sinon.stub(DialogReplayFile.prototype, 'readFileContent').throws(new Error(error));
+                // call
+                instance._getDialogConfig(TEST_CMD_WITH_VALUES, (err) => {
+                    // verify
+                    expect(err.message).eq(error);
                     done();
                 });
             });

--- a/test/unit/controller/dialog-controller/index-test.js
+++ b/test/unit/controller/dialog-controller/index-test.js
@@ -244,22 +244,6 @@ describe('Controller test - dialog controller test', () => {
             expect(warnStub.args[0][0]).equal(`Unable to validate arguments: "${malFormedAppendQuitArgument}". ${RECORD_FORMAT}`);
         });
 
-        it('| file is not of JSON type', () => {
-            // setup
-            const warnStub = sinon.stub();
-            sinon.stub(Messenger, 'getInstance').returns({
-                warn: warnStub
-            });
-            sinon.stub(DialogReplView.prototype, 'registerRecordCommand');
-            DialogReplView.prototype.registerRecordCommand.callsArgWith(0, 'file.yml');
-
-            // call
-            dialogController.setupSpecialCommands(dialogReplView, () => {});
-
-            // verify
-            expect(warnStub.args[0][0]).equal("File should be of type '.json'");
-        });
-
         it('| replay file creation throws error', (done) => {
             // setup
             const infoStub = sinon.stub().throws(new Error(TEST_MSG));

--- a/test/unit/model/dialog-replay-file-test.js
+++ b/test/unit/model/dialog-replay-file-test.js
@@ -2,7 +2,6 @@ const { expect } = require('chai');
 const fs = require('fs-extra');
 const path = require('path');
 const sinon = require('sinon');
-const yaml = require('@src/model/yaml-parser');
 
 const DialogReplayFile = require('@src/model/dialog-replay-file');
 
@@ -166,7 +165,7 @@ describe('Model test - dialog replay file test', () => {
                     dialogReplayFile = new DialogReplayFile(NOT_EXISTING_DIALOG_REPLAY_FILE_PATH);
                 } catch (error) {
                     // verify
-                    expect(error).equal(`Failed to parse .json file ${NOT_EXISTING_DIALOG_REPLAY_FILE_PATH}.`
+                    expect(error).equal(`Failed to parse file: ${NOT_EXISTING_DIALOG_REPLAY_FILE_PATH}.`
                     + `\nFile ${NOT_EXISTING_DIALOG_REPLAY_FILE_PATH} not exists.`);
                 }
             });
@@ -179,14 +178,14 @@ describe('Model test - dialog replay file test', () => {
                     dialogReplayFile = new DialogReplayFile(INVALID_JSON_DIALOG_REPLAY_FILE_PATH);
                 } catch (error) {
                     // verify
-                    expect(error).equal(`Failed to parse .json file ${INVALID_JSON_DIALOG_REPLAY_FILE_PATH}.`
+                    expect(error).equal(`Failed to parse file: ${INVALID_JSON_DIALOG_REPLAY_FILE_PATH}.`
                     + `\n${TEST_ERROR}`);
                 }
             });
 
             it('| test JSON file path extension', () => {
                 // setup
-                sinon.stub(fs, 'readFileSync').returns('{"skillId":"amzn1.ask.skill.1234567890"}');
+                sinon.stub(fs, 'readJsonSync').returns({ skillId: 'amzn1.ask.skill.1234567890' });
 
                 // call
                 dialogReplayFile = new DialogReplayFile(DIALOG_REPLAY_FILE_JSON_PATH);
@@ -195,46 +194,6 @@ describe('Model test - dialog replay file test', () => {
                 expect(dialogReplayFile.content).deep.equal({
                     skillId: 'amzn1.ask.skill.1234567890'
                 });
-            });
-
-            it('| test YAML file path extension', () => {
-                // setup
-                const YAML_FILE_PATH = path.join(FIXTURE_PATH, 'yaml-config.yaml');
-                const yamlStub = sinon.stub(yaml, 'load');
-
-                // call
-                dialogReplayFile = new DialogReplayFile(YAML_FILE_PATH);
-
-                // verify
-                expect(yamlStub.calledOnce).equal(true);
-            });
-
-            it('| test YML file path extension', () => {
-                // setup
-                const YML_FILE_PATH = path.join(FIXTURE_PATH, 'yaml-config.yml');
-                const ymlStub = sinon.stub(yaml, 'load');
-
-                // call
-                dialogReplayFile = new DialogReplayFile(YML_FILE_PATH);
-
-                // verify
-                expect(ymlStub.calledOnce).equal(true);
-            });
-
-            it(' throws error if neither JSON nor YAML/YML file path extension', () => {
-                // setup
-                sinon.stub(DialogReplayFile.prototype, 'doesFileExist');
-                sinon.stub(fs, 'accessSync');
-                const UNSUPPORTED_EXTENSION_FILE_PATH = path.join(FIXTURE_PATH, 'yaml-config.random');
-
-                try {
-                    // call
-                    dialogReplayFile = new DialogReplayFile(UNSUPPORTED_EXTENSION_FILE_PATH);
-                } catch (error) {
-                    // verify
-                    expect(error).equal(`Failed to parse .random file ${UNSUPPORTED_EXTENSION_FILE_PATH}.`
-                    + '\nASK CLI does not support this file type.');
-                }
             });
         });
 
@@ -287,49 +246,6 @@ describe('Model test - dialog replay file test', () => {
 
                 // verify
                 expect(writeFileStub.calledOnce).equal(true);
-            });
-
-            it('| test YAML file path extension', () => {
-                // setup
-                const YAML_FILE_PATH = path.join(FIXTURE_PATH, 'yaml-config.yaml');
-                const yamlStub = sinon.stub(yaml, 'dump');
-
-                // call
-                dialogReplayFile = new DialogReplayFile(YAML_FILE_PATH);
-                dialogReplayFile.writeContentToFile('', YAML_FILE_PATH);
-
-                // verify
-                expect(yamlStub.calledOnce).equal(true);
-            });
-
-            it('| test YML file path extension', () => {
-                // setup
-                const YML_FILE_PATH = path.join(FIXTURE_PATH, 'yaml-config.yml');
-                const ymlStub = sinon.stub(yaml, 'dump');
-
-                // call
-                dialogReplayFile = new DialogReplayFile(YML_FILE_PATH);
-                dialogReplayFile.writeContentToFile('', YML_FILE_PATH);
-
-                // verify
-                expect(ymlStub.calledOnce).equal(true);
-            });
-
-            it(' throws error if neither JSON nor YAML/YML file path extension', () => {
-                // setup
-                sinon.stub(DialogReplayFile.prototype, 'doesFileExist');
-                sinon.stub(fs, 'accessSync');
-                const UNSUPPORTED_EXTENSION_FILE_PATH = path.join(FIXTURE_PATH, 'yaml-config.random');
-
-                try {
-                    // call
-                    dialogReplayFile = new DialogReplayFile(UNSUPPORTED_EXTENSION_FILE_PATH);
-                    dialogReplayFile.writeContentToFile('', UNSUPPORTED_EXTENSION_FILE_PATH);
-                } catch (error) {
-                    // verify
-                    expect(error).equal(`Failed to write to file ${UNSUPPORTED_EXTENSION_FILE_PATH}.`
-                    + '\nASK CLI does not support this file type.');
-                }
             });
         });
     });


### PR DESCRIPTION
Addressing https://github.com/alexa/ask-cli/issues/347 and doing additional clean up

1) minor formatting change for some options descriptions
2) removing restriction for replay file to have .json extension
3) removed code to read/ write yml replay file, since it was not possible due to our validations.

test non exisiting file
```
ask dialog -r not-existing
[Error]: Failed to parse file: not-existing.
File not-existing not exists.
```

test non json file

```
ask dialog -r out
[Error]: Failed to parse file: out.
out: Unexpected string in JSON at position 166
```
 
test good file
```
ask dialog -r out

========================================================== Welcome to ASK Dialog ==========================================================
========================================= Replaying a multi turn conversation with Alexa from out =========================================
======================================== Alexa will then evaluate your input and give a response! =========================================

User  > open node crazy test
Alexa > Welcome, you can say Hello or Help. Which would you like to try?
User  > hello
Alexa > Hello World!
User  > .quit

================================================================ Goodbye! =================================================================
```
