### PR TITLE
fix: do not set DEFAULT to simulation.type when making simulate-skill request

### DIFF
--- a/lib/commands/dialog/index.js
+++ b/lib/commands/dialog/index.js
@@ -125,7 +125,7 @@ class DialogCommand extends AbstractCommand {
                 Messenger.getInstance().info(`Defaulting locale to the first value from the skill manifest: ${firstLocaleFromManifest}`);
             }
             locale = locale || process.env.ASK_DEFAULT_DEVICE_LOCALE || firstLocaleFromManifest;
-            const simulationType = !stringUtils.isNonBlankString(cmd.simulationType) ? 'DEFAULT' : cmd.simulationType;
+            const simulationType = stringUtils.isNonBlankString(cmd.simulationType) ? cmd.simulationType : undefined;
             callback(null, { skillId, locale, stage, profile, debug, replay: cmd.replay, saveSkillIo, smapiClient, userInputs, simulationType });
         });
     }

--- a/test/unit/commands/dialog/index-test.js
+++ b/test/unit/commands/dialog/index-test.js
@@ -240,7 +240,7 @@ describe('Commands Dialog test - command class test', () => {
                     expect(config.replay).equal(DIALOG_REPLAY_FILE_JSON_PATH);
                     expect(config.skillId).equal('amzn1.ask.skill.1234567890');
                     expect(config.stage).equal('development');
-                    expect(config.simulationType).equal('DEFAULT');
+                    expect(config.simulationType).equal(undefined);
                     expect(config.userInputs).deep.equal(['hello', 'world']);
                     done()
                 });


### PR DESCRIPTION
This solves the issue https://github.com/alexa/ask-cli/issues/405

Before
```
$ ask dialog
Defaulting locale to the first value from the skill manifest: en-US
...

User  > open pizza reference
[Error]: {
  "message": "Invalid request payload. Please ensure that the request payload has no invalid fields"
}
User  >
```

AFter the fix:
```
 $ ask dialog
Defaulting locale to the first value from the skill manifest: en-US
...

User  > open pizza reference
Alexa > Welcome.
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
