### PR TITLE
fix: wait until Lambda State is not Pending before calling UpdateFunctionConfiguration

### DIFF
--- a/lib/builtins/deploy-delegates/lambda-deployer/helper.js
+++ b/lib/builtins/deploy-delegates/lambda-deployer/helper.js
@@ -239,36 +239,40 @@ function _updateLambdaFunction(reporter, lambdaClient, options, callback) {
     const zipFile = fs.readFileSync(zipFilePath);
     const functionName = deployState.lambda.arn;
     let { revisionId } = deployState.lambda;
-    lambdaClient.updateFunctionCode(zipFile, functionName, revisionId, (codeErr, codeData) => {
+    lambdaClient.updateFunctionCode(zipFile, functionName, revisionId, function updateConfiguration(codeErr, codeData) {
         if (codeErr) {
             return callback(codeErr);
         }
         reporter.updateStatus(`Update a lambda function (${functionName}) in progress...`);
-        const { runtime } = userConfig;
-        const { handler } = userConfig;
-        revisionId = codeData.RevisionId;
-        lambdaClient.updateFunctionConfiguration(functionName, runtime, handler, revisionId, (configErr, configData) => {
-            if (configErr) {
-                return callback(null, {
-                    isAllStepSuccess: false,
+        if (codeData.State === 'Pending') {
+            setTimeout(() => lambdaClient.getFunction(functionName, updateConfiguration), 1000);
+        } else {
+            const { runtime } = userConfig;
+            const { handler } = userConfig;
+            revisionId = codeData.RevisionId;
+            lambdaClient.updateFunctionConfiguration(functionName, runtime, handler, revisionId, (configErr, configData) => {
+                if (configErr) {
+                    return callback(null, {
+                        isAllStepSuccess: false,
+                        isCodeDeployed: true,
+                        lambdaResponse: {
+                            arn: codeData.FunctionArn,
+                            lastModified: codeData.LastModified,
+                            revisionId: codeData.RevisionId
+                        },
+                        resultMessage: configErr
+                    });
+                }
+                callback(null, {
+                    isAllStepSuccess: true,
                     isCodeDeployed: true,
                     lambdaResponse: {
-                        arn: codeData.FunctionArn,
-                        lastModified: codeData.LastModified,
-                        revisionId: codeData.RevisionId
-                    },
-                    resultMessage: configErr
+                        arn: configData.FunctionArn,
+                        lastModified: configData.LastModified,
+                        revisionId: configData.RevisionId
+                    }
                 });
-            }
-            callback(null, {
-                isAllStepSuccess: true,
-                isCodeDeployed: true,
-                lambdaResponse: {
-                    arn: configData.FunctionArn,
-                    lastModified: configData.LastModified,
-                    revisionId: configData.RevisionId
-                }
             });
-        });
+        }
     });
 }


### PR DESCRIPTION
*Issue #, if available:*
Closes #415 

*Description of changes:*
With the release of AWS Lambda States, the Lambda Deploy code has been broken (see #415 for details). Our code calls `UpdateFunction` and then immediately `UpdateFunctionConfiguration` afterwards. According to AWS's docs, if the Function is in the `Pending` state, then the `UpdateFunctionConfiguration` call will fail. This change updates our flow to wait until the Function exists the Pending state before calling `UpdateFunctionConfiguration`.

TODO:
- [ ] need to test with a real skill
- [ ] should we have a time out?
- [ ] what should we do if the skill enters `Inactive` or `Failed` state? Should we continue or throw error?

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
