### PR TITLE
feat: add cfn deployer skill credentials parameters

### DIFF
--- a/docs/concepts/Deployer-CFN-Deployer.md
+++ b/docs/concepts/Deployer-CFN-Deployer.md
@@ -51,6 +51,8 @@ In the `infrastructure/cfn-deployer/skill-stack.yaml` CloudFormation template fi
 1. Declare the parameters
 2. Modify the template to use the parameters
 
+Optionally, when including `SkillClientId` and `SkillClientSecret` parameters, the value of these parameters is directly retrieved from SMAPI based on the skill ID.
+
 Here you can see we are declaring `ProjectName`, `Environment`, `UserTableName` as string types.
 
 In the CF template we:
@@ -68,6 +70,10 @@ In the CF template we:
 AWSTemplateFormatVersion: 2010-09-09
 Parameters:
   SkillId:
+    Type: String
+  SkillClientId:
+    Type: String
+  SkillClientSecret:
     Type: String
   LambdaRuntime:
     Type: String

--- a/lib/builtins/deploy-delegates/cfn-deployer/helper.js
+++ b/lib/builtins/deploy-delegates/cfn-deployer/helper.js
@@ -5,15 +5,17 @@ const sleep = require('util').promisify(setTimeout);
 const CliCFNDeployerError = require('@src/exceptions/cli-cfn-deployer-error');
 const CloudformationClient = require('@src/clients/aws-client/cloudformation-client');
 const S3Client = require('@src/clients/aws-client/s3-client');
+const SmapiClient = require('@src/clients/smapi-client');
 
 module.exports = class Helper {
-    constructor(awsProfile, awsRegion, reporter) {
+    constructor(profile, doDebug, awsProfile, awsRegion, reporter) {
         this.awsProfile = awsProfile;
         this.awsRegion = awsRegion;
         this.reporter = reporter;
         this.sleep = sleep;
         this.s3Client = (new S3Client({ awsProfile, awsRegion })).client;
         this.cloudformationClient = (new CloudformationClient({ awsProfile, awsRegion })).client;
+        this.smapiClient = new SmapiClient({ profile, doDebug });
     }
 
     async _s3BucketExists(bucketName) {
@@ -174,5 +176,22 @@ module.exports = class Helper {
             message = `${LogicalResourceId}[${ResourceType}]  ${ResourceStatus} (${ResourceStatusReason})`;
         }
         throw new CliCFNDeployerError(message);
+    }
+
+    /**
+     * Gets skill credentials
+     * @param  {string} skillId skill id
+     * @return {Promise{<{clientId: string, clientSecret: string}>}}
+     */
+    async getSkillCredentials(skillId) {
+        return new Promise((resolve, reject) => {
+            this.smapiClient.skill.getSkillCredentials(skillId, (error, response) => {
+                if (error) {
+                    reject(error);
+                } else {
+                    resolve(response.body.skillMessagingCredentials);
+                }
+            });
+        });
     }
 };

--- a/lib/builtins/deploy-delegates/cfn-deployer/index.js
+++ b/lib/builtins/deploy-delegates/cfn-deployer/index.js
@@ -76,7 +76,7 @@ async function invoke(reporter, options, callback) {
 }
 
 async function _deploy(reporter, options, deployProgress) {
-    const { profile, alexaRegion, skillId, skillName, code, userConfig } = options;
+    const { profile, doDebug, alexaRegion, skillId, skillName, code, userConfig } = options;
 
     let { stackId } = deployProgress.deployState;
     const awsProfile = _getAwsProfile(profile);
@@ -87,7 +87,12 @@ async function _deploy(reporter, options, deployProgress) {
     const bucketKey = _getS3BucketKey(alexaRegion, userConfig, code.codeBuild);
     const stackName = `ask-${skillName}-${alexaRegion}-skillStack-${Date.now()}`;
 
-    const helper = new Helper(awsProfile, awsRegion, reporter);
+    const helper = new Helper(profile, doDebug, awsProfile, awsRegion, reporter);
+
+    // skill credentials
+    const skillCredentials = templateBody.includes('SkillClientId') && templateBody.includes('SkillClientSecret')
+        ? await helper.getSkillCredentials(skillId)
+        : {};
 
     // s3 upload
     await helper.createS3BucketIfNotExists(bucketName);
@@ -103,7 +108,8 @@ async function _deploy(reporter, options, deployProgress) {
 
     // cf deploy
     const codeVersion = uploadResult.VersionId;
-    const stackParameters = _mapStackParameters(skillId, userConfig, { bucketName, bucketKey, codeVersion }, userDefinedParameters);
+    const s3Artifact = { bucketName, bucketKey, codeVersion };
+    const stackParameters = _mapStackParameters(skillId, skillCredentials, userConfig, s3Artifact, userDefinedParameters);
     const capabilities = _getCapabilities(alexaRegion, userConfig);
 
     const deployRequest = await helper.deployStack(stackId, stackName, templateBody, stackParameters, capabilities);
@@ -176,6 +182,8 @@ function _getCapabilities(alexaRegion, userConfig) {
 function _getUserDefinedParameters(alexaRegion, userConfig) {
     const reservedParameters = {
         SkillId: 'Please use a different name.',
+        SkillClientId: 'Please use a different name.',
+        SkillClientSecret: 'Please use a different name.',
         LambdaRuntime: 'Please specify under skillInfrastructure.userConfig.runtime.',
         LambdaHandler: 'Please specify under skillInfrastructure.userConfig.handler.',
         CodeBucket: 'Please specify under skillInfrastructure.userConfig.artifactsS3.bucketName.',
@@ -216,7 +224,7 @@ function _makeErrorMessage(error, alexaRegion) {
     return `The CloudFormation deploy failed for Alexa region "${alexaRegion}": ${error.message}`;
 }
 
-function _mapStackParameters(skillId, userConfig, s3Artifact, userDefinedParameters) {
+function _mapStackParameters(skillId, skillCredentials, userConfig, s3Artifact, userDefinedParameters) {
     const parameters = [
         {
             ParameterKey: 'SkillId',
@@ -243,6 +251,18 @@ function _mapStackParameters(skillId, userConfig, s3Artifact, userDefinedParamet
             ParameterValue: s3Artifact.codeVersion
         }
     ];
+
+    if (skillCredentials.clientId && skillCredentials.clientSecret) {
+        const clientIdParameter = {
+            ParameterKey: 'SkillClientId',
+            ParameterValue: skillCredentials.clientId
+        };
+        const clientSecretParameter = {
+            ParameterKey: 'SkillClientSecret',
+            ParameterValue: skillCredentials.clientSecret
+        };
+        parameters.push(clientIdParameter, clientSecretParameter);
+    }
 
     Object.keys(userDefinedParameters).forEach(key => {
         const parameter = {

--- a/lib/controllers/skill-infrastructure-controller/index.js
+++ b/lib/controllers/skill-infrastructure-controller/index.js
@@ -188,6 +188,7 @@ module.exports = class SkillInfrastructureController {
     _deployInfraByRegion(reporter, dd, alexaRegion, skillName, callback) {
         const regionConfig = {
             profile: this.profile,
+            doDebug: this.doDebug,
             ignoreHash: this.ignoreHash,
             alexaRegion,
             skillId: ResourcesConfig.getInstance().getSkillId(this.profile),

--- a/test/unit/builtins/cfn-deployer/index-test.js
+++ b/test/unit/builtins/cfn-deployer/index-test.js
@@ -92,6 +92,7 @@ describe('Builtins test - cfn-deployer index test', () => {
             };
             deployOptions = {
                 profile,
+                doDebug: false,
                 alexaRegion,
                 skillId: 'some skill id',
                 skillName: 'cf-skill',
@@ -128,6 +129,7 @@ describe('Builtins test - cfn-deployer index test', () => {
                 }
             };
             getAWSProfileStub = sinon.stub(awsUtil, 'getAWSProfile').returns('some profile');
+            sinon.stub(Helper.prototype, 'getSkillCredentials').resolves({ clientId: 'id', clientSecret: 'secret' });
             sinon.stub(Helper.prototype, 'createS3BucketIfNotExists').resolves();
             sinon.stub(Helper.prototype, 'enableS3BucketVersioningIfNotEnabled').resolves();
             sinon.stub(Helper.prototype, 'uploadToS3').resolves({ VersionId: s3VersionId });
@@ -135,6 +137,17 @@ describe('Builtins test - cfn-deployer index test', () => {
             waitForStackDeployStub = sinon.stub(Helper.prototype, 'waitForStackDeploy');
         });
         it('should deploy', (done) => {
+            waitForStackDeployStub.resolves({ endpointUri, stackInfo: { Outputs: [] } });
+
+            Deployer.invoke({}, deployOptions, (err, result) => {
+                expect(err).eql(null);
+                expect(result).eql(expectedOutput);
+                done();
+            });
+        });
+
+        it('should deploy with skill credentials', (done) => {
+            sinon.stub(fs, 'readFileSync').withArgs(templatePath, 'utf-8').returns('SkillClientId SkillClientSecret');
             waitForStackDeployStub.resolves({ endpointUri, stackInfo: { Outputs: [] } });
 
             Deployer.invoke({}, deployOptions, (err, result) => {


### PR DESCRIPTION
*Description of changes:*

This change adds optional skill credentials `SkillClientId` & `SkillClientSecret` parameters support to `cfn-deployer` stack templates. If specified, the value of these parameters is directly retrieved from SMAPI based on the skill ID.

This is useful for including that information as environmental variables of a deployed Lambda function handling skill messaging events.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
