### PR TITLE
fix: increase lambda default memory and timeout

### DIFF
--- a/lib/clients/aws-client/lambda-client.js
+++ b/lib/clients/aws-client/lambda-client.js
@@ -30,6 +30,9 @@ module.exports = class LambdaClient extends AbstractAwsClient {
             Role: role,
             Runtime: runtime,
             Handler: handler,
+            // to account for Java runtime cold start
+            Timeout: 15,
+            MemorySize: 512,
             FunctionName: this._generateFunctionName(skillName, profile, alexaRegion)
         };
         this.client.createFunction(params, (err, data) => {


### PR DESCRIPTION
Addressing https://github.com/alexa/ask-cli/issues/370

increase lambda default memory and timeout to match CF deployer default settings.

Only change for on initial creation of lambda.
