### PR TITLE
feat: add new env var ASK_SKIP_LOCATION_HEADER_HINT to avoid sending …

### DIFF
--- a/docs/concepts/Alexa-Hosted-Skill-Commands.md
+++ b/docs/concepts/Alexa-Hosted-Skill-Commands.md
@@ -22,7 +22,7 @@ Users will be asked the following questions to create a new skill:
 
 * Prompts user for `programming language`
 	* Select programming language
-	* AHS supports Python3.7 and Node10.x
+	* AHS supports Python3.7 and Node12.x
 * Prompts user for a method to host your skill's backend resources
 	* Select `Alexa-hosted skills`
 * Prompts user for `skill name`

--- a/lib/commands/smapi/smapi-command-handler.js
+++ b/lib/commands/smapi/smapi-command-handler.js
@@ -143,7 +143,7 @@ const parseSmapiResponse = (response, profile) => {
     const locationHeader = headers.find((h) => h.key === 'location');
     // json if no content type or content type is application/json
     const isJson = !contentType || contentType.value.includes('application/json');
-    if (statusCode === CONSTANTS.HTTP_REQUEST.STATUS_CODE.ACCEPTED && locationHeader) {
+    if (!process.env.ASK_SKIP_LOCATION_HEADER_HINT && statusCode === CONSTANTS.HTTP_REQUEST.STATUS_CODE.ACCEPTED && locationHeader) {
         _showCheckStatusHint(locationHeader, profile);
     }
     if (body && Object.keys(body).length) {


### PR DESCRIPTION
This solves the request from https://github.com/alexa/ask-cli/issues/397

Test result:
```
$ export ASK_SKIP_LOCATION_HEADER_HINT=1
﻿﻿$ ask smapi create-skill-for-vendor --manifest "file:./skill-package/skill.json"
{
  "skillId": "amzn1.ask.skill.xxxx"
}
```
```
$ unset ASK_SKIP_LOCATION_HEADER_HINT
$ ask smapi create-skill-for-vendor --manifest "file:./skill-package/skill.json"
[Warn]: This is an asynchronous operation. Check the progress using the following command: ask smapi get-skill-status --skill-id amzn1.ask.skill.xxxx --resource manifest --profile default
{
  "skillId": "amzn1.ask.skill.xxxx"
}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
