### PR TITLE
feat: Change Alexa Hosted Skill runtime to Node.js 12

### DIFF
--- a/lib/commands/smapi/appended-commands/export-package/index.js
+++ b/lib/commands/smapi/appended-commands/export-package/index.js
@@ -8,10 +8,10 @@ const jsonView = require('@src/view/json-view');
 const Messenger = require('@src/view/messenger');
 const optionModel = require('@src/commands/option-model');
 const profileHelper = require('@src/utils/profile-helper');
-const SmapiClient = require('@src/clients/smapi-client/index.js');
+const SmapiClient = require('@src/clients/smapi-client/index');
 const zipUtils = require('@src/utils/zip-utils');
 
-const helper = require('./helper.js');
+const helper = require('./helper');
 
 class ExportPackageCommand extends AbstractCommand {
     name() {

--- a/lib/controllers/hosted-skill-controller/index.js
+++ b/lib/controllers/hosted-skill-controller/index.js
@@ -10,7 +10,7 @@ const jsonView = require('@src/view/json-view');
 const Messenger = require('@src/view/messenger');
 
 const cloneFlow = require('./clone-flow');
-const helper = require('./helper.js');
+const helper = require('./helper');
 
 module.exports = class HostedSkillController {
     constructor(configuration) {

--- a/lib/controllers/skill-metadata-controller/index.js
+++ b/lib/controllers/skill-metadata-controller/index.js
@@ -4,7 +4,7 @@ const path = require('path');
 
 const retryUtils = require('@src/utils/retry-utility');
 const ResourcesConfig = require('@src/model/resources-config');
-const SmapiClient = require('@src/clients/smapi-client/index.js');
+const SmapiClient = require('@src/clients/smapi-client/index');
 const httpClient = require('@src/clients/http-client');
 const Manifest = require('@src/model/manifest');
 const Messenger = require('@src/view/messenger');

--- a/lib/utils/constants.js
+++ b/lib/utils/constants.js
@@ -40,7 +40,7 @@ module.exports.HOSTED_SKILL = {
         'eu-west-1': 'EU_WEST_1'
     },
     DEFAULT_RUNTIME: {
-        NodeJS: 'NODE_10_X',
+        NodeJS: 'NODE_12_X',
         Python: 'PYTHON_3_7',
     },
     SIGNIN_PATH: '/ap/signin',

--- a/test/integration/commands/smapi-commands-test.js
+++ b/test/integration/commands/smapi-commands-test.js
@@ -504,7 +504,7 @@ parallel('smapi command test', () => {
     });
 
     it('| should get alexa hosted skill user permissions', async () => {
-        const args = [subCmd, 'get-alexa-hosted-skill-user-permissions', '--permission', 'somePermission'];
+        const args = [subCmd, 'get-alexa-hosted-skill-user-permissions', '--hosted-skill-permission-type', 'somePermission'];
         addCoveredCommand(args);
         const result = await run(cmd, args, options);
         expect(result).be.an('object');
@@ -631,7 +631,7 @@ parallel('smapi command test', () => {
     });
 
     it('| should create interaction model catalog version', async () => {
-        const args = [subCmd, 'create-interaction-model-catalog-version', '-c', catalogId, '--description', 'someDescription'];
+        const args = [subCmd, 'create-interaction-model-catalog-version', '-c', catalogId, '--sourceType', 'catalogType', '--sourceUrl', 'catalogUrl', '--description', 'someDescription'];
         addCoveredCommand(args);
         const result = await run(cmd, args, { ...options, parse: false });
         expect(result).include('Command executed successfully!');

--- a/test/integration/commands/smapi-commands-test.js
+++ b/test/integration/commands/smapi-commands-test.js
@@ -631,7 +631,7 @@ parallel('smapi command test', () => {
     });
 
     it('| should create interaction model catalog version', async () => {
-        const args = [subCmd, 'create-interaction-model-catalog-version', '-c', catalogId, '--sourceType', 'catalogType', '--sourceUrl', 'catalogUrl', '--description', 'someDescription'];
+        const args = [subCmd, 'create-interaction-model-catalog-version', '-c', catalogId, '--source-type', 'catalogType', '--source-url', 'catalogUrl', '--description', 'someDescription'];
         addCoveredCommand(args);
         const result = await run(cmd, args, { ...options, parse: false });
         expect(result).include('Command executed successfully!');

--- a/test/integration/fixtures/skill-manifest.json
+++ b/test/integration/fixtures/skill-manifest.json
@@ -9,13 +9,13 @@
        },
        "apis":{
           "custom":{
- 
+
           }
        }
     },
     "hosting":{
        "alexaHosted":{
-          "runtime":"NODE_10_X"
+          "runtime":"NODE_12_X"
        }
     }
  }

--- a/test/unit/clients/smapi-client-test/resources/alexa-hosted.js
+++ b/test/unit/clients/smapi-client-test/resources/alexa-hosted.js
@@ -16,7 +16,7 @@ module.exports = (smapiClient) => {
         const TEST_PROFILE = 'testProfile';
         const TEST_ACCESS_TOKEN = 'access_token';
         const TEST_RUNTIME_FIELD = 'NodeJS';
-        const TEST_RUNTIME_VALUE = 'NODE_10_X';
+        const TEST_RUNTIME_VALUE = 'NODE_12_X';
         const TEST_REGION_VALUE = 'US_EAST_1';
         const TEST_MANIFEST = {
             runtime: TEST_RUNTIME_FIELD,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This change allows the usage of Node.js 12 for Alexa Hosted Skills creation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
