### PR TITLE
fix: use env vars when provided

### DIFF
--- a/lib/clients/aws-client/aws-util.js
+++ b/lib/clients/aws-client/aws-util.js
@@ -16,13 +16,10 @@ module.exports = {
  * @param {string} askProfile cli profile name
  */
 function getAWSProfile(askProfile) {
-    if (askProfile === CONSTANT.PLACEHOLDER.ENVIRONMENT_VAR.PROFILE_NAME) {
-        const awsAccessKeyId = process.env.AWS_ACCESS_KEY_ID;
-        const awsSecretAccessKey = process.env.AWS_SECRET_ACCESS_KEY;
-
-        if (awsAccessKeyId && awsSecretAccessKey) {
-            return CONSTANT.PLACEHOLDER.ENVIRONMENT_VAR.AWS_CREDENTIALS;
-        }
+    const awsAccessKeyId = process.env.AWS_ACCESS_KEY_ID;
+    const awsSecretAccessKey = process.env.AWS_SECRET_ACCESS_KEY;
+    if (awsAccessKeyId && awsSecretAccessKey) {
+        return CONSTANT.PLACEHOLDER.ENVIRONMENT_VAR.AWS_CREDENTIALS;
     }
     const askConfig = fs.readJSONSync(path.join(os.homedir(), '.ask', 'cli_config'));
     return R.view(R.lensPath(['profiles', askProfile, 'aws_profile']), askConfig);

--- a/lib/controllers/authorization-controller/index.js
+++ b/lib/controllers/authorization-controller/index.js
@@ -9,6 +9,7 @@ const LocalHostServer = require('@src/utils/local-host-server');
 const stringUtils = require('@src/utils/string-utils');
 const Messenger = require('@src/view/messenger');
 const SpinnerView = require('@src/view/spinner-view');
+const { isEnvProfileName } = require('@src/utils/profile-helper');
 
 const messages = require('./messages');
 
@@ -46,26 +47,27 @@ module.exports = class AuthorizationController {
      * @param {Function} callback
      */
     tokenRefreshAndRead(profile, callback) {
-        if (profile === CONSTANTS.PLACEHOLDER.ENVIRONMENT_VAR.PROFILE_NAME) {
-            const askRefreshToken = process.env.ASK_REFRESH_TOKEN;
-            const askAccessToken = process.env.ASK_ACCESS_TOKEN;
+        const askRefreshToken = process.env.ASK_REFRESH_TOKEN;
+        const askAccessToken = process.env.ASK_ACCESS_TOKEN;
+        // '!== undefined' check is required because environment variables return values as strings instead of objects.
+        const isNonBlankRefreshToken = stringUtils.isNonBlankString(askRefreshToken) && askRefreshToken !== 'undefined';
+        const isNonBlankAccessToken = stringUtils.isNonBlankString(askAccessToken) && askAccessToken !== 'undefined';
 
-            // '!== undefined' check is required because environment variables return values as strings instead of objects.
-            const isNonBlankRefreshToken = stringUtils.isNonBlankString(askRefreshToken) && askRefreshToken !== 'undefined';
-            const isNonBlankAccessToken = stringUtils.isNonBlankString(askAccessToken) && askAccessToken !== 'undefined';
+        if (isEnvProfileName(profile)) {
             if (!isNonBlankRefreshToken && !isNonBlankAccessToken) {
                 return callback(messages.ASK_ENV_VARIABLES_ERROR_MESSAGE);
             }
-            if (isNonBlankRefreshToken) {
-                this.oauthClient.refreshToken({ refresh_token: askRefreshToken }, (err, token) => {
-                    if (err) {
-                        return callback(err);
-                    }
-                    callback(null, token.access_token);
-                });
-            } else if (isNonBlankAccessToken) {
-                return callback(null, askAccessToken);
-            }
+        }
+
+        if (isNonBlankRefreshToken) {
+            this.oauthClient.refreshToken({ refresh_token: askRefreshToken }, (err, token) => {
+                if (err) {
+                    return callback(err);
+                }
+                callback(null, token.access_token);
+            });
+        } else if (isNonBlankAccessToken) {
+            return callback(null, askAccessToken);
         } else if (this.oauthClient.isValidToken(AppConfig.getInstance().getToken(profile))) {
             callback(null, AppConfig.getInstance().getToken(profile).access_token);
         } else {

--- a/lib/utils/profile-helper.js
+++ b/lib/utils/profile-helper.js
@@ -8,13 +8,14 @@ const CONSTANT = require('./constants');
 module.exports = {
     runtimeProfile,
     isEnvProfile,
+    isEnvProfileName,
     checkASKProfileExist,
     setupProfile,
     resolveVendorId
 };
 
 function runtimeProfile(profile) {
-    const askProfile = profile || _findEnvProfile() || process.env.ASK_DEFAULT_PROFILE || 'default';
+    const askProfile = profile || process.env.ASK_DEFAULT_PROFILE || _findEnvProfile() || 'default';
     if (!module.exports.checkASKProfileExist(askProfile)) {
         throw (`Can't resolve profile [${askProfile}] as it doesn't exist. Please run "ask configure --profile ${askProfile}" first.`);
     }
@@ -27,6 +28,10 @@ function isEnvProfile() {
     && process.env.ASK_VENDOR_ID);
 }
 
+function isEnvProfileName(profileName) {
+    return profileName === CONSTANT.PLACEHOLDER.ENVIRONMENT_VAR.PROFILE_NAME;
+}
+
 function _findEnvProfile() {
     if (isEnvProfile()) {
         // Only when user set every required parameter in ENV, we will treat profile as ENV
@@ -36,7 +41,7 @@ function _findEnvProfile() {
 }
 
 function checkASKProfileExist(profileName) {
-    if (profileName === CONSTANT.PLACEHOLDER.ENVIRONMENT_VAR.PROFILE_NAME) {
+    if (isEnvProfileName(profileName) || isEnvProfile()) {
         return true;
     }
     const askCliConfig = path.join(os.homedir(), '.ask', 'cli_config');
@@ -52,8 +57,9 @@ function setupProfile(awsProfile, askProfile) {
 }
 
 function resolveVendorId(profile) {
-    if (profile === CONSTANT.PLACEHOLDER.ENVIRONMENT_VAR.PROFILE_NAME) {
-        return process.env.ASK_VENDOR_ID;
+    const askVendorId = process.env.ASK_VENDOR_ID;
+    if (isEnvProfileName(profile) || askVendorId) {
+        return askVendorId;
     }
 
     const configFile = path.join(os.homedir(), '.ask', 'cli_config');

--- a/test/unit/clients/aws-client/aws-util-test.js
+++ b/test/unit/clients/aws-client/aws-util-test.js
@@ -1,0 +1,54 @@
+const R = require('ramda');
+const sinon = require('sinon');
+const path = require('path');
+const { expect } = require('chai');
+
+const { getAWSProfile } = require('@src/clients/aws-client/aws-util');
+const CONSTANTS = require('@src/utils/constants');
+
+describe('# aws util tests', () => {
+    const TEST_ASK_PROFILE = 'TEST_ASK_PROFILE';
+    const TEST_AWS_ACCESS_KEY_ID = 'TEST_AWS_ACCESS_KEY_ID';
+    const TEST_AWS_SECRET_ACCESS_KEY = 'TEST_AWS_SECRET_ACCESS_KEY';
+    const TEST_AWS_PROFILE = 'TEST_AWS_PROFILE';
+    const TEST_APP_CONFIG_FILE_PATH = path.join(process.cwd(), 'test', 'unit', 'fixture', 'model', 'cli_config');
+
+    beforeEach(() => {
+        sinon.restore();
+    });
+
+    afterEach(() => {
+        delete process.env.AWS_ACCESS_KEY_ID;
+        delete process.env.AWS_SECRET_ACCESS_KEY;
+    });
+
+    it('| should load aws env profile if env variables are set', () => {
+        process.env.AWS_ACCESS_KEY_ID = TEST_AWS_ACCESS_KEY_ID;
+        process.env.AWS_SECRET_ACCESS_KEY = TEST_AWS_SECRET_ACCESS_KEY;
+        const awsProfile = getAWSProfile(TEST_ASK_PROFILE);
+        expect(awsProfile).eql(CONSTANTS.PLACEHOLDER.ENVIRONMENT_VAR.AWS_CREDENTIALS) 
+    });
+
+    it('| should return aws profile from cli config', () => {
+        sinon.stub(path, 'join').returns(TEST_APP_CONFIG_FILE_PATH);
+        sinon.stub(R, 'view').returns(TEST_AWS_PROFILE);
+        const awsProfile = getAWSProfile(TEST_ASK_PROFILE);
+        expect(awsProfile).eql(TEST_AWS_PROFILE);
+    });
+
+    it('| should return aws profile from cli config if secret key env var is missing', () => {
+        process.env.AWS_ACCESS_KEY_ID = TEST_AWS_ACCESS_KEY_ID;
+        sinon.stub(path, 'join').returns(TEST_APP_CONFIG_FILE_PATH);
+        sinon.stub(R, 'view').returns(TEST_AWS_PROFILE);
+        const awsProfile = getAWSProfile(TEST_ASK_PROFILE);
+        expect(awsProfile).eql(TEST_AWS_PROFILE);
+    });
+
+    it('| should return aws profile from cli config if access key env var is missing', () => {
+        process.env.AWS_SECRET_ACCESS_KEY = TEST_AWS_ACCESS_KEY_ID;
+        sinon.stub(path, 'join').returns(TEST_APP_CONFIG_FILE_PATH);
+        sinon.stub(R, 'view').returns(TEST_AWS_PROFILE);
+        const awsProfile = getAWSProfile(TEST_ASK_PROFILE);
+        expect(awsProfile).eql(TEST_AWS_PROFILE);
+    });
+});

--- a/test/unit/controller/authorization-controller/index-test.js
+++ b/test/unit/controller/authorization-controller/index-test.js
@@ -187,6 +187,42 @@ describe('Controller test - Authorization controller test', () => {
                 });
             });
 
+            it('| non-environment profile, env refresh token', (done) => {
+                process.env.ASK_REFRESH_TOKEN = TEST_ENV_REFRESH_TOKEN;
+                sinon.stub(AuthorizationController.prototype, '_getRefreshTokenAndUpdateConfig').callsArgWith(2, null, VALID_ACCESS_TOKEN);
+                httpClient.request.callsArgWith(3, null, TEST_RESPONSE);
+
+                authorizationController.tokenRefreshAndRead(TEST_PROFILE, (error, accessToken) => {
+                    expect(error).eq(null);
+                    expect(accessToken).to.deep.eq(TEST_RESPONSE.body.access_token);
+                    done();
+                });
+            });
+
+            it('| non-environment profile, valid env access token', (done) => {
+                process.env.ASK_ACCESS_TOKEN = TEST_ENV_ACCESS_TOKEN;
+                sinon.stub(AuthorizationController.prototype, '_getRefreshTokenAndUpdateConfig').callsArgWith(2, null, VALID_ACCESS_TOKEN);
+                httpClient.request.callsArgWith(3, null, TEST_RESPONSE);
+
+                authorizationController.tokenRefreshAndRead(TEST_PROFILE, (error, accessToken) => {
+                    expect(error).eq(null);
+                    expect(accessToken).to.deep.eq(TEST_ENV_ACCESS_TOKEN);
+                    done();
+                });
+            });
+
+            it('| non-environment profile, invalid env refresh token', (done) => {
+                process.env.ASK_ACCESS_TOKEN = TEST_ENV_ACCESS_TOKEN;
+                sinon.stub(AuthorizationController.prototype, '_getRefreshTokenAndUpdateConfig').callsArgWith(2, null, VALID_ACCESS_TOKEN);
+                httpClient.request.callsArgWith(3, null, TEST_RESPONSE);
+
+                authorizationController.tokenRefreshAndRead(TEST_PROFILE, (error, accessToken) => {
+                    expect(error).eq(null);
+                    expect(accessToken).to.deep.eq(TEST_ENV_ACCESS_TOKEN);
+                    done();
+                });
+            });
+
             it('| environment profile, invalid refresh token, valid access token', (done) => {
                 // setup
                 process.env.ASK_ACCESS_TOKEN = TEST_ENV_ACCESS_TOKEN;


### PR DESCRIPTION
*Issue #, if available:*

Fixes: #409

Developers can't use environment variables when using profiles other than `__ENVIRONMENT_ASK_PROFILE__`.


*Description of changes:*

A small fix to allow the developers currently blocked in #409 to provide the environment variables and use them in the authorization controller, and to load the AWS env profile if the CLI sees both the AWS tokens when using a profile other than `__ENVIRONMENT_ASK_PROFILE__`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.