### PR TITLE
feat: add lambda deployer additional user config function parameters

### DIFF
--- a/docs/concepts/Deploy-Command.md
+++ b/docs/concepts/Deploy-Command.md
@@ -12,7 +12,7 @@ This document focuses on explaining the deploy command in details for each type 
 
 **ignore-hash**: Optional. Forces ASK CLI deploy skill package even if the hash of current skill package folder does not change.
 
-**target**: Optional. Specify which skill project resource to deploy. Available options: skill-metadata,skill-infrastructure. 
+**target**: Optional. Specify which skill project resource to deploy. Available options: skill-metadata,skill-infrastructure.
 
 **profile**: Optional. Specify a profile name to be used. Defaults to use `default` as the profile name, if this option or environmental variable `ASK_DEFAULT_PROFILE` is not set.
 
@@ -115,11 +115,16 @@ This deployer is managing Lambda services by using the default settings to creat
      * If Lambda ARN is present, the deloyer will update the Lambda function's code and configuration.
 
 Supported parameters in `userConfig`:
-* awsRegion
-* runtime: Please see [AWS Lambda runtimes](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html) for more details.
-* handler: The entry point for the Lambda function in your code.
-* sourceLambda: You can set the `userConfig.sourceLambda.arn` to specify an existing Lambda ARN to reuse. This will be the target Lambda function when you deploy.
-* regionalOverrides: You can set `regionalOverrides.{region}.{anyPropertiesAbove}` to override the parameters for a certain region.
+* `awsRegion`
+* `runtime`: Please see [AWS Lambda runtimes](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html) for more details.
+* `handler`: The entry point for the Lambda function in your code.
+* `lambda.functionName`: The custom name for the Lambda function, otherwise ask cli will generate a unique name based on the skill, profile and region names.
+* `lambda.description`: The description for the Lambda function.
+* `lambda.memorySize`: The allocated memory size for the Lambda function. Defaults to 512 MB.
+* `lambda.timeout`: The timeout value for the Lambda function. Defaults to 15 seconds.
+* `lambda.environmentVariables`: The environment variables for the Lambda function.
+* `sourceLambda`: You can set the `userConfig.sourceLambda.arn` to specify an existing Lambda ARN to reuse. This will be the target Lambda function when you deploy.
+* `regionalOverrides`: You can set `regionalOverrides.{region}.{anyPropertiesAbove}` to override the parameters for a certain region.
 
 #### @ask-cli/cfn-deployer
 This deployer is implementing the idea of **Code as Infra** by using AWS CloudFormation. By using the CloudFormation template as the recipe, skill applications with similar infrastructure settings can simply share or extend existing template files. CloudFormation service also manages auto-rollback when a failure happens. Below shows the details of what this deployer does:

--- a/lib/builtins/deploy-delegates/lambda-deployer/helper.js
+++ b/lib/builtins/deploy-delegates/lambda-deployer/helper.js
@@ -128,6 +128,11 @@ function _createIAMRole(reporter, iamClient, skillName, callback) {
     });
 }
 
+/**
+ * Returns the IAM role name based on a generated unique role name
+ * @param {String} skillName
+ * @return {String}
+ */
 function _getIAMRoleName(skillName) {
     // Generates a valid IAM Role function name.
     //  a IAM Role function name should follow the pattern: ask-lambda-skillName-timeStamp
@@ -248,11 +253,26 @@ function _addEventPermissions(lambdaClient, skillId, functionArn, profile, callb
     });
 }
 
-function _getLambdaCustomValue(alexaRegion, userConfig, parameter) {
+/**
+ * Returns a Lambda user config parameter value at the regional level defaulting to top level
+ * @param {String} alexaRegion
+ * @param {Object} userConfig
+ * @param {String} parameter
+ * @return {String}
+ */
+function _getLambdaConfigParameter(alexaRegion, userConfig, parameter) {
     return R.path(['regionalOverrides', alexaRegion, 'lambda', parameter], userConfig)
     || R.path(['lambda', parameter], userConfig);
 }
 
+/**
+ * Returns the Lambda function name based on user config or a generated unique function name
+ * @param {String} alexaRegion
+ * @param {Object} userConfig
+ * @param {String} skillName
+ * @param {String} profile
+ * @return {String}
+ */
 function _getLambdaFunctionName(alexaRegion, userConfig, skillName, profile) {
     // Generates a valid Lambda function name.
     //  a lambda function name should follow the pattern: ask-skillName-profileName-alexaRegion-timeStamp
@@ -263,22 +283,27 @@ function _getLambdaFunctionName(alexaRegion, userConfig, skillName, profile) {
         return `ask-${validSkillName}-${validProfile}-${alexaRegion}-${Date.now()}`;
     };
 
-    return _getLambdaCustomValue(alexaRegion, userConfig, 'functionName') || generateFunctionName();
+    return _getLambdaConfigParameter(alexaRegion, userConfig, 'functionName') || generateFunctionName();
 }
 
+/**
+ * Returns the Lambda function config based on user config
+ * @param (String) alexaRegion
+ * @param {Object} userConfig
+ * @return {Object}
+ */
 function _getLambdaFunctionConfig(alexaRegion, userConfig) {
     const { runtime, handler } = userConfig;
-    const description = _getLambdaCustomValue(alexaRegion, userConfig, 'description');
-    const memorySize = _getLambdaCustomValue(alexaRegion, userConfig, 'memorySize');
-    const timeout = _getLambdaCustomValue(alexaRegion, userConfig, 'timeout');
-    const environmentVariables = _getLambdaCustomValue(alexaRegion, userConfig, 'environmentVariables');
+    const description = _getLambdaConfigParameter(alexaRegion, userConfig, 'description');
+    const memorySize = _getLambdaConfigParameter(alexaRegion, userConfig, 'memorySize');
+    const timeout = _getLambdaConfigParameter(alexaRegion, userConfig, 'timeout');
+    const environmentVariables = _getLambdaConfigParameter(alexaRegion, userConfig, 'environmentVariables');
     return {
         runtime,
         handler,
         description,
-        // default values to account for Java runtime cold start
-        memorySize: Number.parseInt(memorySize, 10) || 512,
-        timeout: Number.parseInt(timeout, 10) || 15,
+        memorySize: Number.parseInt(memorySize, 10) || CONSTANTS.LAMBDA.DEFAULT_CONFIG.MEMORY_SIZE,
+        timeout: Number.parseInt(timeout, 10) || CONSTANTS.LAMBDA.DEFAULT_CONFIG.TIMEOUT,
         environmentVariables
     };
 }

--- a/lib/builtins/deploy-delegates/lambda-deployer/helper.js
+++ b/lib/builtins/deploy-delegates/lambda-deployer/helper.js
@@ -112,7 +112,8 @@ function deployIAMRole(reporter, deployIAMConfig, callback) {
 }
 
 function _createIAMRole(reporter, iamClient, skillName, callback) {
-    iamClient.createBasicLambdaRole(skillName, (roleErr, roleData) => {
+    const roleName = _getIAMRoleName(skillName);
+    iamClient.createBasicLambdaRole(roleName, (roleErr, roleData) => {
         if (roleErr) {
             return callback(roleErr);
         }
@@ -125,6 +126,20 @@ function _createIAMRole(reporter, iamClient, skillName, callback) {
             callback(null, roleData.Role.Arn);
         });
     });
+}
+
+function _getIAMRoleName(skillName) {
+    // Generates a valid IAM Role function name.
+    //  a IAM Role function name should follow the pattern: ask-lambda-skillName-timeStamp
+    //  a valid role name cannot be longer than 64 characters, so the skillName should be <=39 characters since
+    //   the roleNamePrefix is 11 characters including the trailing '-' and the timeStamp is 14 characters including the '-'.
+    const generateIAMRoleName = () => {
+        const roleNamePrefix = process.env.ASK_DEPLOY_ROLE_PREFIX || 'ask-lambda';
+        const validSkillName = skillName.replace(/_/g, '-').substr(0, 39 - 1);
+        return `${roleNamePrefix}-${validSkillName}-${Date.now()}`;
+    };
+
+    return generateIAMRoleName();
 }
 
 function deployLambdaFunction(reporter, options, callback) {
@@ -166,8 +181,9 @@ function deployLambdaFunction(reporter, options, callback) {
 
 function _createLambdaFunction(reporter, lambdaClient, options, callback) {
     const { profile, alexaRegion, skillId, skillName, iamRoleArn, zipFilePath, userConfig } = options;
+    const functionName = _getLambdaFunctionName(alexaRegion, userConfig, skillName, profile);
+    const functionConfig = _getLambdaFunctionConfig(alexaRegion, userConfig);
     const zipFile = fs.readFileSync(zipFilePath);
-    const { runtime, handler } = userConfig;
     const retryConfig = {
         base: CONSTANTS.CONFIGURATION.RETRY.CREATE_LAMBDA_FUNCTION.BASE,
         factor: CONSTANTS.CONFIGURATION.RETRY.CREATE_LAMBDA_FUNCTION.FACTOR,
@@ -176,7 +192,7 @@ function _createLambdaFunction(reporter, lambdaClient, options, callback) {
     const RETRY_MESSAGE = 'The role defined for the function cannot be assumed by Lambda.';
     const retryCall = (loopCallback) => {
         // 1. Create a Lambda function
-        lambdaClient.createLambdaFunction(skillName, profile, alexaRegion, iamRoleArn, zipFile, runtime, handler, (lambdaErr, lambdaData) => {
+        lambdaClient.createLambdaFunction(functionName, functionConfig, iamRoleArn, zipFile, (lambdaErr, lambdaData) => {
             if (lambdaErr) {
                 // There may be a (small) window of time after creating IAM role and adding policies, the role will trigger the error
                 // if creating lambda function during this timming. Thus, use retry to bypass this issue.
@@ -232,13 +248,48 @@ function _addEventPermissions(lambdaClient, skillId, functionArn, profile, callb
     });
 }
 
+function _getLambdaCustomValue(alexaRegion, userConfig, parameter) {
+    return R.path(['regionalOverrides', alexaRegion, 'lambda', parameter], userConfig)
+    || R.path(['lambda', parameter], userConfig);
+}
+
+function _getLambdaFunctionName(alexaRegion, userConfig, skillName, profile) {
+    // Generates a valid Lambda function name.
+    //  a lambda function name should follow the pattern: ask-skillName-profileName-alexaRegion-timeStamp
+    //  a valid function name cannot longer than 64 characters, so cli fixes the project name no longer than 22 characters
+    const generateFunctionName = () => {
+        const validSkillName = stringUtils.filterNonAlphanumeric(skillName.toLowerCase()).substring(0, 22);
+        const validProfile = stringUtils.filterNonAlphanumeric(profile.toLowerCase()).substring(0, 15);
+        return `ask-${validSkillName}-${validProfile}-${alexaRegion}-${Date.now()}`;
+    };
+
+    return _getLambdaCustomValue(alexaRegion, userConfig, 'functionName') || generateFunctionName();
+}
+
+function _getLambdaFunctionConfig(alexaRegion, userConfig) {
+    const { runtime, handler } = userConfig;
+    const description = _getLambdaCustomValue(alexaRegion, userConfig, 'description');
+    const memorySize = _getLambdaCustomValue(alexaRegion, userConfig, 'memorySize');
+    const timeout = _getLambdaCustomValue(alexaRegion, userConfig, 'timeout');
+    const environmentVariables = _getLambdaCustomValue(alexaRegion, userConfig, 'environmentVariables');
+    return {
+        runtime,
+        handler,
+        description,
+        // default values to account for Java runtime cold start
+        memorySize: Number.parseInt(memorySize, 10) || 512,
+        timeout: Number.parseInt(timeout, 10) || 15,
+        environmentVariables
+    };
+}
+
 function _updateLambdaFunction(reporter, lambdaClient, options, callback) {
     _updateLambdaFunctionCode(reporter, lambdaClient, options, (codeErr, codeData) => {
         if (codeErr) {
             return callback(codeErr);
         }
 
-        _updateLambdaFunctionConfig(reporter, lambdaClient, codeData, (configErr, configData) => {
+        _updateLambdaFunctionConfig(reporter, lambdaClient, options, codeData.RevisionId, (configErr, configData) => {
             if (configErr) {
                 return callback(null, {
                     isAllStepSuccess: false,
@@ -267,42 +318,44 @@ function _updateLambdaFunction(reporter, lambdaClient, options, callback) {
 function _updateLambdaFunctionCode(reporter, lambdaClient, options, callback) {
     const { zipFilePath, deployState } = options;
     const zipFile = fs.readFileSync(zipFilePath);
-    const functionName = deployState.lambda.arn;
+    const functionArn = deployState.lambda.arn;
     const { revisionId } = deployState.lambda;
 
-    lambdaClient.updateFunctionCode(zipFile, functionName, revisionId, (err) => {
+    lambdaClient.updateFunctionCode(zipFile, functionArn, revisionId, (err) => {
         if (err) {
             return callback(err);
         }
 
-        reporter.updateStatus(`Update a lambda function code (${functionName}) in progress...`);
+        reporter.updateStatus(`Update a lambda function code (${functionArn}) in progress...`);
 
-        _waitForLambdaFunction(lambdaClient, functionName, callback);
+        _waitForLambdaFunction(lambdaClient, functionArn, callback);
     });
 }
 
-function _updateLambdaFunctionConfig(reporter, lambdaClient, lambdaConfig, callback) {
-    const { FunctionName: functionName, Runtime: runtime, Handler: handler, RevisionId: revisionId } = lambdaConfig;
+function _updateLambdaFunctionConfig(reporter, lambdaClient, options, revisionId, callback) {
+    const { alexaRegion, deployState, userConfig } = options;
+    const functionArn = deployState.lambda.arn;
+    const functionConfig = _getLambdaFunctionConfig(alexaRegion, userConfig);
 
-    lambdaClient.updateFunctionConfiguration(functionName, runtime, handler, revisionId, (err) => {
+    lambdaClient.updateFunctionConfiguration(functionArn, functionConfig, revisionId, (err) => {
         if (err) {
             return callback(err);
         }
 
-        reporter.updateStatus(`Update a lambda function configuration (${functionName}) in progress...`);
+        reporter.updateStatus(`Update a lambda function configuration (${functionArn}) in progress...`);
 
-        _waitForLambdaFunction(lambdaClient, functionName, callback);
+        _waitForLambdaFunction(lambdaClient, functionArn, callback);
     });
 }
 
-function _waitForLambdaFunction(lambdaClient, functionName, callback) {
+function _waitForLambdaFunction(lambdaClient, functionArn, callback) {
     const retryConfig = {
         base: CONSTANTS.CONFIGURATION.RETRY.WAIT_LAMBDA_FUNCTION.BASE,
         factor: CONSTANTS.CONFIGURATION.RETRY.WAIT_LAMBDA_FUNCTION.FACTOR,
         maxRetry: CONSTANTS.CONFIGURATION.RETRY.WAIT_LAMBDA_FUNCTION.MAXRETRY
     };
     const retryCall = (loopCallback) => {
-        lambdaClient.getFunction(functionName, (err, data) => {
+        lambdaClient.getFunction(functionArn, (err, data) => {
             if (err) {
                 return loopCallback(err);
             }
@@ -317,10 +370,10 @@ function _waitForLambdaFunction(lambdaClient, functionName, callback) {
             return callback(retryErr);
         }
         if (lambdaData.State !== CONSTANTS.LAMBDA.FUNCTION_STATE.ACTIVE) {
-            return callback(`Function [${functionName}] state is ${lambdaData.State}.`);
+            return callback(`Function [${functionArn}] state is ${lambdaData.State}.`);
         }
         if (lambdaData.LastUpdateStatus !== CONSTANTS.LAMBDA.LAST_UPDATE_STATUS.SUCCESSFUL) {
-            return callback(`Function [${functionName}] last update status is ${lambdaData.LastUpdateStatus}.`);
+            return callback(`Function [${functionArn}] last update status is ${lambdaData.LastUpdateStatus}.`);
         }
         callback(null, lambdaData);
     });

--- a/lib/clients/aws-client/iam-client.js
+++ b/lib/clients/aws-client/iam-client.js
@@ -30,11 +30,10 @@ module.exports = class IAMClient extends AbstractAwsClient {
     /**
      * Wrapper of iam sdk api
      * Creates a new role for AWS account.
-     * @param {string} skillName The name of the skill to generate a IAM role name.
+     * @param {string} roleName The name of the IAM role.
      * @param {callback} callback { error, response }
      */
-    createBasicLambdaRole(skillName, callback) {
-        const roleName = this._generateIAMRoleName(skillName);
+    createBasicLambdaRole(roleName, callback) {
         const policy = CONSTANTS.AWS.IAM.ROLE.LAMBDA_BASIC_ROLE.POLICY;
         const params = {
             RoleName: roleName,
@@ -67,18 +66,5 @@ module.exports = class IAMClient extends AbstractAwsClient {
      */
     _extractIAMRoleName(roleArn) {
         return roleArn.split('role/').pop();
-    }
-
-    /**
-     * Generates a valid IAM Role function name.
-     * a IAM Role function name should follow the pattern: ask-lambda-skillName-timeStamp
-     * a valid role name cannot be longer than 64 characters, so the skillName should be <=39 characters since
-     * the roleNamePrefix is 11 characters including the trailing '-' and the timeStamp is 14 characters including the '-'.
-     * @param {string} skillName
-     */
-    _generateIAMRoleName(skillName) {
-        const roleNamePrefix = process.env.ASK_DEPLOY_ROLE_PREFIX || 'ask-lambda';
-        const validSkillName = skillName.replace(/_/g, '-').substr(0, 39 - 1);
-        return `${roleNamePrefix}-${validSkillName}-${Date.now()}`;
     }
 };

--- a/lib/clients/aws-client/lambda-client.js
+++ b/lib/clients/aws-client/lambda-client.js
@@ -27,12 +27,12 @@ module.exports = class LambdaClient extends AbstractAwsClient {
                 ZipFile: zipFile
             },
             FunctionName: functionName,
+            Handler: handler,
+            MemorySize: memorySize,
             Role: role,
             Runtime: runtime,
-            Handler: handler,
-            ...(description && { Description: description }),
-            MemorySize: memorySize,
             Timeout: timeout,
+            ...(description && { Description: description }),
             ...(environmentVariables && { Environment: { Variables: environmentVariables } })
         };
         this.client.createFunction(params, (err, data) => {
@@ -105,13 +105,13 @@ module.exports = class LambdaClient extends AbstractAwsClient {
         const { runtime, handler, description, memorySize, timeout, environmentVariables } = config;
         const params = {
             FunctionName: functionArn,
-            Runtime: runtime,
             Handler: handler,
-            ...(description && { Description: description }),
             MemorySize: memorySize,
+            RevisionId: revisionId,
+            Runtime: runtime,
             Timeout: timeout,
-            ...(environmentVariables && { Environment: { Variables: environmentVariables } }),
-            RevisionId: revisionId
+            ...(description && { Description: description }),
+            ...(environmentVariables && { Environment: { Variables: environmentVariables } })
         };
         this.client.updateFunctionConfiguration(params, (err, data) => {
             callback(err, !err ? data : null);

--- a/lib/clients/aws-client/lambda-client.js
+++ b/lib/clients/aws-client/lambda-client.js
@@ -30,12 +30,10 @@ module.exports = class LambdaClient extends AbstractAwsClient {
             Role: role,
             Runtime: runtime,
             Handler: handler,
-            Description: description,
+            ...(description && { Description: description }),
             MemorySize: memorySize,
             Timeout: timeout,
-            Environment: {
-                Variables: environmentVariables
-            }
+            ...(environmentVariables && { Environment: { Variables: environmentVariables } })
         };
         this.client.createFunction(params, (err, data) => {
             callback(err, !err ? data : null);
@@ -109,12 +107,10 @@ module.exports = class LambdaClient extends AbstractAwsClient {
             FunctionName: functionArn,
             Runtime: runtime,
             Handler: handler,
-            Description: description,
+            ...(description && { Description: description }),
             MemorySize: memorySize,
             Timeout: timeout,
-            Environment: {
-                Variables: environmentVariables
-            },
+            ...(environmentVariables && { Environment: { Variables: environmentVariables } }),
             RevisionId: revisionId
         };
         this.client.updateFunctionConfiguration(params, (err, data) => {

--- a/lib/clients/aws-client/lambda-client.js
+++ b/lib/clients/aws-client/lambda-client.js
@@ -1,6 +1,5 @@
 const aws = require('aws-sdk');
 
-const stringUtils = require('@src/utils/string-utils');
 const AbstractAwsClient = require('./abstract-aws-client');
 
 /**
@@ -16,24 +15,27 @@ module.exports = class LambdaClient extends AbstractAwsClient {
      * Wrapper of aws sdk api
      * Creates a Lambda function
      * @param {string} functionName The name of the Lambda function.
+     * @param {object} config The configuration of the Lambda function.
      * @param {string} role The Amazon Resource Name (ARN) of the function's execution role.
      * @param {Buffer} zipFile The base64-encoded contents of the deployment package.
-     * @param {string} runtime The identifier of the function's runtime.
-     * @param {string} handler The name of the method within your code that Lambda calls to execute your function.
      * @param {callback} callback { error, response }
      */
-    createLambdaFunction(skillName, profile, alexaRegion, role, zipFile, runtime, handler, callback) {
+    createLambdaFunction(functionName, config, role, zipFile, callback) {
+        const { runtime, handler, description, memorySize, timeout, environmentVariables } = config;
         const params = {
             Code: {
                 ZipFile: zipFile
             },
+            FunctionName: functionName,
             Role: role,
             Runtime: runtime,
             Handler: handler,
-            // to account for Java runtime cold start
-            Timeout: 15,
-            MemorySize: 512,
-            FunctionName: this._generateFunctionName(skillName, profile, alexaRegion)
+            Description: description,
+            MemorySize: memorySize,
+            Timeout: timeout,
+            Environment: {
+                Variables: environmentVariables
+            }
         };
         this.client.createFunction(params, (err, data) => {
             callback(err, !err ? data : null);
@@ -45,7 +47,7 @@ module.exports = class LambdaClient extends AbstractAwsClient {
      * Grants an AWS service or another account permission to use a function.
      * @param {string} domain The type of skill.
      * @param {string} skillId The skill ID is used as a token that must be supplied by the invoker.
-     * @param {string} functionArn The name of the Lambda function.
+     * @param {string} functionArn The arn of the Lambda function.
      * @param {callback} callback { error, response }
      */
     addAlexaPermissionByDomain(domain, skillId, functionArn, callback) {
@@ -78,14 +80,14 @@ module.exports = class LambdaClient extends AbstractAwsClient {
      * Wrapper of aws sdk api
      * Updates a Lambda function's code.
      * @param {Buffer} zipFile The base64-encoded contents of the deployment package.
-     * @param {string} functionName The name of the Lambda function.
+     * @param {string} functionArn The arn of the Lambda function.
      * @param {string} revisionId Only update the function if the revision ID matches the ID that's specified.
      * @param {callback} callback { error, response }
      */
-    updateFunctionCode(zipFile, functionName, revisionId, callback) {
+    updateFunctionCode(zipFile, functionArn, revisionId, callback) {
         const codeUpdateParams = {
             ZipFile: zipFile,
-            FunctionName: functionName,
+            FunctionName: functionArn,
             RevisionId: revisionId
         };
         this.client.updateFunctionCode(codeUpdateParams, (err, data) => {
@@ -96,20 +98,26 @@ module.exports = class LambdaClient extends AbstractAwsClient {
     /**
      * Wrapper of aws sdk api
      * Modifies the version-specific settings of a Lambda function.
-     * @param {string} functionName The name of the Lambda function.
-     * @param {string} runtime The identifier of the function's runtime.
-     * @param {string} handler The name of the method within your code that Lambda calls to execute your function.
+     * @param {string} functionArn The arn of the Lambda function.
+     * @param {object} config The configuration of the Lambda function.
      * @param {string} revisionId Only update the function if the revision ID matches the ID that's specified.
      * @param {callback} callback { error, response }
      */
-    updateFunctionConfiguration(functionName, runtime, handler, revisionId, callback) {
-        const configurationUpdateParams = {
-            FunctionName: functionName,
+    updateFunctionConfiguration(functionArn, config, revisionId, callback) {
+        const { runtime, handler, description, memorySize, timeout, environmentVariables } = config;
+        const params = {
+            FunctionName: functionArn,
             Runtime: runtime,
             Handler: handler,
+            Description: description,
+            MemorySize: memorySize,
+            Timeout: timeout,
+            Environment: {
+                Variables: environmentVariables
+            },
             RevisionId: revisionId
         };
-        this.client.updateFunctionConfiguration(configurationUpdateParams, (err, data) => {
+        this.client.updateFunctionConfiguration(params, (err, data) => {
             callback(err, !err ? data : null);
         });
     }
@@ -141,19 +149,5 @@ module.exports = class LambdaClient extends AbstractAwsClient {
         default:
         }
         return permission;
-    }
-
-    /**
-     * Generates a valid Lambda function name.
-     * a lambda function name should follow the pattern: ask-skillName-profileName-alexaRegion-timeStamp
-     * a valid function name cannot longer than 64 characters, so cli fixes the project name no longer than 22 characters
-     * @param {String} skillName
-     * @param {String} awsProfile
-     */
-    _generateFunctionName(skillName, profile, alexaRegion) {
-        const validSkillName = stringUtils.filterNonAlphanumeric(skillName.toLowerCase()).substring(0, 22);
-        const validProfile = stringUtils.filterNonAlphanumeric(profile.toLowerCase()).substring(0, 15);
-        const shortRegionName = alexaRegion.replace(/-/g, '');
-        return `ask-${validSkillName}-${validProfile}-${shortRegionName}-${Date.now()}`;
     }
 };

--- a/lib/utils/constants.js
+++ b/lib/utils/constants.js
@@ -302,6 +302,11 @@ module.exports.AWS = {
 };
 
 module.exports.LAMBDA = {
+    DEFAULT_CONFIG: {
+        // default values to account for Java runtime cold start
+        MEMORY_SIZE: 512,
+        TIMEOUT: 15
+    },
     FUNCTION_STATE: {
         ACTIVE: 'Active',
         INACTIVE: 'Inactive',

--- a/test/unit/builtins/lambda-deployer/helper-test.js
+++ b/test/unit/builtins/lambda-deployer/helper-test.js
@@ -337,7 +337,7 @@ Please solve this revision mismatch and re-deploy again. To ignore this error ru
         const TEST_HANDLER = 'handler';
         const TEST_CREATE_OPTIONS = {
             profile: TEST_PROFILE,
-            awsProfile: TEST_AWS_REGION,
+            awsProfile: TEST_PROFILE,
             alexaRegion: TEST_ALEXA_REGION,
             awsRegion: TEST_AWS_REGION,
             skillId: TEST_SKILL_ID,
@@ -392,7 +392,7 @@ Please solve this revision mismatch and re-deploy again. To ignore this error ru
             const TEST_CREATE_FUNCTION_ERROR = 'createLambdaFunction error';
             sinon.stub(fs, 'readFileSync').withArgs(TEST_ZIP_FILE_PATH).returns(TEST_ZIP_FILE);
             sinon.stub(aws, 'Lambda');
-            sinon.stub(LambdaClient.prototype, 'createLambdaFunction').callsArgWith(7, TEST_CREATE_FUNCTION_ERROR);
+            sinon.stub(LambdaClient.prototype, 'createLambdaFunction').callsArgWith(4, TEST_CREATE_FUNCTION_ERROR);
             // call
             helper.deployLambdaFunction(REPORTER, TEST_CREATE_OPTIONS, (err) => {
                 // verify
@@ -410,8 +410,8 @@ Please solve this revision mismatch and re-deploy again. To ignore this error ru
             sinon.stub(fs, 'readFileSync').withArgs(TEST_ZIP_FILE_PATH).returns(TEST_ZIP_FILE);
             sinon.stub(aws, 'Lambda');
             const stubTestFunc = sinon.stub(LambdaClient.prototype, 'createLambdaFunction');
-            stubTestFunc.onCall(0).callsArgWith(7, TEST_CREATE_FUNCTION_ERROR);
-            stubTestFunc.onCall(1).callsArgWith(7, null, TEST_CREATE_DATA);
+            stubTestFunc.onCall(0).callsArgWith(4, TEST_CREATE_FUNCTION_ERROR);
+            stubTestFunc.onCall(1).callsArgWith(4, null, TEST_CREATE_DATA);
             sinon.stub(LambdaClient.prototype, 'addAlexaPermissionByDomain').callsArgWith(3, TEST_ADD_PERMISSION_ERROR);
             sinon.stub(LambdaClient.prototype, 'getFunction').callsArgWith(1, null, TEST_GET_DATA);
             // call
@@ -428,7 +428,7 @@ Please solve this revision mismatch and re-deploy again. To ignore this error ru
             const TEST_GET_STATE_ERROR = `Function [${TEST_FUNCTION_ARN}] state is Inactive.`;
             sinon.stub(fs, 'readFileSync').withArgs(TEST_ZIP_FILE_PATH).returns(TEST_ZIP_FILE);
             sinon.stub(aws, 'Lambda');
-            sinon.stub(LambdaClient.prototype, 'createLambdaFunction').callsArgWith(7, null, TEST_CREATE_DATA);
+            sinon.stub(LambdaClient.prototype, 'createLambdaFunction').callsArgWith(4, null, TEST_CREATE_DATA);
             sinon.stub(LambdaClient.prototype, 'getFunction').callsArgWith(1, null, TEST_GET_STATE_DATA);
             // call
             helper.deployLambdaFunction(REPORTER, TEST_CREATE_OPTIONS, (err) => {
@@ -443,7 +443,7 @@ Please solve this revision mismatch and re-deploy again. To ignore this error ru
             const TEST_ADD_PERMISSION_ERROR = 'addAlexaPermissionByDomain error';
             sinon.stub(fs, 'readFileSync').withArgs(TEST_ZIP_FILE_PATH).returns(TEST_ZIP_FILE);
             sinon.stub(aws, 'Lambda');
-            sinon.stub(LambdaClient.prototype, 'createLambdaFunction').callsArgWith(7, null, TEST_CREATE_DATA);
+            sinon.stub(LambdaClient.prototype, 'createLambdaFunction').callsArgWith(4, null, TEST_CREATE_DATA);
             sinon.stub(LambdaClient.prototype, 'addAlexaPermissionByDomain').callsArgWith(3, TEST_ADD_PERMISSION_ERROR);
             sinon.stub(LambdaClient.prototype, 'getFunction').callsArgWith(1, null, TEST_GET_DATA);
             // call
@@ -460,7 +460,7 @@ Please solve this revision mismatch and re-deploy again. To ignore this error ru
             const TEST_REVISION_ID_ERROR = 'getFunctionRevisionId error';
             sinon.stub(fs, 'readFileSync').withArgs(TEST_ZIP_FILE_PATH).returns(TEST_ZIP_FILE);
             sinon.stub(aws, 'Lambda');
-            sinon.stub(LambdaClient.prototype, 'createLambdaFunction').callsArgWith(7, null, TEST_CREATE_DATA);
+            sinon.stub(LambdaClient.prototype, 'createLambdaFunction').callsArgWith(4, null, TEST_CREATE_DATA);
             sinon.stub(LambdaClient.prototype, 'addAlexaPermissionByDomain').callsArgWith(3, null);
             const stubTestFunc = sinon.stub(LambdaClient.prototype, 'getFunction');
             stubTestFunc.onCall(0).callsArgWith(1, null, TEST_GET_DATA);
@@ -479,7 +479,7 @@ Please solve this revision mismatch and re-deploy again. To ignore this error ru
             // setup
             sinon.stub(fs, 'readFileSync').withArgs(TEST_ZIP_FILE_PATH).returns(TEST_ZIP_FILE);
             sinon.stub(aws, 'Lambda');
-            sinon.stub(LambdaClient.prototype, 'createLambdaFunction').callsArgWith(7, null, TEST_CREATE_DATA);
+            sinon.stub(LambdaClient.prototype, 'createLambdaFunction').callsArgWith(4, null, TEST_CREATE_DATA);
             sinon.stub(LambdaClient.prototype, 'addAlexaPermissionByDomain').callsArgWith(3, null);
             sinon.stub(LambdaClient.prototype, 'getFunction').callsArgWith(1, null, TEST_GET_DATA);
 
@@ -505,7 +505,7 @@ Please solve this revision mismatch and re-deploy again. To ignore this error ru
             sinon.stub(fs, 'readFileSync').withArgs(TEST_ZIP_FILE_PATH).returns(TEST_ZIP_FILE);
             sinon.stub(aws, 'Lambda');
             sinon.stub(ResourcesConfig.prototype, 'getTargetEndpoints').returns([]);
-            sinon.stub(LambdaClient.prototype, 'createLambdaFunction').callsArgWith(7, null, TEST_CREATE_DATA);
+            sinon.stub(LambdaClient.prototype, 'createLambdaFunction').callsArgWith(4, null, TEST_CREATE_DATA);
             sinon.stub(LambdaClient.prototype, 'addAlexaPermissionByDomain').callsArgWith(3, null);
             sinon.stub(LambdaClient.prototype, 'getFunction').callsArgWith(1, null, TEST_GET_DATA);
 
@@ -557,11 +557,11 @@ Please solve this revision mismatch and re-deploy again. To ignore this error ru
 
         it('| an existing Lambda found, update function code passes, update function configuration fails, expect an error return.', (done) => {
             // setup
-            const TEST_UPDATE_CONGIF_ERROR = 'updateFunctionConfiguration error';
+            const TEST_UPDATE_CONFIG_ERROR = 'updateFunctionConfiguration error';
             sinon.stub(fs, 'readFileSync').withArgs(TEST_ZIP_FILE_PATH).returns(TEST_ZIP_FILE);
             sinon.stub(aws, 'Lambda');
             sinon.stub(LambdaClient.prototype, 'updateFunctionCode').callsArgWith(3, null, { RevisionId: TEST_REVISION_ID });
-            sinon.stub(LambdaClient.prototype, 'updateFunctionConfiguration').callsArgWith(4, TEST_UPDATE_CONGIF_ERROR);
+            sinon.stub(LambdaClient.prototype, 'updateFunctionConfiguration').callsArgWith(3, TEST_UPDATE_CONFIG_ERROR);
             sinon.stub(LambdaClient.prototype, 'getFunction').callsArgWith(1, null, TEST_GET_DATA);
             // call
             helper.deployLambdaFunction(REPORTER, TEST_UPDATE_OPTIONS, (err, res) => {
@@ -575,7 +575,7 @@ Please solve this revision mismatch and re-deploy again. To ignore this error ru
                         lastModified: TEST_LAST_MODIFIED,
                         revisionId: TEST_UPDATED_REVISION_ID
                     },
-                    resultMessage: TEST_UPDATE_CONGIF_ERROR
+                    resultMessage: TEST_UPDATE_CONFIG_ERROR
                 });
                 done();
             });
@@ -591,7 +591,7 @@ Please solve this revision mismatch and re-deploy again. To ignore this error ru
             sinon.stub(fs, 'readFileSync').withArgs(TEST_ZIP_FILE_PATH).returns(TEST_ZIP_FILE);
             sinon.stub(aws, 'Lambda');
             sinon.stub(LambdaClient.prototype, 'updateFunctionCode').callsArgWith(3, null, { RevisionId: TEST_REVISION_ID });
-            sinon.stub(LambdaClient.prototype, 'updateFunctionConfiguration').callsArgWith(4, null, TEST_UPDATE_CONFIG_DATA);
+            sinon.stub(LambdaClient.prototype, 'updateFunctionConfiguration').callsArgWith(3, null, TEST_UPDATE_CONFIG_DATA);
             sinon.stub(LambdaClient.prototype, 'getFunction').callsArgWith(1, null, TEST_GET_DATA);
             // call
             helper.deployLambdaFunction(REPORTER, TEST_UPDATE_OPTIONS, (err, data) => {

--- a/test/unit/clients/aws-client/iam-client-test.js
+++ b/test/unit/clients/aws-client/iam-client-test.js
@@ -12,7 +12,7 @@ describe('Clients test - iam client test', () => {
         awsRegion: TEST_AWS_REGION
     };
     const TEST_ROLE_ARN = 'iam_role_arn';
-    const TEST_SKILL_NAME = 'skill_name';
+    const TEST_ROLE_NAME = 'iam_role_name';
 
     afterEach(() => {
         sinon.restore();
@@ -91,7 +91,7 @@ describe('Clients test - iam client test', () => {
             const TEST_CREATE_ROLE_ERR = 'CREATE_ROLE_ERROR';
             sinon.stub(iamClient.client, 'createRole').callsArgWith(1, TEST_CREATE_ROLE_ERR);
             // call
-            iamClient.createBasicLambdaRole(TEST_SKILL_NAME, (err) => {
+            iamClient.createBasicLambdaRole(TEST_ROLE_NAME, (err) => {
                 // verify
                 expect(err).equal(TEST_CREATE_ROLE_ERR);
                 done();
@@ -108,7 +108,7 @@ describe('Clients test - iam client test', () => {
             };
             sinon.stub(iamClient.client, 'createRole').callsArgWith(1, null, TEST_CREATE_ROLE_RESPONSE);
             // call
-            iamClient.createBasicLambdaRole(TEST_SKILL_NAME, (err, data) => {
+            iamClient.createBasicLambdaRole(TEST_ROLE_NAME, (err, data) => {
                 // verify
                 expect(data.Role.Arn).equal(TEST_ROLE_ARN);
                 expect(err).equal(null);

--- a/test/unit/clients/aws-client/lambda-client-test.js
+++ b/test/unit/clients/aws-client/lambda-client-test.js
@@ -7,18 +7,16 @@ const LambdaClient = require('@src/clients/aws-client/lambda-client');
 describe('Clients test - lambda client test', () => {
     const TEST_AWS_PROFILE = 'TEST_AWS_PROFILE';
     const TEST_AWS_REGION = 'TEST_AWS_REGION';
-    const TEST_ALEXA_REGION = 'TEST_ALEXA_REGION';
     const TEST_CONFIGURATION = {
         awsProfile: TEST_AWS_PROFILE,
         awsRegion: TEST_AWS_REGION
     };
-    const TEST_SKILL_NAME = 'skill_name';
     const TEST_FUNCTION_ARN = 'function_arn';
     const TEST_SKILL_ID = 'skill_id';
     const TEST_REVISION_ID = 'revision_id';
-    const TEST_ZIPFILD = 'zipfile_path';
-    const TEST_RUNTIME = 'runtime';
-    const TEST_HANDLE = 'handler';
+    const TEST_ZIPFILE = 'zipfile_path';
+    const TEST_FUNCTION_NAME = 'function_name';
+    const TEST_FUNCTION_CONFIG = 'function_config';
 
     afterEach(() => {
         sinon.restore();
@@ -66,8 +64,7 @@ describe('Clients test - lambda client test', () => {
             const TEST_CREATE_FUNCTION_ERR = 'create_function_error';
             sinon.stub(lambdaClient.client, 'createFunction').callsArgWith(1, TEST_CREATE_FUNCTION_ERR);
             // call
-            lambdaClient.createLambdaFunction(TEST_SKILL_NAME, TEST_AWS_PROFILE, TEST_ALEXA_REGION,
-                TEST_IAM_ROLE, TEST_ZIPFILD, TEST_RUNTIME, TEST_HANDLE, (err) => {
+            lambdaClient.createLambdaFunction(TEST_FUNCTION_NAME, TEST_FUNCTION_CONFIG, TEST_IAM_ROLE, TEST_ZIPFILE, (err) => {
                 // verify
                     expect(err).equal(TEST_CREATE_FUNCTION_ERR);
                     done();
@@ -82,8 +79,7 @@ describe('Clients test - lambda client test', () => {
             };
             sinon.stub(lambdaClient.client, 'createFunction').callsArgWith(1, null, TEST_CREATE_FUNCTION_RESPONSE);
             // call
-            lambdaClient.createLambdaFunction(TEST_SKILL_NAME, TEST_AWS_PROFILE, TEST_ALEXA_REGION,
-                TEST_IAM_ROLE, TEST_ZIPFILD, TEST_RUNTIME, TEST_HANDLE, (err, data) => {
+            lambdaClient.createLambdaFunction(TEST_FUNCTION_NAME, TEST_FUNCTION_CONFIG, TEST_IAM_ROLE, TEST_ZIPFILE, (err, data) => {
                 // verify
                     expect(data.FunctionArn).equal(TEST_FUNCTION_ARN);
                     done();
@@ -185,7 +181,7 @@ describe('Clients test - lambda client test', () => {
             const TEST_UPDATE_CODE_ERR = 'UPDATE_CODE_ERROR';
             sinon.stub(lambdaClient.client, 'updateFunctionCode').callsArgWith(1, TEST_UPDATE_CODE_ERR);
             // call
-            lambdaClient.updateFunctionCode(TEST_ZIPFILD, TEST_FUNCTION_ARN, TEST_REVISION_ID, (err) => {
+            lambdaClient.updateFunctionCode(TEST_ZIPFILE, TEST_FUNCTION_ARN, TEST_REVISION_ID, (err) => {
                 // verify
                 expect(err).equal(TEST_UPDATE_CODE_ERR);
                 done();
@@ -200,7 +196,7 @@ describe('Clients test - lambda client test', () => {
             };
             sinon.stub(lambdaClient.client, 'updateFunctionCode').callsArgWith(1, null, TEST_UPDATE_CODE_RESPONSE);
             // call
-            lambdaClient.updateFunctionCode(TEST_ZIPFILD, TEST_FUNCTION_ARN, TEST_REVISION_ID, (err, data) => {
+            lambdaClient.updateFunctionCode(TEST_ZIPFILE, TEST_FUNCTION_ARN, TEST_REVISION_ID, (err, data) => {
                 // verify
                 expect(data.FunctionArn).equal(TEST_FUNCTION_ARN);
                 done();
@@ -215,7 +211,7 @@ describe('Clients test - lambda client test', () => {
             const TEST_UPDATE_CONFIG_ERR = 'UPDATE_CONFIG_ERROR';
             sinon.stub(lambdaClient.client, 'updateFunctionConfiguration').callsArgWith(1, TEST_UPDATE_CONFIG_ERR);
             // call
-            lambdaClient.updateFunctionConfiguration(TEST_FUNCTION_ARN, TEST_RUNTIME, TEST_HANDLE, TEST_REVISION_ID, (err) => {
+            lambdaClient.updateFunctionConfiguration(TEST_FUNCTION_ARN, TEST_FUNCTION_CONFIG, TEST_REVISION_ID, (err) => {
                 // verify
                 expect(err).equal(TEST_UPDATE_CONFIG_ERR);
                 done();
@@ -230,7 +226,7 @@ describe('Clients test - lambda client test', () => {
             };
             sinon.stub(lambdaClient.client, 'updateFunctionConfiguration').callsArgWith(1, null, TEST_UPDATE_CONFIG_RESPONSE);
             // call
-            lambdaClient.updateFunctionConfiguration(TEST_FUNCTION_ARN, TEST_RUNTIME, TEST_HANDLE, TEST_REVISION_ID, (err, data) => {
+            lambdaClient.updateFunctionConfiguration(TEST_FUNCTION_ARN, TEST_FUNCTION_CONFIG, TEST_REVISION_ID, (err, data) => {
                 // verify
                 expect(data.RevisionId).equal(TEST_REVISION_ID);
                 done();


### PR DESCRIPTION
*Description of changes:*

This change adds the ability to customize some additional Lambda function config parameters (function name, description, memory size, timeout and environmental variables) through the ask resources user config, when using the Lambda deployer. This is useful if a user only needs to deploy a Lambda function part of the skill stack without the need to use the CFN deployer just to set this customization.

Some minor code refactoring and cleanup is included mostly moving the generate AWS resource name functions out of the clients library into the relevant builtins instead.

```
{
  "askcliResourcesVersion": "2020-03-31",
  "profiles": {
    "default": {
      "skillMetadata": {
        "src": "./skill-package"
      },
      "code": {
        "default": {
          "src": "./lambda"
        }
      },
      "skillInfrastructure": {
        "type": "@ask-cli/lambda-deployer",
        "userConfig": {
          "runtime": "nodejs14.x",
          "handler": "index.handler",
          "lambda": {
            "functionName": "<functionName>",
            "description": "<description>",
            "memorySize": 128,
            "timeout": 10,
            "environmentVariables": {
              "ENV_1": "<value1>",
              "ENV_2": "<value2>"
            }
          }
        }
      }
    }
  }
}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
