### PR TITLE
fix(lambda): truncating the skill name for lambda role creation

### DIFF
--- a/lib/clients/aws-client/iam-client.js
+++ b/lib/clients/aws-client/iam-client.js
@@ -77,6 +77,7 @@ module.exports = class IAMClient extends AbstractAwsClient {
     _generateIAMRoleName(skillName) {
         const roleNamePrefix = process.env.ASK_DEPLOY_ROLE_PREFIX || 'ask-lambda';
         const validSkillName = skillName.replace(/_/g, '-');
-        return `${roleNamePrefix}-${validSkillName}-${Date.now()}`;
+        const truncatedSkillName = (validSkillName.length > 39) ? validSkillName.substr(0, 39 - 1) : validSkillName;
+        return `${roleNamePrefix}-${truncatedSkillName}-${Date.now()}`;
     }
 };

--- a/lib/clients/aws-client/iam-client.js
+++ b/lib/clients/aws-client/iam-client.js
@@ -72,6 +72,8 @@ module.exports = class IAMClient extends AbstractAwsClient {
     /**
      * Generates a valid IAM Role function name.
      * a IAM Role function name should follow the pattern: ask-lambda-skillName-timeStamp
+     * a valid role name cannot longer than 64 characters, so the skillName should be <=39 characters since
+     * the roleNamePrefix is 11 characters including the trailing '-' and the timeStamp is 14 characters including the '-'.
      * @param {string} skillName
      */
     _generateIAMRoleName(skillName) {

--- a/lib/clients/aws-client/iam-client.js
+++ b/lib/clients/aws-client/iam-client.js
@@ -72,7 +72,7 @@ module.exports = class IAMClient extends AbstractAwsClient {
     /**
      * Generates a valid IAM Role function name.
      * a IAM Role function name should follow the pattern: ask-lambda-skillName-timeStamp
-     * a valid role name cannot longer than 64 characters, so the skillName should be <=39 characters since
+     * a valid role name cannot be longer than 64 characters, so the skillName should be <=39 characters since
      * the roleNamePrefix is 11 characters including the trailing '-' and the timeStamp is 14 characters including the '-'.
      * @param {string} skillName
      */

--- a/lib/clients/aws-client/iam-client.js
+++ b/lib/clients/aws-client/iam-client.js
@@ -78,8 +78,7 @@ module.exports = class IAMClient extends AbstractAwsClient {
      */
     _generateIAMRoleName(skillName) {
         const roleNamePrefix = process.env.ASK_DEPLOY_ROLE_PREFIX || 'ask-lambda';
-        const validSkillName = skillName.replace(/_/g, '-');
-        const truncatedSkillName = (validSkillName.length > 39) ? validSkillName.substr(0, 39 - 1) : validSkillName;
-        return `${roleNamePrefix}-${truncatedSkillName}-${Date.now()}`;
+        const validSkillName = skillName.replace(/_/g, '-').substr(0, 39 - 1);
+        return `${roleNamePrefix}-${validSkillName}-${Date.now()}`;
     }
 };


### PR DESCRIPTION
**Issue**: If a user used the lambda option to host their skill and their skill name was >39 characters it would throw an error when running the `ask deploy` command, since the lambda role name can currently only be <=64 characters.

**Fix Description**: Truncating the skill name for lambda role creation (It truncates the skill name if the skill name is >39 characters.)

**Before the change**: 
`[Error]: CliError: Failed to create IAM role before deploying Lambda. ValidationError: 1 validation error detected: Value 'ask-lambda-python-alexa-skill-starter-template-cli-v2-1614216403551' at 'roleName' failed to satisfy constraint: Member must have length less than or equal to 64`

**After the change**:
`arn:aws:iam::453667022293:role/ask-lambda-python-alexa-skill-starter-template-cl-1614216451762`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
