### PR TITLE
fix: update build flow nodejs npm to use ci command and silent flag

### DIFF
--- a/lib/builtins/build-flows/nodejs-npm.js
+++ b/lib/builtins/build-flows/nodejs-npm.js
@@ -33,9 +33,9 @@ class NodeJsNpmBuildFlow extends AbstractBuildFlow {
      * @param {Function} callback
      */
     execute(callback) {
-        const quiteFlag = this.doDebug ? '' : ' --quite';
+        const silentFlag = this.doDebug ? '' : ' --silent';
         this.debug(`Installing NodeJS dependencies based on the ${NodeJsNpmBuildFlow.manifest}.`);
-        this.execCommand(`npm install --production${quiteFlag}`);
+        this.execCommand(`npm ci --production${silentFlag}`);
         this.createZip(callback);
     }
 }

--- a/test/integration/fixtures/code-builder/custom/hooks/build.ps1
+++ b/test/integration/fixtures/code-builder/custom/hooks/build.ps1
@@ -83,9 +83,9 @@ function Install-Dependencies() {
         Show-Log "Installing skill dependencies based on package.json."
     }
     process {
-        $DepCmd = "npm install --production"
+        $DepCmd = "npm ci --production"
         if (-not $Verbose) {
-            $DepCmd += " --quiet"
+            $DepCmd += " --silent"
         }
         Invoke-Expression -Command $DepCmd
         if(!($LASTEXITCODE -eq 0)) {

--- a/test/integration/fixtures/code-builder/custom/hooks/build.sh
+++ b/test/integration/fixtures/code-builder/custom/hooks/build.sh
@@ -45,10 +45,10 @@ display_debug() {
 }
 
 install_dependencies() {
-  [[ $DO_DEBUG == true ]] && display_debug "Installing NodeJS dependencies based on the package.json." 
-  [[ $DO_DEBUG == false ]] && QQ=true # decide if quiet flag will be appended
+  [[ $DO_DEBUG == true ]] && display_debug "Installing NodeJS dependencies based on the package.json."
+  [[ $DO_DEBUG == false ]] && QQ=true # decide if silent flag will be appended
 
-  npm install --production ${QQ:+--quiet}
+  npm ci --production ${QQ:+--silent}
   return $?
 }
 

--- a/test/unit/builtins/build-flows/nodejs-npm-test.js
+++ b/test/unit/builtins/build-flows/nodejs-npm-test.js
@@ -27,7 +27,7 @@ describe('NodeJsNpmBuildFlow test', () => {
             buildFlow.execute((err, res) => {
                 expect(err).eql(undefined);
                 expect(res).eql(undefined);
-                expect(execStub.args[0][0]).eql('npm install --production --quite');
+                expect(execStub.args[0][0]).eql('npm ci --production --silent');
                 expect(createZipStub.callCount).eql(1);
                 done();
             });
@@ -40,7 +40,7 @@ describe('NodeJsNpmBuildFlow test', () => {
             buildFlow.execute((err, res) => {
                 expect(err).eql(undefined);
                 expect(res).eql(undefined);
-                expect(execStub.args[0][0]).eql('npm install --production');
+                expect(execStub.args[0][0]).eql('npm ci --production');
                 expect(debugStub.args[0][0]).eql('Installing NodeJS dependencies based on the package.json.');
                 done();
             });


### PR DESCRIPTION
*Description of changes:*

The npm [`ci`](https://docs.npmjs.com/cli/v7/commands/npm-ci) command should be used over the `install` one when building a project for deployment. This change also fixes the debug output suppression typo by swapping the `quiet` flag for the `silent` one which is more appropriate in this case.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
