### PR TITLE
fix: allow source folder copy task to dereference symlinks

### DIFF
--- a/lib/controllers/skill-code-controller/code-builder.js
+++ b/lib/controllers/skill-code-controller/code-builder.js
@@ -48,7 +48,7 @@ class CodeBuilder {
     _setUpBuildFolder() {
         fs.ensureDirSync(this.build.folder);
         fs.emptyDirSync(this.build.folder);
-        fs.copySync(path.resolve(this.src), this.build.folder, { filter: src => !src.includes(this.build.folder) });
+        fs.copySync(path.resolve(this.src), this.build.folder, { filter: src => !src.includes(this.build.folder), dereference: true });
     }
 
     _selectBuildFlowClass() {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

I have my skill source code set up as a package in a monorepo, and the symlinked NPM modules (the other packages) are not copied into the build folder. This change instructs fs-extra to also copy the symlinked modules. 

I wasn't sure if it was worth writing new tests for this change or updating the existing ones. I could also make this a config option for CodeBuilder instead of hardcoding it to true (and adding a cli option to set it). Any input or advice would be appreciated. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
