### PR TITLE
chore: updated hosted skill documentation link

### DIFF
--- a/lib/commands/new/index.js
+++ b/lib/commands/new/index.js
@@ -11,9 +11,6 @@ const helper = require('./helper');
 const hostedHelper = require('./hosted-skill-helper');
 const wizardHelper = require('./wizard-helper');
 
-const GIT_USAGE_HOSTED_SKILL_DOCUMENTATION = 'https://developer.amazon.com/en-US/docs/alexa/'
-    + 'hosted-skills/build-a-skill-end-to-end-using-an-alexa-hosted-skill.html#askcli';
-
 class NewCommand extends AbstractCommand {
     name() {
         return 'new';
@@ -82,7 +79,7 @@ function createHostedSkill(cmd, profile, vendorId, userInput, callback) {
                 return callback(createErr);
             }
             Messenger.getInstance().info(`Hosted skill provisioning finished. Skill-Id: ${skillId}`);
-            Messenger.getInstance().info(`Please follow the instructions at ${GIT_USAGE_HOSTED_SKILL_DOCUMENTATION}`
+            Messenger.getInstance().info(`Please follow the instructions at ${CONSTANTS.GIT_USAGE_HOSTED_SKILL_DOCUMENTATION}`
                 + ' to learn more about the usage of "git" for Hosted skill.');
             ResourcesConfig.getInstance().write();
             callback();

--- a/lib/utils/constants.js
+++ b/lib/utils/constants.js
@@ -507,3 +507,5 @@ module.exports.RUNTIME = {
     PYTHON: 'python',
     JAVA: 'java'
 };
+
+module.exports.GIT_USAGE_HOSTED_SKILL_DOCUMENTATION = 'https://developer.amazon.com/en-US/docs/alexa/hosted-skills/alexa-hosted-skills-ask-cli.html';

--- a/test/unit/commands/new/index-test.js
+++ b/test/unit/commands/new/index-test.js
@@ -11,6 +11,7 @@ const Manifest = require('@src/model/manifest');
 const Messenger = require('@src/view/messenger');
 const profileHelper = require('@src/utils/profile-helper');
 const wizardHelper = require('@src/commands/new/wizard-helper');
+const CONSTANTS = require('@src/utils/constants');
 
 describe('Commands new test - command class test', () => {
     const FIXTURE_BASE_PATH = path.join(process.cwd(), 'test', 'unit', 'fixture', 'model');
@@ -183,7 +184,7 @@ describe('Commands new test - command class test', () => {
                     expect(err).equal(undefined);
                     expect(infoStub.args[0][0]).equal('Please follow the wizard to start your Alexa skill project ->');
                     expect(infoStub.args[1][0]).equal(`Hosted skill provisioning finished. Skill-Id: ${TEST_SKILL_ID}`);
-                    expect(infoStub.args[2][0]).equal(`Please follow the instructions at ${GIT_USAGE_HOSTED_SKILL_DOCUMENTATION}`
+                    expect(infoStub.args[2][0]).equal(`Please follow the instructions at ${CONSTANTS.GIT_USAGE_HOSTED_SKILL_DOCUMENTATION}`
                         + ' to learn more about the usage of "git" for Hosted skill.');
                     expect(warnStub.callCount).equal(0);
                     done();


### PR DESCRIPTION
*Issue #, if available:*

#393 

*Description of changes:*

Updating the documentation link that is displayed after `ask new` with an Alexa hosted skill. The current link navigates to Alexa hosted skill docs that aren't relevant to the CLI. The new link navigates to CLI related docs for hosted skills.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
