### PR TITLE
fix: maven-assembly-plugin 2.6 doesn't work with Java > 8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ test/temp
 .vagrant
 
 # java project
+target/
 .classpath
 .project
 .settings/

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,7 @@ test/temp
 
 .vagrant
 
+# java project
+.classpath
+.project
+.settings/

--- a/lib/builtins/build-flows/java-mvn.js
+++ b/lib/builtins/build-flows/java-mvn.js
@@ -34,8 +34,7 @@ class JavaMvnBuildFlow extends AbstractBuildFlow {
      */
     execute(callback) {
         this.debug(`Building skill artifacts based on the ${JavaMvnBuildFlow.manifest}.`);
-        this.execCommand('mvn clean package org.apache.maven.plugins:maven-assembly-plugin:3.3.0:single '
-        + '-DdescriptorId=jar-with-dependencies');
+        this.execCommand('mvn clean package org.apache.maven.plugins:maven-assembly-plugin:single');
         const targetFolderPath = path.join(this.cwd, 'target');
         const jarFileName = fs.readdirSync(targetFolderPath).find(fileName => fileName.endsWith('jar-with-dependencies.jar'));
         const jarFilePath = path.join(targetFolderPath, jarFileName);

--- a/lib/builtins/build-flows/java-mvn.js
+++ b/lib/builtins/build-flows/java-mvn.js
@@ -34,7 +34,7 @@ class JavaMvnBuildFlow extends AbstractBuildFlow {
      */
     execute(callback) {
         this.debug(`Building skill artifacts based on the ${JavaMvnBuildFlow.manifest}.`);
-        this.execCommand('mvn clean package org.apache.maven.plugins:maven-assembly-plugin:single');
+        this.execCommand('mvn clean package assembly:single');
         const targetFolderPath = path.join(this.cwd, 'target');
         const jarFileName = fs.readdirSync(targetFolderPath).find(fileName => fileName.endsWith('jar-with-dependencies.jar'));
         const jarFilePath = path.join(targetFolderPath, jarFileName);

--- a/lib/builtins/build-flows/java-mvn.js
+++ b/lib/builtins/build-flows/java-mvn.js
@@ -34,8 +34,8 @@ class JavaMvnBuildFlow extends AbstractBuildFlow {
      */
     execute(callback) {
         this.debug(`Building skill artifacts based on the ${JavaMvnBuildFlow.manifest}.`);
-        this.execCommand('mvn clean org.apache.maven.plugins:maven-assembly-plugin:2.6:assembly '
-        + '-DdescriptorId=jar-with-dependencies package');
+        this.execCommand('mvn clean package org.apache.maven.plugins:maven-assembly-plugin:3.3.0:single '
+        + '-DdescriptorId=jar-with-dependencies');
         const targetFolderPath = path.join(this.cwd, 'target');
         const jarFileName = fs.readdirSync(targetFolderPath).find(fileName => fileName.endsWith('jar-with-dependencies.jar'));
         const jarFilePath = path.join(targetFolderPath, jarFileName);

--- a/test/integration/fixtures/code-builder/java-mvn/lambda/pom.xml
+++ b/test/integration/fixtures/code-builder/java-mvn/lambda/pom.xml
@@ -40,6 +40,15 @@
     <pluginManagement>
       <plugins>
         <plugin>
+          <artifactId>maven-assembly-plugin</artifactId>
+          <version>3.3.0</version>
+          <configuration>
+            <descriptorRefs>
+              <descriptorRef>jar-with-dependencies</descriptorRef>
+            </descriptorRefs>
+          </configuration>
+        </plugin>
+        <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
           <version>3.7.0</version>
@@ -52,5 +61,5 @@
       </plugins>
     </pluginManagement>
   </build>
-  
+
 </project>

--- a/test/integration/fixtures/code-builder/java-mvn/lambda/pom.xml
+++ b/test/integration/fixtures/code-builder/java-mvn/lambda/pom.xml
@@ -51,7 +51,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.7.0</version>
+          <version>3.8.1</version>
           <configuration>
             <source>1.8</source>
             <target>1.8</target>

--- a/test/unit/builtins/build-flows/java-mvn-test.js
+++ b/test/unit/builtins/build-flows/java-mvn-test.js
@@ -31,8 +31,7 @@ describe('JavaMvnBuildFlow test', () => {
             buildFlow.execute((err, res) => {
                 expect(err).eql(undefined);
                 expect(res).eql(undefined);
-                expect(execStub.args[0][0]).eql('mvn clean package org.apache.maven.plugins:maven-'
-                + 'assembly-plugin:3.3.0:single -DdescriptorId=jar-with-dependencies');
+                expect(execStub.args[0][0]).eql('mvn clean package org.apache.maven.plugins:maven-assembly-plugin:single');
                 done();
             });
         });
@@ -44,8 +43,7 @@ describe('JavaMvnBuildFlow test', () => {
             buildFlow.execute((err, res) => {
                 expect(err).eql(undefined);
                 expect(res).eql(undefined);
-                expect(execStub.args[0][0]).eql('mvn clean package org.apache.maven.plugins:maven-'
-                + 'assembly-plugin:3.3.0:single -DdescriptorId=jar-with-dependencies');
+                expect(execStub.args[0][0]).eql('mvn clean package org.apache.maven.plugins:maven-assembly-plugin:single');
                 expect(debugStub.args[0][0]).eql('Building skill artifacts based on the pom.xml.');
                 expect(debugStub.args[1][0]).eql('Renaming the jar file some-path to buildFile.');
                 done();

--- a/test/unit/builtins/build-flows/java-mvn-test.js
+++ b/test/unit/builtins/build-flows/java-mvn-test.js
@@ -31,7 +31,7 @@ describe('JavaMvnBuildFlow test', () => {
             buildFlow.execute((err, res) => {
                 expect(err).eql(undefined);
                 expect(res).eql(undefined);
-                expect(execStub.args[0][0]).eql('mvn clean package org.apache.maven.plugins:maven-assembly-plugin:single');
+                expect(execStub.args[0][0]).eql('mvn clean package assembly:single');
                 done();
             });
         });
@@ -43,7 +43,7 @@ describe('JavaMvnBuildFlow test', () => {
             buildFlow.execute((err, res) => {
                 expect(err).eql(undefined);
                 expect(res).eql(undefined);
-                expect(execStub.args[0][0]).eql('mvn clean package org.apache.maven.plugins:maven-assembly-plugin:single');
+                expect(execStub.args[0][0]).eql('mvn clean package assembly:single');
                 expect(debugStub.args[0][0]).eql('Building skill artifacts based on the pom.xml.');
                 expect(debugStub.args[1][0]).eql('Renaming the jar file some-path to buildFile.');
                 done();

--- a/test/unit/builtins/build-flows/java-mvn-test.js
+++ b/test/unit/builtins/build-flows/java-mvn-test.js
@@ -31,8 +31,8 @@ describe('JavaMvnBuildFlow test', () => {
             buildFlow.execute((err, res) => {
                 expect(err).eql(undefined);
                 expect(res).eql(undefined);
-                expect(execStub.args[0][0]).eql('mvn clean org.apache.maven.plugins:maven-'
-                + 'assembly-plugin:2.6:assembly -DdescriptorId=jar-with-dependencies package');
+                expect(execStub.args[0][0]).eql('mvn clean package org.apache.maven.plugins:maven-'
+                + 'assembly-plugin:3.3.0:single -DdescriptorId=jar-with-dependencies');
                 done();
             });
         });
@@ -44,8 +44,8 @@ describe('JavaMvnBuildFlow test', () => {
             buildFlow.execute((err, res) => {
                 expect(err).eql(undefined);
                 expect(res).eql(undefined);
-                expect(execStub.args[0][0]).eql('mvn clean org.apache.maven.plugins:maven-'
-                + 'assembly-plugin:2.6:assembly -DdescriptorId=jar-with-dependencies package');
+                expect(execStub.args[0][0]).eql('mvn clean package org.apache.maven.plugins:maven-'
+                + 'assembly-plugin:3.3.0:single -DdescriptorId=jar-with-dependencies');
                 expect(debugStub.args[0][0]).eql('Building skill artifacts based on the pom.xml.');
                 expect(debugStub.args[1][0]).eql('Renaming the jar file some-path to buildFile.');
                 done();


### PR DESCRIPTION
… failures

*Issue #, if available:*
 fixes #372

*Description of changes:*

Bumping the **2015** [2.6](https://github.com/apache/maven-assembly-plugin/releases/tag/maven-assembly-plugin-2.6) `maven-assembly-plugin`  version to the latest **2020** [3.3.0](https://github.com/apache/maven-assembly-plugin/releases/tag/maven-assembly-plugin-3.3.0) one.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
