### PR TITLE
fix: use npm registry https url

### DIFF
--- a/lib/utils/constants.js
+++ b/lib/utils/constants.js
@@ -1,7 +1,7 @@
 const path = require('path');
 
 module.exports.APPLICATION_NAME = 'ask-cli';
-module.exports.NPM_REGISTRY_URL_BASE = 'http://registry.npmjs.org';
+module.exports.NPM_REGISTRY_URL_BASE = 'https://registry.npmjs.org';
 
 module.exports.METRICS = {
     ENDPOINT: 'https://client-telemetry.amazonalexa.com'


### PR DESCRIPTION
*Description of changes:*

npm has [announced](https://github.blog/2021-08-23-npm-registry-deprecating-tls-1-0-tls-1-1/) that they will be deprecating non-HTTPS access on October 4, 2021. This change updates the npm registry base url to use https.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
