### PR TITLE
fix: limit skill infrastructure deployment to one task per aws region

### DIFF
--- a/lib/builtins/deploy-delegates/cfn-deployer/index.js
+++ b/lib/builtins/deploy-delegates/cfn-deployer/index.js
@@ -3,18 +3,12 @@ const fs = require('fs');
 const R = require('ramda');
 
 const awsUtil = require('@src/clients/aws-client/aws-util');
+const stringUtils = require('@src/utils/string-utils');
 const CliCFNDeployerError = require('@src/exceptions/cli-cfn-deployer-error');
 const Helper = require('./helper');
 
 const SKILL_STACK_PUBLIC_FILE_NAME = 'skill-stack.yaml';
 const SKILL_STACK_ASSET_FILE_NAME = 'basic-lambda.yaml';
-
-const alexaAwsRegionMap = {
-    default: 'us-east-1',
-    NA: 'us-east-1',
-    EU: 'eu-west-1',
-    FE: 'us-west-2'
-};
 
 module.exports = {
     bootstrap,
@@ -58,16 +52,17 @@ function bootstrap(options, callback) {
  */
 async function invoke(reporter, options, callback) {
     const { alexaRegion, deployState = {} } = options;
-    deployState[alexaRegion] = deployState[alexaRegion] || {};
     const deployProgress = {
         isAllStepSuccess: false,
         isCodeDeployed: false,
-        deployState: deployState[alexaRegion]
+        deployState: deployState[alexaRegion] || {}
     };
 
     try {
         await _deploy(reporter, options, deployProgress);
-        deployProgress.resultMessage = _makeSuccessMessage(deployProgress.endpoint.uri, alexaRegion);
+        deployProgress.resultMessage = deployProgress.isDeploySkipped
+            ? _makeSkippedMessage(deployProgress.deployRegion, alexaRegion)
+            : _makeSuccessMessage(deployProgress.endpoint.uri, alexaRegion);
         callback(null, deployProgress);
     } catch (err) {
         deployProgress.resultMessage = _makeErrorMessage(err, alexaRegion);
@@ -76,16 +71,23 @@ async function invoke(reporter, options, callback) {
 }
 
 async function _deploy(reporter, options, deployProgress) {
-    const { profile, doDebug, alexaRegion, skillId, skillName, code, userConfig } = options;
+    const { profile, doDebug, alexaRegion, skillId, skillName, code, userConfig, deployRegions = {} } = options;
 
     let { stackId } = deployProgress.deployState;
     const awsProfile = _getAwsProfile(profile);
-    const awsRegion = _getAwsRegion(alexaRegion, userConfig);
+    const awsRegion = _getAwsRegion(alexaRegion, deployRegions);
     const templateBody = _getTemplateBody(alexaRegion, userConfig);
     const userDefinedParameters = _getUserDefinedParameters(alexaRegion, userConfig);
     const bucketName = _getS3BucketName(alexaRegion, userConfig, deployProgress.deployState, awsProfile, awsRegion);
     const bucketKey = _getS3BucketKey(alexaRegion, userConfig, code.codeBuild);
-    const stackName = `ask-${skillName}-${alexaRegion}-skillStack-${Date.now()}`;
+    const stackName = _getStackName(skillName, alexaRegion);
+    const deployRegion = R.keys(deployRegions).find((region) => deployRegions[region] === awsRegion);
+
+    if (deployRegion !== alexaRegion) {
+        deployProgress.isDeploySkipped = true;
+        deployProgress.deployRegion = deployRegion;
+        return;
+    }
 
     const helper = new Helper(profile, doDebug, awsProfile, awsRegion, reporter);
 
@@ -132,11 +134,8 @@ function _getAwsProfile(profile) {
     return awsProfile;
 }
 
-function _getAwsRegion(alexaRegion, userConfig) {
-    let awsRegion = alexaRegion === 'default' ? userConfig.awsRegion
-        : R.path(['regionalOverrides', alexaRegion, 'awsRegion'], userConfig);
-    awsRegion = awsRegion || alexaAwsRegionMap[alexaRegion];
-
+function _getAwsRegion(alexaRegion, deployRegions) {
+    const awsRegion = deployRegions[alexaRegion];
     if (!awsRegion) {
         throw new CliCFNDeployerError(`Unsupported Alexa region: ${alexaRegion}. `
         + 'Please check your region name or use "regionalOverrides" to specify AWS region.');
@@ -150,13 +149,16 @@ function _getS3BucketName(alexaRegion, userConfig, currentRegionDeployState, aws
 
     if (customValue) return customValue;
 
-    function generateBucketName() {
+    // Generates a valid S3 bucket name.
+    //  a bucket name should follow the pattern: ask-projectName-profileName-awsRegion-timeStamp
+    //  a valid bucket name cannot longer than 63 characters, so cli fixes the project name no longer than 22 characters
+    const generateBucketName = () => {
         const projectName = path.basename(process.cwd());
-        const validProjectName = projectName.toLowerCase().replace(/[^a-z0-9-.]+/g, '').substring(0, 22);
-        const validProfile = awsProfile.toLowerCase().replace(/[^a-z0-9-.]+/g, '').substring(0, 9);
+        const validProjectName = stringUtils.filterNonAlphanumeric(projectName.toLowerCase()).substring(0, 22);
+        const validProfile = stringUtils.filterNonAlphanumeric(awsProfile.toLowerCase()).substring(0, 9);
         const shortRegionName = awsRegion.replace(/-/g, '');
         return `ask-${validProjectName}-${validProfile}-${shortRegionName}-${Date.now()}`;
-    }
+    };
 
     return R.path(['s3', 'bucket'], currentRegionDeployState) || generateBucketName();
 }
@@ -168,6 +170,19 @@ function _getS3BucketKey(alexaRegion, userConfig, codeBuild) {
     if (customValue) return customValue;
 
     return `endpoint/${path.basename(codeBuild)}`;
+}
+
+function _getStackName(skillName, alexaRegion) {
+    // Generates a valid CloudFormation stack name.
+    //  a stack name should follow the pattern: ask-skillName-alexaRegion-skillStack-timeStamp
+    //  a valid stack name cannot longer than 128 characters, so cli fixes the skill name no longer than 64 characters
+    const generateStackName = () => {
+        const validSkillName = stringUtils.filterNonAlphanumeric(skillName).substring(0, 64);
+        const shortRegionName = alexaRegion.replace(/-/g, '');
+        return `ask-${validSkillName}-${shortRegionName}-skillStack-${Date.now()}`;
+    };
+
+    return generateStackName();
 }
 
 function _getCapabilities(alexaRegion, userConfig) {
@@ -214,6 +229,10 @@ function _getTemplateBody(alexaRegion, userConfig) {
         throw new CliCFNDeployerError('The template path in userConfig must be provided.');
     }
     return fs.readFileSync(templatePath, 'utf-8');
+}
+
+function _makeSkippedMessage(deployRegion, alexaRegion) {
+    return `The CloudFormation deploy for Alexa region "${alexaRegion}" is same as "${deployRegion}".`;
 }
 
 function _makeSuccessMessage(endpointUri, alexaRegion) {

--- a/lib/builtins/deploy-delegates/cfn-deployer/index.js
+++ b/lib/builtins/deploy-delegates/cfn-deployer/index.js
@@ -71,7 +71,7 @@ async function invoke(reporter, options, callback) {
 }
 
 async function _deploy(reporter, options, deployProgress) {
-    const { profile, doDebug, alexaRegion, skillId, skillName, code, userConfig, deployRegions = {} } = options;
+    const { profile, doDebug, alexaRegion, skillId, skillName, code, userConfig, deployRegions } = options;
 
     let { stackId } = deployProgress.deployState;
     const awsProfile = _getAwsProfile(profile);

--- a/lib/builtins/deploy-delegates/cfn-deployer/index.js
+++ b/lib/builtins/deploy-delegates/cfn-deployer/index.js
@@ -71,7 +71,7 @@ async function invoke(reporter, options, callback) {
 }
 
 async function _deploy(reporter, options, deployProgress) {
-    const { profile, doDebug, alexaRegion, skillId, skillName, code, userConfig, deployRegions } = options;
+    const { profile, doDebug, alexaRegion, skillId, skillName, code, userConfig, deployState = {}, deployRegions } = options;
 
     let { stackId } = deployProgress.deployState;
     const awsProfile = _getAwsProfile(profile);
@@ -83,7 +83,7 @@ async function _deploy(reporter, options, deployProgress) {
     const stackName = _getStackName(skillName, alexaRegion);
     const deployRegion = R.keys(deployRegions).find((region) => deployRegions[region] === awsRegion);
 
-    if (deployRegion !== alexaRegion) {
+    if (deployRegion !== alexaRegion && R.equals(deployState[deployRegion], deployState[alexaRegion])) {
         deployProgress.isDeploySkipped = true;
         deployProgress.deployRegion = deployRegion;
         return;

--- a/lib/builtins/deploy-delegates/lambda-deployer/index.js
+++ b/lib/builtins/deploy-delegates/lambda-deployer/index.js
@@ -29,7 +29,7 @@ function bootstrap(options, callback) {
  * @param {Function} callback
  */
 function invoke(reporter, options, callback) {
-    const { profile, ignoreHash, alexaRegion, skillId, skillName, code, userConfig, deployState = {}, deployRegions = {} } = options;
+    const { profile, ignoreHash, alexaRegion, skillId, skillName, code, userConfig, deployState = {}, deployRegions } = options;
     const currentRegionDeployState = deployState[alexaRegion] || {};
     const awsProfile = awsUtil.getAWSProfile(profile);
     if (!stringUtils.isNonBlankString(awsProfile)) {

--- a/lib/builtins/deploy-delegates/lambda-deployer/index.js
+++ b/lib/builtins/deploy-delegates/lambda-deployer/index.js
@@ -40,7 +40,7 @@ function invoke(reporter, options, callback) {
         return callback(`Unsupported Alexa region: ${alexaRegion}. Please check your region name or use "regionalOverrides" to specify AWS region.`);
     }
     const deployRegion = R.keys(deployRegions).find((region) => deployRegions[region] === awsRegion);
-    if (deployRegion !== alexaRegion) {
+    if (deployRegion !== alexaRegion && R.equals(deployState[deployRegion], deployState[alexaRegion])) {
         return callback(null, {
             isDeploySkipped: true,
             deployRegion,

--- a/lib/builtins/deploy-delegates/lambda-deployer/index.js
+++ b/lib/builtins/deploy-delegates/lambda-deployer/index.js
@@ -4,13 +4,6 @@ const awsUtil = require('@src/clients/aws-client/aws-util');
 const stringUtils = require('@src/utils/string-utils');
 const helper = require('./helper');
 
-const alexaAwsRegionMap = {
-    default: 'us-east-1',
-    NA: 'us-east-1',
-    EU: 'eu-west-1',
-    FE: 'us-west-2'
-};
-
 module.exports = {
     bootstrap,
     invoke
@@ -36,28 +29,35 @@ function bootstrap(options, callback) {
  * @param {Function} callback
  */
 function invoke(reporter, options, callback) {
-    const { profile, ignoreHash, alexaRegion, skillId, skillName, code, userConfig, deployState = {} } = options;
+    const { profile, ignoreHash, alexaRegion, skillId, skillName, code, userConfig, deployState = {}, deployRegions = {} } = options;
+    const currentRegionDeployState = deployState[alexaRegion] || {};
     const awsProfile = awsUtil.getAWSProfile(profile);
     if (!stringUtils.isNonBlankString(awsProfile)) {
         return callback(`Profile [${profile}] doesn't have AWS profile linked to it. Please run "ask configure" to re-configure your porfile.`);
     }
-    let currentRegionDeployState = deployState[alexaRegion];
-    if (!currentRegionDeployState) {
-        currentRegionDeployState = {};
-        deployState[alexaRegion] = currentRegionDeployState;
-    }
-    // parse AWS region to use
-    let awsRegion = alexaRegion === 'default' ? userConfig.awsRegion : R.path(['regionalOverrides', alexaRegion, 'awsRegion'], userConfig);
-    awsRegion = awsRegion || alexaAwsRegionMap[alexaRegion];
+    const awsRegion = deployRegions[alexaRegion];
     if (!stringUtils.isNonBlankString(awsRegion)) {
         return callback(`Unsupported Alexa region: ${alexaRegion}. Please check your region name or use "regionalOverrides" to specify AWS region.`);
+    }
+    const deployRegion = R.keys(deployRegions).find((region) => deployRegions[region] === awsRegion);
+    if (deployRegion !== alexaRegion) {
+        return callback(null, {
+            isDeploySkipped: true,
+            deployRegion,
+            resultMessage: `The lambda deploy for Alexa region "${alexaRegion}" is same as "${deployRegion}"`
+        });
     }
 
     // load Lambda info from either existing deployState or userConfig's sourceLambda
     const loadLambdaConfig = { awsProfile, awsRegion, alexaRegion, ignoreHash, deployState: currentRegionDeployState, userConfig };
     helper.loadLambdaInformation(reporter, loadLambdaConfig, (loadLambdaErr, lambdaData) => {
         if (loadLambdaErr) {
-            return callback(loadLambdaErr);
+            return callback(null, {
+                isAllStepSuccess: false,
+                isCodeDeployed: false,
+                deployState: currentRegionDeployState,
+                resultMessage: `The lambda deploy failed for Alexa region "${alexaRegion}": ${loadLambdaErr}`
+            });
         }
         currentRegionDeployState.lambda = lambdaData.lambda;
         currentRegionDeployState.iamRole = lambdaData.iamRole;
@@ -71,9 +71,14 @@ function invoke(reporter, options, callback) {
         };
         helper.deployIAMRole(reporter, deployIAMConfig, (iamErr, iamRoleArn) => {
             if (iamErr) {
-                return callback(iamErr);
+                return callback(null, {
+                    isAllStepSuccess: false,
+                    isCodeDeployed: false,
+                    deployState: currentRegionDeployState,
+                    resultMessage: `The lambda deploy failed for Alexa region "${alexaRegion}": ${iamErr}`
+                });
             }
-            deployState[alexaRegion].iamRole = iamRoleArn;
+            currentRegionDeployState.iamRole = iamRoleArn;
             // create/update deploy for Lambda
             const deployLambdaConfig = {
                 profile,
@@ -93,19 +98,19 @@ function invoke(reporter, options, callback) {
                     return callback(null, {
                         isAllStepSuccess: false,
                         isCodeDeployed: false,
-                        deployState: deployState[alexaRegion],
+                        deployState: currentRegionDeployState,
                         resultMessage: `The lambda deploy failed for Alexa region "${alexaRegion}": ${lambdaErr}`
                     });
                 }
                 const { isAllStepSuccess, isCodeDeployed, lambdaResponse = {} } = lambdaResult;
-                deployState[alexaRegion].lambda = lambdaResponse;
+                currentRegionDeployState.lambda = lambdaResponse;
                 const { arn } = lambdaResponse;
                 // 2.full successs in Lambda deploy
                 if (isAllStepSuccess) {
                     return callback(null, {
                         isAllStepSuccess,
                         isCodeDeployed,
-                        deployState: deployState[alexaRegion],
+                        deployState: currentRegionDeployState,
                         endpoint: { uri: arn },
                         resultMessage: `The lambda deploy succeeded for Alexa region "${alexaRegion}" with output Lambda ARN: ${arn}.`
                     });
@@ -114,7 +119,7 @@ function invoke(reporter, options, callback) {
                 return callback(null, {
                     isAllStepSuccess,
                     isCodeDeployed,
-                    deployState: deployState[alexaRegion],
+                    deployState: currentRegionDeployState,
                     resultMessage: `The lambda deploy failed for Alexa region "${alexaRegion}": ${lambdaResult.resultMessage}`
                 });
             });

--- a/lib/controllers/skill-infrastructure-controller/index.js
+++ b/lib/controllers/skill-infrastructure-controller/index.js
@@ -13,6 +13,13 @@ const profileHelper = require('@src/utils/profile-helper');
 
 const DeployDelegate = require('./deploy-delegate');
 
+const defaultAlexaAwsRegionMap = {
+    default: 'us-east-1',
+    NA: 'us-east-1',
+    EU: 'eu-west-1',
+    FE: 'us-west-2'
+};
+
 module.exports = class SkillInfrastructureController {
     constructor(configuration) {
         const { profile, doDebug, ignoreHash } = configuration;
@@ -99,6 +106,8 @@ module.exports = class SkillInfrastructureController {
         if (!regionsList || regionsList.length === 0) {
             return callback('[Warn]: Skip the infrastructure deployment, as the "code" field has not been set in the resources config file.');
         }
+        const userConfig = ResourcesConfig.getInstance().getSkillInfraUserConfig(this.profile);
+        const deployRegions = this._getAlexaDeployRegions(regionsList, userConfig);
 
         // 1.instantiate MultiTasksView
         const taskConfig = {
@@ -110,27 +119,36 @@ module.exports = class SkillInfrastructureController {
         regionsList.forEach((region) => {
             const taskTitle = `Deploy Alexa skill infrastructure for region "${region}"`;
             const taskHandle = (reporter, taskCallback) => {
-                this._deployInfraByRegion(reporter, dd, region, skillName, taskCallback);
+                this._deployInfraByRegion(reporter, dd, region, skillName, deployRegions, taskCallback);
             };
             multiTasksView.loadTask(taskHandle, taskTitle, region);
         });
         // 3.start multi-tasks and validate task response
         multiTasksView.start((taskErr, taskResult) => {
-            if (taskErr) {
+            const { error, partialResult } = taskErr || {};
+            const result = partialResult || taskResult;
+            // update skipped deployment task with deploy region result
+            if (result) {
+                R.keys(result).filter((alexaRegion) => result[alexaRegion].isDeploySkipped).forEach((alexaRegion) => {
+                    const { deployRegion } = result[alexaRegion];
+                    result[alexaRegion] = result[deployRegion];
+                });
+            }
+            if (error) {
                 // update partial successful deploy results to resources config
-                if (taskErr.partialResult && !R.isEmpty(R.keys(taskErr.partialResult))) {
-                    this._updateResourcesConfig(taskErr.partialResult);
+                if (result && !R.isEmpty(R.keys(result))) {
+                    this._updateResourcesConfig(regionsList, result);
                 }
-                return callback(taskErr.error);
+                return callback(error);
             }
             // 4.validate response and update states based on the results
             try {
-                dd.validateDeployDelegateResponse(taskResult);
+                dd.validateDeployDelegateResponse(result);
             } catch (responseInvalidErr) {
                 return callback(responseInvalidErr);
             }
-            this._updateResourcesConfig(taskResult);
-            callback(null, taskResult);
+            this._updateResourcesConfig(regionsList, result);
+            callback(null, result);
         });
     }
 
@@ -182,10 +200,11 @@ module.exports = class SkillInfrastructureController {
      * @param {Object} dd injected deploy delegate instance
      * @param {String} alexaRegion
      * @param {String} skillName
+     * @param {Object} deployRegions
      * @param {Function} callback (error, invokeResult)
      *                   callback.error can be a String or { message, context } Object which passes back the partial deploy result
      */
-    _deployInfraByRegion(reporter, dd, alexaRegion, skillName, callback) {
+    _deployInfraByRegion(reporter, dd, alexaRegion, skillName, deployRegions, callback) {
         const regionConfig = {
             profile: this.profile,
             doDebug: this.doDebug,
@@ -198,7 +217,8 @@ module.exports = class SkillInfrastructureController {
                 isCodeModified: null
             },
             userConfig: ResourcesConfig.getInstance().getSkillInfraUserConfig(this.profile),
-            deployState: ResourcesConfig.getInstance().getSkillInfraDeployState(this.profile)
+            deployState: ResourcesConfig.getInstance().getSkillInfraDeployState(this.profile),
+            deployRegions
         };
         // 1.calculate the lastDeployHash for current code folder and compare with the one in record
         const lastDeployHash = ResourcesConfig.getInstance().getCodeLastDeployHashByRegion(this.profile, regionConfig.alexaRegion);
@@ -212,26 +232,39 @@ module.exports = class SkillInfrastructureController {
                 if (invokeErr) {
                     return callback(invokeErr);
                 }
-                const { isAllStepSuccess, isCodeDeployed } = invokeResult;
+                const { isAllStepSuccess, isCodeDeployed, isDeploySkipped, resultMessage } = invokeResult;
                 // track the current hash if isCodeDeployed
                 if (isCodeDeployed) {
                     invokeResult.lastDeployHash = currentHash;
                 }
-                // pass back result based on if isAllStepSuccess, pass result as error if not all steps succeed
-                callback(isAllStepSuccess ? null : invokeResult, isAllStepSuccess ? invokeResult : undefined);
+                // skip task if isDeploySkipped
+                if (isDeploySkipped) {
+                    reporter.skipTask(resultMessage);
+                }
+                // pass result message as error message if deploy not success and not skipped
+                if (!isAllStepSuccess && !isDeploySkipped) {
+                    callback({ message: resultMessage, context: invokeResult });
+                } else {
+                    callback(null, invokeResult);
+                }
             });
         });
     }
 
     /**
      * Update the the ask resources config and the deploy state.
+     * @param {Object} regionsList list of configured alexa regions
      * @param {Object} rawDeployResult deploy result from invoke: { $region: deploy-delegate's response }
      */
-    _updateResourcesConfig(rawDeployResult) {
+    _updateResourcesConfig(regionsList, rawDeployResult) {
+        const curDeployState = ResourcesConfig.getInstance().getSkillInfraDeployState(this.profile) || {};
         const newDeployState = {};
-        R.keys(rawDeployResult).forEach((alexaRegion) => {
-            newDeployState[alexaRegion] = rawDeployResult[alexaRegion].deployState;
-            ResourcesConfig.getInstance().setCodeLastDeployHashByRegion(this.profile, alexaRegion, rawDeployResult[alexaRegion].lastDeployHash);
+        regionsList.forEach((alexaRegion) => {
+            const { deployState, lastDeployHash } = rawDeployResult[alexaRegion] || {};
+            newDeployState[alexaRegion] = deployState || curDeployState[alexaRegion];
+            if (lastDeployHash) {
+                ResourcesConfig.getInstance().setCodeLastDeployHashByRegion(this.profile, alexaRegion, lastDeployHash);
+            }
         });
         ResourcesConfig.getInstance().setSkillInfraDeployState(this.profile, newDeployState);
         ResourcesConfig.getInstance().write();
@@ -259,5 +292,22 @@ module.exports = class SkillInfrastructureController {
             }
             callback();
         });
+    }
+
+    /**
+     * Return deploy regions map based on configured alexa code regions
+     * @param  {Array} regionsList list of configured alexa regions
+     * @param  {Object} userConfig
+     * @return {Object}
+     */
+    _getAlexaDeployRegions(regionsList, userConfig) {
+        const deployRegions = {};
+        regionsList.forEach((alexaRegion) => {
+            const awsRegion = alexaRegion === 'default'
+                ? userConfig.awsRegion
+                : R.path(['regionalOverrides', alexaRegion, 'awsRegion'], userConfig);
+            deployRegions[alexaRegion] = awsRegion || defaultAlexaAwsRegionMap[alexaRegion];
+        });
+        return deployRegions;
     }
 };

--- a/lib/view/multi-tasks-view.js
+++ b/lib/view/multi-tasks-view.js
@@ -26,6 +26,9 @@ class ListrReactiveTask {
      */
     get reporter() {
         return {
+            skipTask: (reason) => {
+                this._eventEmitter.emit('skip', reason);
+            },
             updateStatus: (status) => {
                 this._eventEmitter.emit('status', status);
             }
@@ -50,6 +53,7 @@ class ListrReactiveTask {
      * Mapping is:      event           observable
      *                  status          subscriber.next
      *                  error           subscriber.error + record error.context to task context
+     *                  skill           task.skip
      *                  title           task.next
      *                  complete        subscriber.complete + record result to task context
      */
@@ -60,6 +64,12 @@ class ListrReactiveTask {
             });
             this._eventEmitter.on('error', (error) => {
                 subscriber.error(error);
+                if (error.context) {
+                    ctx[this.taskId] = error.context;
+                }
+            });
+            this._eventEmitter.on('skip', (reason) => {
+                task.skip(reason);
             });
             this._eventEmitter.on('title', (title) => {
                 task.title = title;
@@ -116,7 +126,7 @@ class MultiTasksView {
             callback(null, context);
         }).catch((listrError) => {
             const errorMessage = listrError.errors
-                .map(e => e.resultMessage || e.message || e).join('\n');
+                .map(e => e.message || e).join('\n');
             callback({
                 error: new CliError(errorMessage),
                 partialResult: listrError.context

--- a/test/unit/builtins/cfn-deployer/index-test.js
+++ b/test/unit/builtins/cfn-deployer/index-test.js
@@ -209,7 +209,7 @@ describe('Builtins test - cfn-deployer index test', () => {
             });
         });
 
-        it('should skip deploy', (done) => {
+        it('should skip deploy when region is not primary deploy region', (done) => {
             const deployRegion = 'default';
             const skipRegion = 'NA';
             deployOptions.alexaRegion = skipRegion;
@@ -221,6 +221,22 @@ describe('Builtins test - cfn-deployer index test', () => {
                 deployRegion,
                 resultMessage: `The CloudFormation deploy for Alexa region "${skipRegion}" is same as "${deployRegion}".`
             };
+
+            Deployer.invoke({}, deployOptions, (err, result) => {
+                expect(err).eql(null);
+                expect(result).eql(expectedOutput);
+                done();
+            });
+        });
+
+        it('should not skip deploy when region is not primary deploy region but has different deploy state', (done) => {
+            const deployRegion = 'default';
+            const currentRegion = 'NA';
+            waitForStackDeployStub.resolves({ endpointUri, stackInfo: { Outputs: [] } });
+            deployOptions.alexaRegion = currentRegion;
+            deployOptions.deployRegions[currentRegion] = deployOptions.deployRegions[deployRegion];
+            deployOptions.deployState[currentRegion] = { ...deployOptions.deployState[deployRegion], stackId: 'different stack id' };
+            expectedOutput.resultMessage = `The CloudFormation deploy succeeded for Alexa region "${currentRegion}" with output Lambda ARN: ${endpointUri}.`;
 
             Deployer.invoke({}, deployOptions, (err, result) => {
                 expect(err).eql(null);

--- a/test/unit/builtins/cfn-deployer/index-test.js
+++ b/test/unit/builtins/cfn-deployer/index-test.js
@@ -122,8 +122,8 @@ describe('Builtins test - cfn-deployer index test', () => {
                     default: {
                         stackId,
                         s3: {
-                            bucket: 'someName',
-                            key: 'someKey.zip'
+                            bucket: bucketName,
+                            key: bucketKey
                         }
                     }
                 },
@@ -139,6 +139,7 @@ describe('Builtins test - cfn-deployer index test', () => {
             deployStackStub = sinon.stub(Helper.prototype, 'deployStack').resolves({ StackId: stackId });
             waitForStackDeployStub = sinon.stub(Helper.prototype, 'waitForStackDeploy');
         });
+
         it('should deploy', (done) => {
             waitForStackDeployStub.resolves({ endpointUri, stackInfo: { Outputs: [] } });
 
@@ -204,6 +205,26 @@ describe('Builtins test - cfn-deployer index test', () => {
                 expectedErrorOutput.resultMessage = `The CloudFormation deploy failed for Alexa region "${alexaRegion}": ${errorMessage}`;
                 expect(err).eql(null);
                 expect(result).eql(expectedErrorOutput);
+                done();
+            });
+        });
+
+        it('should skip deploy', (done) => {
+            const deployRegion = 'default';
+            const skipRegion = 'NA';
+            deployOptions.alexaRegion = skipRegion;
+            deployOptions.deployRegions[skipRegion] = deployOptions.deployRegions[deployRegion];
+            deployOptions.deployState[skipRegion] = deployOptions.deployState[deployRegion];
+            expectedOutput = {
+                ...expectedErrorOutput,
+                isDeploySkipped: true,
+                deployRegion,
+                resultMessage: `The CloudFormation deploy for Alexa region "${skipRegion}" is same as "${deployRegion}".`
+            };
+
+            Deployer.invoke({}, deployOptions, (err, result) => {
+                expect(err).eql(null);
+                expect(result).eql(expectedOutput);
                 done();
             });
         });

--- a/test/unit/builtins/cfn-deployer/index-test.js
+++ b/test/unit/builtins/cfn-deployer/index-test.js
@@ -126,6 +126,9 @@ describe('Builtins test - cfn-deployer index test', () => {
                             key: 'someKey.zip'
                         }
                     }
+                },
+                deployRegions: {
+                    default: 'us-east-1'
                 }
             };
             getAWSProfileStub = sinon.stub(awsUtil, 'getAWSProfile').returns('some profile');

--- a/test/unit/builtins/lambda-deployer/index-test.js
+++ b/test/unit/builtins/lambda-deployer/index-test.js
@@ -10,7 +10,9 @@ describe('Builtins test - lambda-deployer index.js test', () => {
     const TEST_PROFILE = 'default'; // test file uses 'default' profile
     const TEST_IGNORE_HASH = false;
     const TEST_ALEXA_REGION_DEFAULT = 'default';
+    const TEST_ALEXA_REGION_NA = 'NA';
     const TEST_AWS_REGION_DEFAULT = 'us-east-1';
+    const TEST_AWS_REGION_NA = 'us-east-1';
     const TEST_SKILL_NAME = 'skill_name';
     const TEST_IAM_ROLE_ARN = 'IAM role arn';
     const NULL_PROFILE = 'null';
@@ -49,10 +51,11 @@ describe('Builtins test - lambda-deployer index.js test', () => {
             skillId: '',
             skillName: TEST_SKILL_NAME,
             code: {},
-            userConfig: {
-                awsRegion: TEST_AWS_REGION_DEFAULT
-            },
-            deployState: {}
+            userConfig: {},
+            deployState: {},
+            deployRegions: {
+              [TEST_ALEXA_REGION_DEFAULT]: TEST_AWS_REGION_DEFAULT
+            }
         };
         const TEST_VALIDATED_DEPLOY_STATE = {
             lambda: {},
@@ -88,7 +91,8 @@ Please run "ask configure" to re-configure your porfile.`;
                 skillName: TEST_SKILL_NAME,
                 code: {},
                 userConfig: {},
-                deployState: {}
+                deployState: {},
+                deployRegions: {}
             };
             const TEST_ERROR = `Unsupported Alexa region: ${null}. Please check your region name or use "regionalOverrides" to specify AWS region.`;
             sinon.stub(awsUtil, 'getAWSProfile').withArgs(TEST_PROFILE).returns(TEST_PROFILE);
@@ -100,29 +104,61 @@ Please run "ask configure" to re-configure your porfile.`;
             });
         });
 
-        it('| alexaRegion is set correctly, validate Lambda deploy state fails, expect an error return', (done) => {
+        it('| alexaRegion is set correctly but not primary deployRegion in multi-regions environment, expect deploy skipped message return', (done) => {
             // setup
-            const TEST_ERROR = 'loadLambdaInformation error message';
+            const TEST_OPTIONS_WITH_MULTI_REGIONS = {
+                profile: TEST_PROFILE,
+                alexaRegion: TEST_ALEXA_REGION_NA,
+                skillId: '',
+                skillName: TEST_SKILL_NAME,
+                code: {},
+                userConfig: {},
+                deployState: {},
+                deployRegions: {
+                  [TEST_ALEXA_REGION_DEFAULT]: TEST_AWS_REGION_DEFAULT,
+                  [TEST_ALEXA_REGION_NA]: TEST_AWS_REGION_NA
+                }
+            };
+            const TEST_SKIPPED_RESPONSE = `The lambda deploy for Alexa region "${TEST_ALEXA_REGION_NA}" is same as "${TEST_ALEXA_REGION_DEFAULT}"`;
             sinon.stub(awsUtil, 'getAWSProfile').withArgs(TEST_PROFILE).returns(TEST_PROFILE);
-            sinon.stub(helper, 'loadLambdaInformation').callsArgWith(2, TEST_ERROR);
             // call
-            lambdaDeployer.invoke(REPORTER, TEST_OPTIONS, (err) => {
+            lambdaDeployer.invoke(REPORTER, TEST_OPTIONS_WITH_MULTI_REGIONS, (err, res) => {
                 // verify
-                expect(err).equal(TEST_ERROR);
+                expect(res.isDeploySkipped).equal(true);
+                expect(res.deployRegion).equal(TEST_ALEXA_REGION_DEFAULT);
+                expect(res.resultMessage).equal(TEST_SKIPPED_RESPONSE);
+                expect(err).equal(null);
                 done();
             });
         });
 
-        it('| validate Lambda deploy state passes, deploy IAM role fails, expect an error return', (done) => {
+        it('| alexaRegion is set correctly, validate Lambda deploy state fails, expect an error message return', (done) => {
+            // setup
+            const TEST_ERROR = 'loadLambdaInformation error message';
+            const TEST_ERROR_MESSAGE_RESPONSE = `The lambda deploy failed for Alexa region "default": ${TEST_ERROR}`;
+            sinon.stub(awsUtil, 'getAWSProfile').withArgs(TEST_PROFILE).returns(TEST_PROFILE);
+            sinon.stub(helper, 'loadLambdaInformation').callsArgWith(2, TEST_ERROR);
+            // call
+            lambdaDeployer.invoke(REPORTER, TEST_OPTIONS, (err, res) => {
+                // verify
+                expect(res.resultMessage).equal(TEST_ERROR_MESSAGE_RESPONSE);
+                expect(err).equal(null);
+                done();
+            });
+        });
+
+        it('| validate Lambda deploy state passes, deploy IAM role fails, expect an error message return', (done) => {
             // setup
             const TEST_ERROR = 'IAMRole error message';
+            const TEST_ERROR_MESSAGE_RESPONSE = `The lambda deploy failed for Alexa region "default": ${TEST_ERROR}`;
             sinon.stub(awsUtil, 'getAWSProfile').withArgs(TEST_PROFILE).returns(TEST_PROFILE);
             sinon.stub(helper, 'loadLambdaInformation').callsArgWith(2, null, TEST_VALIDATED_DEPLOY_STATE);
             sinon.stub(helper, 'deployIAMRole').callsArgWith(2, TEST_ERROR);
             // call
-            lambdaDeployer.invoke(REPORTER, TEST_OPTIONS, (err) => {
+            lambdaDeployer.invoke(REPORTER, TEST_OPTIONS, (err, res) => {
                 // verify
-                expect(err).equal(TEST_ERROR);
+                expect(res.resultMessage).equal(TEST_ERROR_MESSAGE_RESPONSE);
+                expect(err).equal(null);
                 done();
             });
         });
@@ -136,27 +172,45 @@ Please run "ask configure" to re-configure your porfile.`;
             sinon.stub(helper, 'deployIAMRole').callsArgWith(2, null, TEST_IAM_ROLE_ARN);
             sinon.stub(helper, 'deployLambdaFunction').callsArgWith(2, TEST_ERROR);
             // call
-            lambdaDeployer.invoke(REPORTER, TEST_OPTIONS, (err, data) => {
+            lambdaDeployer.invoke(REPORTER, TEST_OPTIONS, (err, res) => {
                 // verify
-                expect(data.resultMessage).equal(TEST_ERROR_MESSAGE_RESPONSE);
-                expect(data.deployState.iamRole).equal(TEST_IAM_ROLE_ARN);
+                expect(res.resultMessage).equal(TEST_ERROR_MESSAGE_RESPONSE);
+                expect(res.deployState.iamRole).equal(TEST_IAM_ROLE_ARN);
+                expect(err).equal(null);
                 done();
             });
         });
 
-        it('| deploy IAM role passes, deploy Lambda code configuration fails, expect IAM role arn, revisionId and a message returned', (done) => {
+        it('| deploy IAM role passes, deploy Lambda config fails, expect all data, except endpoint, and an error message returned', (done) => {
             // setup
+            const LAMBDA_ARN = 'lambda_arn';
+            const LAST_MODIFIED = 'last_modified';
+            const REVISION_ID = '1';
             const TEST_ERROR = 'LambdaFunction error message';
             const TEST_ERROR_MESSAGE_RESPONSE = `The lambda deploy failed for Alexa region "default": ${TEST_ERROR}`;
+            const LAMDBA_RESPONSE = {
+                arn: LAMBDA_ARN,
+                lastModified: LAST_MODIFIED,
+                revisionId: REVISION_ID
+            };
+            const TEST_LAMBDA_RESULT = {
+                isAllStepSuccess: false,
+                isCodeDeployed: true,
+                lambdaResponse: LAMDBA_RESPONSE,
+                resultMessage: TEST_ERROR
+            };
             sinon.stub(awsUtil, 'getAWSProfile').withArgs(TEST_PROFILE).returns(TEST_PROFILE);
             sinon.stub(helper, 'loadLambdaInformation').callsArgWith(2, null, TEST_VALIDATED_DEPLOY_STATE);
             sinon.stub(helper, 'deployIAMRole').callsArgWith(2, null, TEST_IAM_ROLE_ARN);
-            sinon.stub(helper, 'deployLambdaFunction').callsArgWith(2, TEST_ERROR);
+            sinon.stub(helper, 'deployLambdaFunction').callsArgWith(2, null, TEST_LAMBDA_RESULT);
             // call
-            lambdaDeployer.invoke(REPORTER, TEST_OPTIONS, (err, data) => {
+            lambdaDeployer.invoke(REPORTER, TEST_OPTIONS, (err, res) => {
                 // verify
-                expect(data.resultMessage).equal(TEST_ERROR_MESSAGE_RESPONSE);
-                expect(data.deployState.iamRole).equal(TEST_IAM_ROLE_ARN);
+                expect(res.endpoint).equal(undefined);
+                expect(res.deployState.iamRole).equal(TEST_IAM_ROLE_ARN);
+                expect(res.deployState.lambda).deep.equal(LAMDBA_RESPONSE);
+                expect(res.resultMessage).equal(TEST_ERROR_MESSAGE_RESPONSE);
+                expect(err).equal(null);
                 done();
             });
         });
@@ -190,129 +244,6 @@ with output Lambda ARN: ${LAMBDA_ARN}.`;
                 expect(res.deployState.lambda).deep.equal(LAMDBA_RESPONSE);
                 expect(res.resultMessage).equal(TEST_SUCCESS_RESPONSE);
                 expect(err).equal(null);
-                done();
-            });
-        });
-
-        it('| alexaRegion is default, userConfig awsRegion is set, expect awsRegion is retrieved correctly.', (done) => {
-            // setup
-            const USER_CONFIG_AWS_REGION = 'sa-east-1';
-            const TEST_OPTIONS_WITHOUT_AWS_REGION = {
-                profile: TEST_PROFILE,
-                alexaRegion: TEST_ALEXA_REGION_DEFAULT,
-                skillId: '',
-                skillName: TEST_SKILL_NAME,
-                code: {},
-                userConfig: {
-                    awsRegion: USER_CONFIG_AWS_REGION
-                },
-                deployState: {}
-            };
-            const TEST_LAMBDA_RESULT = {
-                isAllStepSuccess: true,
-                isCodeDeployed: true,
-                lambdaResponse: {}
-            };
-            sinon.stub(awsUtil, 'getAWSProfile').withArgs(TEST_PROFILE).returns(TEST_PROFILE);
-            sinon.stub(helper, 'loadLambdaInformation').callsArgWith(2, null, TEST_VALIDATED_DEPLOY_STATE);
-            sinon.stub(helper, 'deployIAMRole').callsArgWith(2, null, TEST_IAM_ROLE_ARN);
-            sinon.stub(helper, 'deployLambdaFunction').callsArgWith(2, null, TEST_LAMBDA_RESULT);
-            // call
-            lambdaDeployer.invoke(REPORTER, TEST_OPTIONS_WITHOUT_AWS_REGION, (err) => {
-                // verify
-                expect(err).equal(null);
-                expect(helper.loadLambdaInformation.args[0][1].awsRegion).equal(USER_CONFIG_AWS_REGION);
-                expect(helper.deployIAMRole.args[0][1].awsRegion).equal(USER_CONFIG_AWS_REGION);
-                done();
-            });
-        });
-
-        it('| alexaRegion is default, userConfig awsRegion is NOT set, expect awsRegion is set based on Alexa and AWS region map.', (done) => {
-            // setup
-            const MAPPING_ALEXA_DEFAULT_AWS_REGION = 'us-east-1';
-            const TEST_OPTIONS_WITHOUT_AWS_REGION = {
-                profile: TEST_PROFILE,
-                alexaRegion: TEST_ALEXA_REGION_DEFAULT,
-                skillId: '',
-                skillName: TEST_SKILL_NAME,
-                code: {},
-                userConfig: {},
-                deployState: {}
-            };
-            const LAMDBA_RESULT = {};
-            sinon.stub(awsUtil, 'getAWSProfile').withArgs(TEST_PROFILE).returns(TEST_PROFILE);
-            sinon.stub(helper, 'loadLambdaInformation').callsArgWith(2, null, TEST_VALIDATED_DEPLOY_STATE);
-            sinon.stub(helper, 'deployIAMRole').callsArgWith(2, null, TEST_IAM_ROLE_ARN);
-            sinon.stub(helper, 'deployLambdaFunction').callsArgWith(2, null, LAMDBA_RESULT);
-            // call
-            lambdaDeployer.invoke(REPORTER, TEST_OPTIONS_WITHOUT_AWS_REGION, (err) => {
-                // verify
-                expect(err).equal(null);
-                expect(helper.loadLambdaInformation.args[0][1].awsRegion).equal(MAPPING_ALEXA_DEFAULT_AWS_REGION);
-                expect(helper.deployIAMRole.args[0][1].awsRegion).equal(MAPPING_ALEXA_DEFAULT_AWS_REGION);
-                done();
-            });
-        });
-
-        it('| alexaRegion is not default, userConfig regionalOverrides awsRegion is set, expect awsRegion is retrieved correctly.', (done) => {
-            // setup
-            const TEST_ALEXA_REGION_EU = 'EU';
-            const USER_CONFIG_AWS_REGION = 'eu-west-2';
-            const TEST_OPTIONS_WITHOUT_EU_REGION = {
-                profile: TEST_PROFILE,
-                alexaRegion: TEST_ALEXA_REGION_EU,
-                skillId: '',
-                skillName: TEST_SKILL_NAME,
-                code: {},
-                userConfig: {
-                    regionalOverrides: {
-                        EU: {
-                            awsRegion: USER_CONFIG_AWS_REGION
-                        }
-                    }
-                },
-                deployState: {}
-            };
-            const LAMDBA_RESULT = {};
-            sinon.stub(awsUtil, 'getAWSProfile').withArgs(TEST_PROFILE).returns(TEST_PROFILE);
-            sinon.stub(helper, 'loadLambdaInformation').callsArgWith(2, null, TEST_VALIDATED_DEPLOY_STATE);
-            sinon.stub(helper, 'deployIAMRole').callsArgWith(2, null, TEST_IAM_ROLE_ARN);
-            sinon.stub(helper, 'deployLambdaFunction').callsArgWith(2, null, LAMDBA_RESULT);
-            // call
-            lambdaDeployer.invoke(REPORTER, TEST_OPTIONS_WITHOUT_EU_REGION, (err) => {
-                // verify
-                expect(err).equal(null);
-                expect(helper.loadLambdaInformation.args[0][1].awsRegion).equal(USER_CONFIG_AWS_REGION);
-                expect(helper.deployIAMRole.args[0][1].awsRegion).equal(USER_CONFIG_AWS_REGION);
-                done();
-            });
-        });
-
-        it('| alexaRegion is not default, userConfig regionalOverrides awsRegion is NOT set, '
-        + 'expect awsRegion is set based on Alexa and AWS region map.', (done) => {
-            // setup
-            const TEST_ALEXA_REGION_EU = 'EU';
-            const MAPPING_ALEXA_EU_AWS_REGION = 'eu-west-1';
-            const TEST_OPTIONS_WITHOUT_AWS_REGION = {
-                profile: TEST_PROFILE,
-                alexaRegion: TEST_ALEXA_REGION_EU,
-                skillId: '',
-                skillName: TEST_SKILL_NAME,
-                code: {},
-                userConfig: {},
-                deployState: {}
-            };
-            const LAMDBA_RESULT = {};
-            sinon.stub(awsUtil, 'getAWSProfile').withArgs(TEST_PROFILE).returns(TEST_PROFILE);
-            sinon.stub(helper, 'loadLambdaInformation').callsArgWith(2, null, TEST_VALIDATED_DEPLOY_STATE);
-            sinon.stub(helper, 'deployIAMRole').callsArgWith(2, null, TEST_IAM_ROLE_ARN);
-            sinon.stub(helper, 'deployLambdaFunction').callsArgWith(2, null, LAMDBA_RESULT);
-            // call
-            lambdaDeployer.invoke(REPORTER, TEST_OPTIONS_WITHOUT_AWS_REGION, (err) => {
-                // verify
-                expect(err).equal(null);
-                expect(helper.loadLambdaInformation.args[0][1].awsRegion).equal(MAPPING_ALEXA_EU_AWS_REGION);
-                expect(helper.deployIAMRole.args[0][1].awsRegion).equal(MAPPING_ALEXA_EU_AWS_REGION);
                 done();
             });
         });


### PR DESCRIPTION
*Issue #, if available:*

Fixes: #388

*Description of changes:*

This change limits the skill infrastructure deployment to one task per AWS region by skipping the additional task(s) and copying the deploy state of the first task deployed in the same region. This will prevent unnecessary resources from being deployed twice in the same region and more importantly allow non-unique resource names configured in the stack template to be used on a per region basis.

The task skip implementation is taking advantage of the `listr` skip function. The change also includes a fix to ensure that previous Lambda deploy states are kept in the ask states file after getting an error. A basic use case of a revision id mismatch would currently reset that information making the subsequent call recreate unnecessarily the Lambda function and IAM role.

Some minor code refactoring and cleanup is included mostly due to the deployer aws region determination logic now happening earlier to accommodate for the task skip implementation.

```
==================== Deploy Skill Infrastructure ====================
  ✔ Deploy Alexa skill infrastructure for region "default"
  ↓ Deploy Alexa skill infrastructure for region "NA" [skipped]
    → The lambda deploy for Alexa region "NA" is same as "default".
  ✔ Deploy Alexa skill infrastructure for region "EU"
  ✔ Deploy Alexa skill infrastructure for region "FE"
Skill infrastructures deployed successfully through @ask-cli/lambda-deployer.
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
