### PR TITLE
fix: use proper npm install quiet flag

### DIFF
--- a/lib/builtins/build-flows/nodejs-npm.js
+++ b/lib/builtins/build-flows/nodejs-npm.js
@@ -33,9 +33,9 @@ class NodeJsNpmBuildFlow extends AbstractBuildFlow {
      * @param {Function} callback
      */
     execute(callback) {
-        const quiteFlag = this.doDebug ? '' : ' --quite';
+        const quietFlag = this.doDebug ? '' : ' --quiet';
         this.debug(`Installing NodeJS dependencies based on the ${NodeJsNpmBuildFlow.manifest}.`);
-        this.execCommand(`npm install --production${quiteFlag}`);
+        this.execCommand(`npm install --production${quietFlag}`);
         this.createZip(callback);
     }
 }

--- a/test/unit/builtins/build-flows/nodejs-npm-test.js
+++ b/test/unit/builtins/build-flows/nodejs-npm-test.js
@@ -27,7 +27,7 @@ describe('NodeJsNpmBuildFlow test', () => {
             buildFlow.execute((err, res) => {
                 expect(err).eql(undefined);
                 expect(res).eql(undefined);
-                expect(execStub.args[0][0]).eql('npm install --production --quite');
+                expect(execStub.args[0][0]).eql('npm install --production --quiet');
                 expect(createZipStub.callCount).eql(1);
                 done();
             });


### PR DESCRIPTION
*Description of changes:*

This change fixes the misspelling of the `quiet` flag for the `npm install` command.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
