### PR TITLE
fix: move the temp zip file to .ask to integ with extension

### DIFF
--- a/lib/controllers/skill-metadata-controller/index.js
+++ b/lib/controllers/skill-metadata-controller/index.js
@@ -203,7 +203,8 @@ module.exports = class SkillMetadataController {
                 return callback(createUploadErr);
             }
             // 2.zip skill package
-            zipUtils.createTempZip(skillPackageSrc, (zipErr, zipFilePath) => {
+            const outputDir = path.join(process.cwd(), '.ask');
+            zipUtils.createTempZip(skillPackageSrc, outputDir, (zipErr, zipFilePath) => {
                 if (zipErr) {
                     return callback(zipErr);
                 }

--- a/lib/utils/zip-utils.js
+++ b/lib/utils/zip-utils.js
@@ -18,9 +18,13 @@ module.exports = {
  * @param {string} src The file path of resource want to zip
  * @param {callback} callback { error, filePath }
  */
-function createTempZip(src, callback) {
+function createTempZip(src, outputDir, callback) {
     if (!src) {
         return callback('Zip file path must be set.');
+    }
+
+    if (!outputDir) {
+        return callback('Zip file output path must be set.');
     }
     fs.access(src, (fs.constants || fs).W_OK, (err) => {
         if (err) {
@@ -30,10 +34,11 @@ function createTempZip(src, callback) {
             Messenger.getInstance().debug(`The source file ${src} has already been compressed. Skip the zipping`);
             return callback(null, src);
         }
+        // Create the temp zip at the same level of the source file
         const zipFilePath = tmp.tmpNameSync({
             prefix: 'askcli_temp_',
             postfix: '.zip',
-            dir: src
+            dir: outputDir
         });
         const writeStream = fs.createWriteStream(zipFilePath);
         const archive = archiver('zip');

--- a/test/unit/controller/skill-metadata-controller-test.js
+++ b/test/unit/controller/skill-metadata-controller-test.js
@@ -607,7 +607,7 @@ describe('Controller test - skill metadata controller test', () => {
             sinon.stub(SkillMetadataController.prototype, '_createUploadUrl').callsArgWith(0, null, {
                 uploadUrl: TEST_UPLOAD_URL
             });
-            sinon.stub(zipUtils, 'createTempZip').callsArgWith(1, 'zipErr');
+            sinon.stub(zipUtils, 'createTempZip').callsArgWith(2, 'zipErr');
             // call
             skillMetaController.uploadSkillPackage(TEST_PATH, (err, res) => {
                 // verify
@@ -624,7 +624,7 @@ describe('Controller test - skill metadata controller test', () => {
             sinon.stub(SkillMetadataController.prototype, '_createUploadUrl').callsArgWith(0, null, {
                 uploadUrl: TEST_UPLOAD_URL
             });
-            sinon.stub(zipUtils, 'createTempZip').callsArgWith(1, null, TEST_PATH);
+            sinon.stub(zipUtils, 'createTempZip').callsArgWith(2, null, TEST_PATH);
             sinon.stub(fs, 'removeSync');
             sinon.stub(httpClient, 'putByUrl').callsArgWith(4, 'uploadErr');
             // call
@@ -642,7 +642,7 @@ describe('Controller test - skill metadata controller test', () => {
 
         it('| upload zip file meets error, expect callback error', (done) => {
             // setup
-            sinon.stub(zipUtils, 'createTempZip').callsArgWith(1, null, TEST_PATH);
+            sinon.stub(zipUtils, 'createTempZip').callsArgWith(2, null, TEST_PATH);
             sinon.stub(fs, 'readFileSync').withArgs(TEST_PATH).returns(TEST_FILE_CONTENT);
             sinon.stub(SkillMetadataController.prototype, '_createUploadUrl').callsArgWith(0, null, {
                 uploadUrl: TEST_UPLOAD_URL
@@ -666,7 +666,7 @@ describe('Controller test - skill metadata controller test', () => {
 
         it('| upload skill package succeeds, expect callback upload result', (done) => {
             // setup
-            sinon.stub(zipUtils, 'createTempZip').callsArgWith(1, null, TEST_PATH);
+            sinon.stub(zipUtils, 'createTempZip').callsArgWith(2, null, TEST_PATH);
             sinon.stub(fs, 'readFileSync').withArgs(TEST_PATH).returns(TEST_FILE_CONTENT);
             sinon.stub(SkillMetadataController.prototype, '_createUploadUrl').callsArgWith(0, null, {
                 uploadUrl: TEST_UPLOAD_URL

--- a/test/unit/utils/zip-utils-test.js
+++ b/test/unit/utils/zip-utils-test.js
@@ -11,6 +11,7 @@ const CONSTANTS = require('@src/utils/constants');
 
 describe('Utils test - zip utility', () => {
     const TEST_SRC = 'TEST_SRC';
+    const TEST_OUTPUT_DIR = 'TEST_OUTPUT_DIR';
     const TEST_ERROR = 'TEST_ERROR';
     const TEST_ZIP_FILE_PATH = 'TEST_ZIP_FILE_PATH';
     const TEST_REMOTE_ZIP_URL = 'TEST_REMOTE_ZIP_URL';
@@ -21,7 +22,7 @@ describe('Utils test - zip utility', () => {
             sinon.stub(tmp, 'tmpNameSync').withArgs({
                 prefix: 'askcli_temp_',
                 postfix: '.zip',
-                dir: TEST_SRC
+                dir: TEST_OUTPUT_DIR
             }).callsFake(() => TEST_ZIP_FILE_PATH);
 
             new Messenger({});
@@ -34,9 +35,18 @@ describe('Utils test - zip utility', () => {
 
         it('| call back error when src file is not set', (done) => {
             // call
-            zipUtils.createTempZip(null, (error) => {
+            zipUtils.createTempZip(null, TEST_OUTPUT_DIR, (error) => {
                 // verify
                 expect(error).equal('Zip file path must be set.');
+                done();
+            });
+        });
+
+        it('| call back error when outputDir is not set', (done) => {
+            // call
+            zipUtils.createTempZip(TEST_SRC, null, (error) => {
+                // verify
+                expect(error).equal('Zip file output path must be set.');
                 done();
             });
         });
@@ -46,7 +56,7 @@ describe('Utils test - zip utility', () => {
             sinon.stub(fs, 'access').callsArgWith(2, TEST_ERROR);
 
             // call
-            zipUtils.createTempZip(TEST_SRC, (error) => {
+            zipUtils.createTempZip(TEST_SRC, TEST_OUTPUT_DIR, (error) => {
                 // verify
                 expect(error).equal(`File access error. ${TEST_ERROR}`);
                 done();
@@ -61,7 +71,7 @@ describe('Utils test - zip utility', () => {
             sinon.stub(Messenger.getInstance(), 'debug');
 
             // call
-            zipUtils.createTempZip(src, (error, response) => {
+            zipUtils.createTempZip(src, TEST_OUTPUT_DIR, (error, response) => {
                 // verify
                 expect(Messenger.getInstance().debug.args[0][0]).equal(`The source file ${src} has already been compressed. Skip the zipping`);
                 expect(error).equal(null);
@@ -78,7 +88,7 @@ describe('Utils test - zip utility', () => {
             sinon.stub(Messenger.getInstance(), 'debug');
 
             // call
-            zipUtils.createTempZip(src, (error, response) => {
+            zipUtils.createTempZip(src, TEST_OUTPUT_DIR, (error, response) => {
                 // verify
                 expect(Messenger.getInstance().debug.args[0][0]).equal(`The source file ${src} has already been compressed. Skip the zipping`);
                 expect(error).equal(null);
@@ -122,7 +132,7 @@ describe('Utils test - zip utility', () => {
                 });
                 archiveOnStub.callsArgWith(1, 'error');
                 // call
-                proxyZipUtils.createTempZip(TEST_SRC, (error, response) => {
+                proxyZipUtils.createTempZip(TEST_SRC, TEST_OUTPUT_DIR, (error, response) => {
                     // verify
                     expect(fs.createWriteStream.args[0][0]).equal(TEST_ZIP_FILE_PATH);
                     expect(error).equal('Archive error. error');
@@ -139,7 +149,7 @@ describe('Utils test - zip utility', () => {
                 });
                 writeStreamOnStub.callsArgWith(1);
                 // call
-                proxyZipUtils.createTempZip(TEST_SRC, (error, response) => {
+                proxyZipUtils.createTempZip(TEST_SRC, TEST_OUTPUT_DIR, (error, response) => {
                     // verify
                     expect(fs.createWriteStream.args[0][0]).equal(TEST_ZIP_FILE_PATH);
                     expect(archiveFileStub.args[0][0]).equal(TEST_SRC);
@@ -158,7 +168,7 @@ describe('Utils test - zip utility', () => {
                 });
                 writeStreamOnStub.callsArgWith(1);
                 // call
-                proxyZipUtils.createTempZip(TEST_SRC, (error, response) => {
+                proxyZipUtils.createTempZip(TEST_SRC, TEST_OUTPUT_DIR, (error, response) => {
                     // verify
                     expect(fs.createWriteStream.args[0][0]).equal(TEST_ZIP_FILE_PATH);
                     expect(archiveGlobStub.args[0][0]).equal('**/*');


### PR DESCRIPTION


*Issue #, if available:*

There's a new extension feature skill-package validator, which is a fileSystemWatcher on skilPackage folder. If the watcher catch any unexecpeted files, it will throw warn in the extension. 

Recently there's customer tried to use the cli to deploy skill with the extension opened. Since the cli will generate the temp zip under skillPackage, it will trigger the extension alert. 

*Description of changes:*

Instead of generating the zip file under skillPackage folder, rightnow will move the temp zip to .ask folder.
Changed the zipUtil.createTempZip function to take in a new param which will specify the output dir. And in the skillDeployController, add logic to get the .ask folder path and pass it into the createTempZip.

Fixed all the unit tests. And tested this feature with a skill at my local, the temp zip file will now generated inside .ask folder.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
