### PR TITLE
feature enhancement: add export-package to ask-init to download skill-packages from smapi

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,7 +8,7 @@
     "rules": {
         "class-methods-use-this" : "off",
         "indent": ["error", 4],
-        "max-len": ["error", 150, 4],
+        "max-len": ["error", 165, 4],
         "import/no-unresolved":"off",
         "no-plusplus":"off",
         "no-underscore-dangle": 0,

--- a/docs/concepts/Alexa-Hosted-Skill-Commands.md
+++ b/docs/concepts/Alexa-Hosted-Skill-Commands.md
@@ -40,10 +40,11 @@ The user is not prompted for a `skill template`. The [Hello World Skill](https:/
 
 This command initializes Alexa Hosted Skills by cloning the project from the hosted skill service, downloading the latest Alexa skill package, and provide a git-ready environment. Developers can then checkout, pull from, and push to a remote Git repository from their local machines.
 
+If you make changes to the skill package such as the interaction model or publishing information on the Alexa Developer Console, these changes will not be reflected in your git repository. You will have to resync the skill-package which you could you do by running `ask init --hosted-skill-id <id> --export-package` and committing the changes that were made on the console.
 
 **STRUCTURE OF INIT COMMAND:**
 
-`ask init [--hosted-skill-id <hosted-skill-id>] [-p | --profile <profile>] [--debug] [-h | --help]`
+`ask init [--hosted-skill-id <hosted-skill-id>] [-p | --profile <profile>] [--debug] [--export-package] [-h | --help]`
 
 **OPTIONS DESCRIPTION:**
 
@@ -53,6 +54,7 @@ This command initializes Alexa Hosted Skills by cloning the project from the hos
 
 **debug**: Optional. Show debug messages.
 
+**export-package**: Optional. Downloads the skill-packages using `smapi export-package` behind the scenes. Use this if your git repository is not in sync with the skill-package.
 
 
 ## GIT CREDENTIALS

--- a/lib/commands/init/index.js
+++ b/lib/commands/init/index.js
@@ -57,6 +57,7 @@ class InitCommand extends AbstractCommand {
 function initAlexaHostedSkill(rootPath, cmd, profile, cb) {
     const smapiClient = new SmapiClient({ profile, doDebug: cmd.debug });
     const hostedSkillController = new HostedSkillController({ profile, doDebug: cmd.debug });
+
     _getSkillName(smapiClient, cmd.hostedSkillId, (nameErr, skillName) => {
         if (nameErr) {
             Messenger.getInstance().error(nameErr);
@@ -74,7 +75,7 @@ function initAlexaHostedSkill(rootPath, cmd, profile, cb) {
                     Messenger.getInstance().error(scriptErr);
                     return cb(scriptErr);
                 }
-                hostedSkillController.clone(cmd.hostedSkillId, skillName, projectPath, cmd.exportPackage || false, (cloneErr) => {
+                hostedSkillController.clone(cmd.hostedSkillId, skillName, projectPath, cmd.exportPackage, (cloneErr) => {
                     if (cloneErr) {
                         Messenger.getInstance().error(cloneErr);
                         return cb(cloneErr);
@@ -85,6 +86,9 @@ function initAlexaHostedSkill(rootPath, cmd, profile, cb) {
                             return cb(hooksErr);
                         }
                         Messenger.getInstance().info(`\n${skillName} successfully initialized.\n`);
+                        Messenger.getInstance().warn('If updating the skill package via the developer console, your git repo will be out of sync. '
+                            + 'You can use the "export-package" option with "ask init" to download the skill package and commit the changes to get back in sync.\n');
+
                         cb();
                     });
                 });

--- a/lib/commands/init/index.js
+++ b/lib/commands/init/index.js
@@ -29,7 +29,7 @@ class InitCommand extends AbstractCommand {
     }
 
     optionalOptions() {
-        return ['hosted-skill-id', 'profile', 'debug'];
+        return ['hosted-skill-id', 'profile', 'debug', 'export-package'];
     }
 
     handle(cmd, cb) {
@@ -74,7 +74,7 @@ function initAlexaHostedSkill(rootPath, cmd, profile, cb) {
                     Messenger.getInstance().error(scriptErr);
                     return cb(scriptErr);
                 }
-                hostedSkillController.clone(cmd.hostedSkillId, skillName, projectPath, (cloneErr) => {
+                hostedSkillController.clone(cmd.hostedSkillId, skillName, projectPath, cmd.exportPackage || false, (cloneErr) => {
                     if (cloneErr) {
                         Messenger.getInstance().error(cloneErr);
                         return cb(cloneErr);

--- a/lib/commands/new/hosted-skill-helper.js
+++ b/lib/commands/new/hosted-skill-helper.js
@@ -91,7 +91,7 @@ function createHostedSkill(hostedSkillController, userInput, vendorId, callback)
             if (scriptErr) {
                 return callback(scriptErr);
             }
-            hostedSkillController.clone(skillId, userInput.skillName, projectPath, (cloneErr) => {
+            hostedSkillController.clone(skillId, userInput.skillName, projectPath, false, (cloneErr) => {
                 if (cloneErr) {
                     return callback(cloneErr);
                 }

--- a/lib/commands/new/index.js
+++ b/lib/commands/new/index.js
@@ -11,9 +11,6 @@ const helper = require('./helper');
 const hostedHelper = require('./hosted-skill-helper');
 const wizardHelper = require('./wizard-helper');
 
-const GIT_USAGE_HOSTED_SKILL_DOCUMENTATION = 'https://developer.amazon.com/en-US/docs/alexa/'
-    + 'hosted-skills/build-a-skill-end-to-end-using-an-alexa-hosted-skill.html#askcli';
-
 class NewCommand extends AbstractCommand {
     name() {
         return 'new';
@@ -82,7 +79,7 @@ function createHostedSkill(cmd, profile, vendorId, userInput, callback) {
                 return callback(createErr);
             }
             Messenger.getInstance().info(`Hosted skill provisioning finished. Skill-Id: ${skillId}`);
-            Messenger.getInstance().info(`Please follow the instructions at ${GIT_USAGE_HOSTED_SKILL_DOCUMENTATION}`
+            Messenger.getInstance().info(`Please follow the instructions at ${CONSTANTS.GIT_USAGE_HOSTED_SKILL_DOCUMENTATION}`
                 + ' to learn more about the usage of "git" for Hosted skill.');
             ResourcesConfig.getInstance().write();
             callback();

--- a/lib/commands/option-model.json
+++ b/lib/commands/option-model.json
@@ -200,5 +200,11 @@
     "name": "watch",
     "description": "Uses nodemon to monitor changes and automatically restart the run session.",
     "stringInput": "NONE"
+  },
+  "export-package": {
+    "name": "export-package",
+    "description": "Downloads the skill-package usage the smapi export-package api rather than cloning from git.",
+    "alias": null,
+    "stringInput": "NONE"
   }
 }

--- a/lib/commands/smapi/appended-commands/export-package/index.js
+++ b/lib/commands/smapi/appended-commands/export-package/index.js
@@ -70,7 +70,7 @@ class ExportPackageCommand extends AbstractCommand {
                 const skillPackageLocation = R.view(R.lensPath(['body', 'skill', 'location']), pollResponse);
                 const rootPath = process.cwd();
                 const targetPath = path.join(rootPath, CONSTANTS.FILE_PATH.SKILL_PACKAGE.PACKAGE);
-                zipUtils.unzipRemoteZipFile(skillPackageLocation, targetPath, false, (unzipErr) => {
+                zipUtils.unzipRemoteZipFile(skillPackageLocation, targetPath, cmd.debug, false, (unzipErr) => {
                     if (unzipErr) {
                         Messenger.getInstance().error(unzipErr);
                         return cb(unzipErr);

--- a/lib/commands/util/upgrade-project/helper.js
+++ b/lib/commands/util/upgrade-project/helper.js
@@ -203,7 +203,7 @@ function createV2ProjectSkeletonAndLoadModel(rootPath, skillId, profile) {
  */
 function downloadSkillPackage(rootPath, skillId, skillStage, profile, doDebug, callback) {
     const skillMetaController = new SkillMetadataController({ profile, doDebug });
-    skillMetaController.getSkillPackage(rootPath, skillId, skillStage, (packageErr) => {
+    skillMetaController.getSkillPackage(rootPath, skillId, skillStage, false, (packageErr) => {
         if (packageErr) {
             return callback(`Failed to retrieve the skill-package for skillId: ${skillId}.\n${packageErr}`);
         }

--- a/lib/commands/util/upgrade-project/hosted-skill-helper.js
+++ b/lib/commands/util/upgrade-project/hosted-skill-helper.js
@@ -87,7 +87,7 @@ function createV2ProjectSkeletonAndLoadModel(rootPath, skillId, profile) {
  */
 function downloadSkillPackage(rootPath, skillId, skillStage, profile, doDebug, callback) {
     const skillMetaController = new SkillMetadataController({ profile, doDebug });
-    skillMetaController.getSkillPackage(rootPath, skillId, skillStage, (packageErr) => {
+    skillMetaController.getSkillPackage(rootPath, skillId, skillStage, false, (packageErr) => {
         if (packageErr) {
             return callback(packageErr);
         }

--- a/lib/controllers/hosted-skill-controller/index.js
+++ b/lib/controllers/hosted-skill-controller/index.js
@@ -51,9 +51,10 @@ module.exports = class HostedSkillController {
      * @param {string} skillId The skill id
      * @param {string} skillName The skill name
      * @param {string} projectPath The skill project folder path
+     * @param {boolean} exportPackage Whether to export the skill package from smapi
      * @param {callback} callback { error, response }
      */
-    clone(skillId, skillName, projectPath, callback) {
+    clone(skillId, skillName, projectPath, exportPackage, callback) {
         if (fs.existsSync(projectPath)) {
             return callback(`${projectPath} directory already exists.`);
         }
@@ -64,15 +65,17 @@ module.exports = class HostedSkillController {
             }
             // 1. generate project
             cloneFlow.generateProject(projectPath, skillId, skillName, metadata, this.profile);
+
             // 2. clone project, set up git
             cloneFlow.cloneProjectFromGit(projectPath, skillId, skillName, this.profile, metadata.repository.url, this.doDebug);
+
             // 3. check skill-package content
             cloneFlow.doSkillPackageExist(skillName, projectPath, skillId, (checkErr, doExist) => {
                 if (checkErr) {
                     return callback(checkErr);
                 }
-                if (!doExist) {
-                    this.skillMetaController.getSkillPackage(projectPath, skillId, CONSTANTS.SKILL.STAGE.DEVELOPMENT, (exportErr) => {
+                if (!doExist || exportPackage) {
+                    this.skillMetaController.getSkillPackage(projectPath, skillId, CONSTANTS.SKILL.STAGE.DEVELOPMENT, true, (exportErr) => {
                         if (exportErr) {
                             return callback(exportErr);
                         }

--- a/lib/controllers/hosted-skill-controller/index.js
+++ b/lib/controllers/hosted-skill-controller/index.js
@@ -81,7 +81,7 @@ module.exports = class HostedSkillController {
                     return callback(checkErr);
                 }
 
-                const skillCreatedMsg = `Skill schema and interactionModels for ${skillName} created at\n\t./skill-package\n`;
+                const skillCreatedMsg = `\nSkill schema and interactionModels for ${skillName} created at\n\t./skill-package\n`;
 
                 if (!doExist || exportPackage) {
                     this.skillMetaController.getSkillPackage(projectPath, skillId, CONSTANTS.SKILL.STAGE.DEVELOPMENT, true, (exportErr) => {

--- a/lib/controllers/hosted-skill-controller/index.js
+++ b/lib/controllers/hosted-skill-controller/index.js
@@ -48,10 +48,11 @@ module.exports = class HostedSkillController {
 
     /**
      * To clone an Alexa hosted skill from git repository to local project directory
+     *
      * @param {string} skillId The skill id
      * @param {string} skillName The skill name
      * @param {string} projectPath The skill project folder path
-     * @param {boolean} exportPackage Whether to export the skill package from smapi
+     * @param {boolean} exportPackage To export the skill package from smapi
      * @param {callback} callback { error, response }
      */
     clone(skillId, skillName, projectPath, exportPackage, callback) {
@@ -63,6 +64,11 @@ module.exports = class HostedSkillController {
             if (metadataErr) {
                 return callback(metadataErr);
             }
+
+            if (exportPackage) {
+                Messenger.getInstance().info(`\nCloning project from git and exporting skill package from smapi for ${skillName}`);
+            }
+
             // 1. generate project
             cloneFlow.generateProject(projectPath, skillId, skillName, metadata, this.profile);
 
@@ -74,16 +80,19 @@ module.exports = class HostedSkillController {
                 if (checkErr) {
                     return callback(checkErr);
                 }
+
+                const skillCreatedMsg = `Skill schema and interactionModels for ${skillName} created at\n\t./skill-package\n`;
+
                 if (!doExist || exportPackage) {
                     this.skillMetaController.getSkillPackage(projectPath, skillId, CONSTANTS.SKILL.STAGE.DEVELOPMENT, true, (exportErr) => {
                         if (exportErr) {
                             return callback(exportErr);
                         }
-                        Messenger.getInstance().info(`\nSkill schema and interactionModels for ${skillName} created at\n\t./skill-package\n`);
+                        Messenger.getInstance().info(skillCreatedMsg);
                         callback();
                     });
                 } else {
-                    Messenger.getInstance().info(`\nSkill schema and interactionModels for ${skillName} created at\n\t./skill-package\n`);
+                    Messenger.getInstance().info(skillCreatedMsg);
                     callback();
                 }
             });

--- a/lib/controllers/skill-metadata-controller/index.js
+++ b/lib/controllers/skill-metadata-controller/index.js
@@ -166,7 +166,7 @@ module.exports = class SkillMetadataController {
      * @param {String stage
      * @param {Function} callback
      */
-    getSkillPackage(rootFolder, skillId, stage, callback) {
+    getSkillPackage(rootFolder, skillId, stage, overwrite = false, callback) {
         // 1.request to export skill package
         this._exportPackage(skillId, stage, (exportErr, exportResponse) => {
             if (exportErr) {
@@ -184,7 +184,7 @@ module.exports = class SkillMetadataController {
                 // 3.download skill package into local file system
                 const skillPackageLocation = R.view(R.lensPath(['body', 'skill', 'location']), pollResponse);
                 const targetPath = path.join(rootFolder, 'skill-package');
-                zipUtils.unzipRemoteZipFile(skillPackageLocation, targetPath, false, (unzipErr) => {
+                zipUtils.unzipRemoteZipFile(skillPackageLocation, targetPath, false, overwrite, (unzipErr) => {
                     callback(unzipErr);
                 });
             });

--- a/lib/controllers/skill-metadata-controller/index.js
+++ b/lib/controllers/skill-metadata-controller/index.js
@@ -161,10 +161,12 @@ module.exports = class SkillMetadataController {
 
     /**
      * Download the skill package by exporting the skill package and then download it into the skill project
+     *
      * @param {String} rootFolder Folder path for the skill project root
-     * @param {String} skillId
-     * @param {String stage
-     * @param {Function} callback
+     * @param {String} skillId skillId of the package to be downloaded
+     * @param {String} stage development or live stage of the skill
+     * @param {Boolean} overwrite to overwrite the any existing files when unzipping the skill package
+     * @param {Function} callback { error }
      */
     getSkillPackage(rootFolder, skillId, stage, overwrite = false, callback) {
         // 1.request to export skill package

--- a/lib/utils/constants.js
+++ b/lib/utils/constants.js
@@ -507,3 +507,5 @@ module.exports.RUNTIME = {
     PYTHON: 'python',
     JAVA: 'java'
 };
+
+module.exports.GIT_USAGE_HOSTED_SKILL_DOCUMENTATION = 'https://developer.amazon.com/en-US/docs/alexa/hosted-skills/alexa-hosted-skills-ask-cli.html';

--- a/lib/utils/zip-utils.js
+++ b/lib/utils/zip-utils.js
@@ -65,7 +65,7 @@ function createTempZip(src, outputDir, callback) {
     });
 }
 
-function unzipRemoteZipFile(url, targetPath, doDebug, callback) {
+function unzipRemoteZipFile(url, targetPath, doDebug, overwrite = false, callback) {
     httpClient.request({
         url,
         method: CONSTANTS.HTTP_REQUEST.VERB.GET,
@@ -76,7 +76,7 @@ function unzipRemoteZipFile(url, targetPath, doDebug, callback) {
         }
         const zip = new AdmZip(response.body);
         try {
-            zip.extractAllTo(targetPath, false);
+            zip.extractAllTo(targetPath, overwrite);
         } catch (unzipErr) {
             return callback(unzipErr);
         }

--- a/lib/utils/zip-utils.js
+++ b/lib/utils/zip-utils.js
@@ -65,6 +65,16 @@ function createTempZip(src, outputDir, callback) {
     });
 }
 
+/**
+ * Makes an http request to a remote url to fetch a zip file and unzips the contents
+ * to a local directory
+ * 
+ * @param {*} url - the http url for making a GET request
+ * @param {*} targetPath - the local path to extract the file
+ * @param {*} doDebug - to include debug messages with the http request
+ * @param {*} overwrite - whether to overwrite the existing file
+ * @param {*} callback - { error }
+ */
 function unzipRemoteZipFile(url, targetPath, doDebug, overwrite = false, callback) {
     httpClient.request({
         url,

--- a/test/unit/commands/init/index-test.js
+++ b/test/unit/commands/init/index-test.js
@@ -50,7 +50,7 @@ describe('Commands init test - command class test', () => {
         expect(instance.name()).equal('init');
         expect(instance.description()).equal('setup a new or existing Alexa skill project');
         expect(instance.requiredOptions()).deep.equal([]);
-        expect(instance.optionalOptions()).deep.equal(['hosted-skill-id', 'profile', 'debug']);
+        expect(instance.optionalOptions()).deep.equal(['hosted-skill-id', 'profile', 'debug', 'export-package']);
     });
 
     describe('validate command handle', () => {
@@ -541,7 +541,7 @@ describe('Commands init test - command class test', () => {
             sinon.stub(httpClient, 'request').callsArgWith(3, null, GET_MANIFEST_RESPONSE); // stub getManifest request
             sinon.stub(ui, 'getProjectFolderName').callsArgWith(1, null, TEST_FOLDER_NAME);
             sinon.stub(HostedSkillController.prototype, 'updateAskSystemScripts').callsArgWith(0, null);
-            sinon.stub(HostedSkillController.prototype, 'clone').callsArgWith(3, TEST_ERROR);
+            sinon.stub(HostedSkillController.prototype, 'clone').callsArgWith(4, TEST_ERROR);
             // call
             instance.handle(TEST_CMD, (err) => {
                 // verify
@@ -573,7 +573,7 @@ describe('Commands init test - command class test', () => {
             sinon.stub(httpClient, 'request').callsArgWith(3, null, GET_MANIFEST_RESPONSE); // stub getManifest request
             sinon.stub(ui, 'getProjectFolderName').callsArgWith(1, null, TEST_FOLDER_NAME);
             sinon.stub(HostedSkillController.prototype, 'updateAskSystemScripts').callsArgWith(0, null);
-            sinon.stub(HostedSkillController.prototype, 'clone').callsArgWith(3, null);
+            sinon.stub(HostedSkillController.prototype, 'clone').callsArgWith(4, null);
             sinon.stub(HostedSkillController.prototype, 'updateSkillPrePushScript').callsArgWith(1, TEST_ERROR);
             // call
             instance.handle(TEST_CMD, (err) => {
@@ -606,7 +606,7 @@ describe('Commands init test - command class test', () => {
             sinon.stub(httpClient, 'request').callsArgWith(3, null, GET_MANIFEST_RESPONSE); // stub getManifest request
             sinon.stub(ui, 'getProjectFolderName').callsArgWith(1, null, TEST_FOLDER_NAME);
             sinon.stub(HostedSkillController.prototype, 'updateAskSystemScripts').callsArgWith(0, null);
-            sinon.stub(HostedSkillController.prototype, 'clone').callsArgWith(3, null);
+            sinon.stub(HostedSkillController.prototype, 'clone').callsArgWith(4, null);
             sinon.stub(HostedSkillController.prototype, 'updateSkillPrePushScript').callsArgWith(1, null);
             // call
             instance.handle(TEST_CMD, (err) => {

--- a/test/unit/commands/new/hosted-skill-helper-test.js
+++ b/test/unit/commands/new/hosted-skill-helper-test.js
@@ -418,7 +418,7 @@ describe('Commands new test - hosted skill helper test', () => {
             sinon.stub(SpinnerView.prototype, 'start');
             sinon.stub(HostedSkillController.prototype, 'updateAskSystemScripts').callsArgWith(0, null);
             sinon.stub(process, 'cwd').returns('root/');
-            sinon.stub(HostedSkillController.prototype, 'clone').callsArgWith(3, TEST_ERROR);
+            sinon.stub(HostedSkillController.prototype, 'clone').callsArgWith(4, TEST_ERROR);
             // call
             hostedSkillHelper.createHostedSkill(HostedSkillController.prototype, TEST_USER_INPUT, TEST_VENDOR_ID, (err, res) => {
                 // verify
@@ -434,7 +434,7 @@ describe('Commands new test - hosted skill helper test', () => {
             sinon.stub(SpinnerView.prototype, 'start');
             sinon.stub(HostedSkillController.prototype, 'updateAskSystemScripts').callsArgWith(0, null);
             sinon.stub(process, 'cwd').returns('root/');
-            sinon.stub(HostedSkillController.prototype, 'clone').callsArgWith(3, null);
+            sinon.stub(HostedSkillController.prototype, 'clone').callsArgWith(4, null);
             sinon.stub(SkillMetadataController.prototype, 'enableSkill').yields(TEST_ERROR);
             // call
             hostedSkillHelper.createHostedSkill(HostedSkillController.prototype, TEST_USER_INPUT, TEST_VENDOR_ID, (err, res) => {
@@ -451,7 +451,7 @@ describe('Commands new test - hosted skill helper test', () => {
             sinon.stub(SpinnerView.prototype, 'start');
             sinon.stub(HostedSkillController.prototype, 'updateAskSystemScripts').callsArgWith(0, null);
             sinon.stub(process, 'cwd').returns('root/');
-            sinon.stub(HostedSkillController.prototype, 'clone').callsArgWith(3, null);
+            sinon.stub(HostedSkillController.prototype, 'clone').callsArgWith(4, null);
             sinon.stub(SkillMetadataController.prototype, 'enableSkill').yields();
             sinon.stub(HostedSkillController.prototype, 'updateSkillPrePushScript').callsArgWith(1, TEST_ERROR);
             // call
@@ -469,7 +469,7 @@ describe('Commands new test - hosted skill helper test', () => {
             sinon.stub(SpinnerView.prototype, 'start');
             sinon.stub(HostedSkillController.prototype, 'updateAskSystemScripts').callsArgWith(0, null);
             sinon.stub(process, 'cwd').returns('root/');
-            sinon.stub(HostedSkillController.prototype, 'clone').callsArgWith(3, null);
+            sinon.stub(HostedSkillController.prototype, 'clone').callsArgWith(4, null);
             sinon.stub(SkillMetadataController.prototype, 'enableSkill').yields();
             sinon.stub(HostedSkillController.prototype, 'updateSkillPrePushScript').callsArgWith(1, null);
             // call

--- a/test/unit/commands/new/index-test.js
+++ b/test/unit/commands/new/index-test.js
@@ -11,6 +11,7 @@ const Manifest = require('@src/model/manifest');
 const Messenger = require('@src/view/messenger');
 const profileHelper = require('@src/utils/profile-helper');
 const wizardHelper = require('@src/commands/new/wizard-helper');
+const CONSTANTS = require('@src/utils/constants');
 
 describe('Commands new test - command class test', () => {
     const FIXTURE_BASE_PATH = path.join(process.cwd(), 'test', 'unit', 'fixture', 'model');
@@ -183,7 +184,7 @@ describe('Commands new test - command class test', () => {
                     expect(err).equal(undefined);
                     expect(infoStub.args[0][0]).equal('Please follow the wizard to start your Alexa skill project ->');
                     expect(infoStub.args[1][0]).equal(`Hosted skill provisioning finished. Skill-Id: ${TEST_SKILL_ID}`);
-                    expect(infoStub.args[2][0]).equal(`Please follow the instructions at ${GIT_USAGE_HOSTED_SKILL_DOCUMENTATION}`
+                    expect(infoStub.args[2][0]).equal(`Please follow the instructions at ${CONSTANTS.GIT_USAGE_HOSTED_SKILL_DOCUMENTATION}`
                         + ' to learn more about the usage of "git" for Hosted skill.');
                     expect(warnStub.callCount).equal(0);
                     done();

--- a/test/unit/commands/smapi/appended-commands/export-package/index-test.js
+++ b/test/unit/commands/smapi/appended-commands/export-package/index-test.js
@@ -172,7 +172,7 @@ describe('Commands export-package test - command class test', () => {
                 sinon.stub(fs, 'existsSync').returns(false);
                 sinon.stub(httpClient, 'request').callsArgWith(3, null, EXPORT_RESPONSE); // stub smapi request
                 sinon.stub(helper, 'pollExportStatus').callsArgWith(2, null, POLL_RESPONSE);
-                sinon.stub(zipUtils, 'unzipRemoteZipFile').callsArgWith(3, ERROR);
+                sinon.stub(zipUtils, 'unzipRemoteZipFile').callsArgWith(4, ERROR);
                 // call
                 instance.handle(TEST_CMD, (err) => {
                     // verify
@@ -188,7 +188,7 @@ describe('Commands export-package test - command class test', () => {
                 sinon.stub(fs, 'existsSync').returns(false);
                 sinon.stub(httpClient, 'request').callsArgWith(3, null, EXPORT_RESPONSE); // stub smapi request
                 sinon.stub(helper, 'pollExportStatus').callsArgWith(2, null, POLL_RESPONSE);
-                sinon.stub(zipUtils, 'unzipRemoteZipFile').callsArgWith(3, null);
+                sinon.stub(zipUtils, 'unzipRemoteZipFile').callsArgWith(4, null);
                 // call
                 instance.handle(TEST_CMD, (err) => {
                     // verify

--- a/test/unit/commands/util/upgrade-project/helper-test.js
+++ b/test/unit/commands/util/upgrade-project/helper-test.js
@@ -411,7 +411,7 @@ You have multiple Lambda codebases for region ${TEST_REGION}, we will use "${TES
 
         it('| skillMetaController getSkillPackage fails, expect callback error', (done) => {
             // setup
-            sinon.stub(SkillMetadataController.prototype, 'getSkillPackage').callsArgWith(3, TEST_ERROR);
+            sinon.stub(SkillMetadataController.prototype, 'getSkillPackage').callsArgWith(4, TEST_ERROR);
             // call
             helper.downloadSkillPackage(TEST_ROOT_PATH, TEST_SKILL_ID, TEST_SKILL_STAGE, TEST_PROFILE, TEST_DO_DEBUG, (err) => {
                 expect(err.includes(TEST_ERROR)).equal(true);
@@ -421,7 +421,7 @@ You have multiple Lambda codebases for region ${TEST_REGION}, we will use "${TES
 
         it('| skillMetaController getSkillPackage passes, hashUtils fails, expect error return', (done) => {
             // setup
-            sinon.stub(SkillMetadataController.prototype, 'getSkillPackage').callsArgWith(3, null);
+            sinon.stub(SkillMetadataController.prototype, 'getSkillPackage').callsArgWith(4, null);
             sinon.stub(hashUtils, 'getHash').callsArgWith(1, TEST_ERROR);
             // call
             helper.downloadSkillPackage(TEST_ROOT_PATH, TEST_SKILL_ID, TEST_SKILL_STAGE, TEST_PROFILE, TEST_DO_DEBUG, (err) => {
@@ -434,7 +434,7 @@ You have multiple Lambda codebases for region ${TEST_REGION}, we will use "${TES
         it('| hashUtils passes, expect no error return', (done) => {
             // setup
             const TEST_HASH = 'hash';
-            sinon.stub(SkillMetadataController.prototype, 'getSkillPackage').callsArgWith(3, null);
+            sinon.stub(SkillMetadataController.prototype, 'getSkillPackage').callsArgWith(4, null);
             sinon.stub(hashUtils, 'getHash').callsArgWith(1, null, TEST_HASH);
             // call
             helper.downloadSkillPackage(TEST_ROOT_PATH, TEST_SKILL_ID, TEST_SKILL_STAGE, TEST_PROFILE, TEST_DO_DEBUG, (err) => {

--- a/test/unit/commands/util/upgrade-project/hosted-skill-helper-test.js
+++ b/test/unit/commands/util/upgrade-project/hosted-skill-helper-test.js
@@ -144,7 +144,7 @@ describe('Commands upgrade-project test - hosted skill helper test', () => {
 
         it('| skillMetaController getSkillPackage fails, expect callback error', (done) => {
             // setup
-            sinon.stub(SkillMetadataController.prototype, 'getSkillPackage').callsArgWith(3, TEST_ERROR);
+            sinon.stub(SkillMetadataController.prototype, 'getSkillPackage').callsArgWith(4, TEST_ERROR);
             // call
             hostedSkillHelper.downloadSkillPackage(TEST_ROOT_PATH, TEST_SKILL_ID, TEST_SKILL_STAGE, TEST_PROFILE, TEST_DO_DEBUG, (err) => {
                 expect(err).equal(TEST_ERROR);
@@ -154,7 +154,7 @@ describe('Commands upgrade-project test - hosted skill helper test', () => {
 
         it('| skillMetaController getSkillPackage passes, hashUtils fails, expect no error return', (done) => {
             // setup
-            sinon.stub(SkillMetadataController.prototype, 'getSkillPackage').callsArgWith(3, null);
+            sinon.stub(SkillMetadataController.prototype, 'getSkillPackage').callsArgWith(4, null);
             // call
             hostedSkillHelper.downloadSkillPackage(TEST_ROOT_PATH, TEST_SKILL_ID, TEST_SKILL_STAGE, TEST_PROFILE, TEST_DO_DEBUG, (err) => {
                 // verify

--- a/test/unit/controller/hosted-skill-controller/index-test.js
+++ b/test/unit/controller/hosted-skill-controller/index-test.js
@@ -244,7 +244,7 @@ describe('Controller test - hosted skill controller test', () => {
             hostedSkillController.clone(TEST_SKILL_ID, TEST_SKILL_NAME, TEST_PROJECT_PATH, TEST_DO_NOT_EXPORT_PACKAGE, (err, res) => {
                 expect(err).equal(undefined);
                 expect(Messenger.getInstance().info.args[0][0]).equal(
-                    `\nImported Skill schema and interactionModels for ${TEST_SKILL_NAME} created at\n\t./skill-package\n`
+                    `\nSkill schema and interactionModels for ${TEST_SKILL_NAME} created at\n\t./skill-package\n`
                 );
                 done();
             });
@@ -262,7 +262,10 @@ describe('Controller test - hosted skill controller test', () => {
             hostedSkillController.clone(TEST_SKILL_ID, TEST_SKILL_NAME, TEST_PROJECT_PATH, TEST_DO_EXPORT_PACKAGE, (err, res) => {
                 expect(err).equal(undefined);
                 expect(Messenger.getInstance().info.args[0][0]).equal(
-                    `\nImported Skill schema and interactionModels for ${TEST_SKILL_NAME} created at\n\t./skill-package\n`
+                    `\nCloning project from git and exporting skill package from smapi for ${TEST_SKILL_NAME}`
+                );
+                expect(Messenger.getInstance().info.args[1][0]).equal(
+                    `\nSkill schema and interactionModels for ${TEST_SKILL_NAME} created at\n\t./skill-package\n`
                 );
                 done();
             });
@@ -279,8 +282,8 @@ describe('Controller test - hosted skill controller test', () => {
             // call
             hostedSkillController.clone(TEST_SKILL_ID, TEST_SKILL_NAME, TEST_PROJECT_PATH, TEST_DO_EXPORT_PACKAGE, (err, res) => {
                 expect(err).equal(undefined);
-                expect(Messenger.getInstance().info.args[0][0]).equal(
-                    `\nImported Skill schema and interactionModels for ${TEST_SKILL_NAME} created at\n\t./skill-package\n`
+                expect(Messenger.getInstance().info.args[1][0]).equal(
+                    `\nSkill schema and interactionModels for ${TEST_SKILL_NAME} created at\n\t./skill-package\n`
                 );
                 done();
             });

--- a/test/unit/controller/hosted-skill-controller/index-test.js
+++ b/test/unit/controller/hosted-skill-controller/index-test.js
@@ -137,7 +137,7 @@ describe('Controller test - hosted skill controller test', () => {
             // setup
             sinon.stub(fs, 'existsSync').withArgs(TEST_PROJECT_PATH).returns(true);
             // call
-            hostedSkillController.clone(TEST_SKILL_ID, TEST_SKILL_NAME, TEST_PROJECT_PATH, false, (err, res) => {
+            hostedSkillController.clone(TEST_SKILL_ID, TEST_SKILL_NAME, TEST_PROJECT_PATH, TEST_DO_NOT_EXPORT_PACKAGE, (err, res) => {
                 expect(err).equal(`${TEST_PROJECT_PATH} directory already exists.`);
                 expect(res).equal(undefined);
                 done();
@@ -151,7 +151,7 @@ describe('Controller test - hosted skill controller test', () => {
             sinon.stub(fs, 'existsSync').withArgs(TEST_PROJECT_PATH).returns(false);
             sinon.stub(httpClient, 'request').callsArgWith(3, TEST_ERROR); // stub getAlexaHostedSkillMetadata smapi request
             // call
-            hostedSkillController.clone(TEST_SKILL_ID, TEST_SKILL_NAME, TEST_PROJECT_PATH, false, (err, res) => {
+            hostedSkillController.clone(TEST_SKILL_ID, TEST_SKILL_NAME, TEST_PROJECT_PATH, TEST_DO_NOT_EXPORT_PACKAGE, (err, res) => {
                 expect(err.message).equal(TEST_METADATA_ERROR);
                 expect(res).equal(undefined);
                 done();
@@ -170,7 +170,7 @@ describe('Controller test - hosted skill controller test', () => {
             sinon.stub(fs, 'existsSync').withArgs(TEST_PROJECT_PATH).returns(false);
             sinon.stub(httpClient, 'request').callsArgWith(3, null, TEST_STATUS_ERROR); // stub getAlexaHostedSkillMetadata smapi request
             // call
-            hostedSkillController.clone(TEST_SKILL_ID, TEST_SKILL_NAME, TEST_PROJECT_PATH, false, (err, res) => {
+            hostedSkillController.clone(TEST_SKILL_ID, TEST_SKILL_NAME, TEST_PROJECT_PATH, TEST_DO_NOT_EXPORT_PACKAGE, (err, res) => {
                 expect(err).equal(jsonView.toString({ error: TEST_METADATA_ERROR }));
                 expect(res).equal(undefined);
                 done();
@@ -192,7 +192,7 @@ describe('Controller test - hosted skill controller test', () => {
             sinon.stub(CloneFlow, 'cloneProjectFromGit');
             sinon.stub(CloneFlow, 'doSkillPackageExist').callsArgWith(3, TEST_SKILL_PACKAGE_ERROR);
             // call
-            hostedSkillController.clone(TEST_SKILL_ID, TEST_SKILL_NAME, TEST_PROJECT_PATH, false, (err, res) => {
+            hostedSkillController.clone(TEST_SKILL_ID, TEST_SKILL_NAME, TEST_PROJECT_PATH, TEST_DO_NOT_EXPORT_PACKAGE, (err, res) => {
                 expect(err).equal(TEST_SKILL_PACKAGE_ERROR);
                 expect(res).equal(undefined);
                 done();
@@ -207,7 +207,7 @@ describe('Controller test - hosted skill controller test', () => {
             sinon.stub(CloneFlow, 'cloneProjectFromGit');
             sinon.stub(CloneFlow, 'doSkillPackageExist').callsArgWith(3, null, true);
             // call
-            hostedSkillController.clone(TEST_SKILL_ID, TEST_SKILL_NAME, TEST_PROJECT_PATH, false, (err) => {
+            hostedSkillController.clone(TEST_SKILL_ID, TEST_SKILL_NAME, TEST_PROJECT_PATH, TEST_DO_NOT_EXPORT_PACKAGE, (err) => {
                 expect(err).equal(undefined);
                 expect(Messenger.getInstance().info.args[0][0]).equal(
                     `\nSkill schema and interactionModels for ${TEST_SKILL_NAME} created at\n\t./skill-package\n`
@@ -226,7 +226,7 @@ describe('Controller test - hosted skill controller test', () => {
             sinon.stub(CloneFlow, 'doSkillPackageExist').callsArgWith(3, null, false);
             sinon.stub(SkillMetadataController.prototype, 'getSkillPackage').callsArgWith(4, TEST_EXPORT_ERROR);
             // call
-            hostedSkillController.clone(TEST_SKILL_ID, TEST_SKILL_NAME, TEST_PROJECT_PATH, false, (err, res) => {
+            hostedSkillController.clone(TEST_SKILL_ID, TEST_SKILL_NAME, TEST_PROJECT_PATH, TEST_DO_NOT_EXPORT_PACKAGE, (err, res) => {
                 expect(err).equal(TEST_EXPORT_ERROR);
                 done();
             });
@@ -241,10 +241,10 @@ describe('Controller test - hosted skill controller test', () => {
             sinon.stub(CloneFlow, 'doSkillPackageExist').callsArgWith(3, null);
             sinon.stub(SkillMetadataController.prototype, 'getSkillPackage').callsArgWith(4, null);
             // call
-            hostedSkillController.clone(TEST_SKILL_ID, TEST_SKILL_NAME, TEST_PROJECT_PATH, false, (err, res) => {
+            hostedSkillController.clone(TEST_SKILL_ID, TEST_SKILL_NAME, TEST_PROJECT_PATH, TEST_DO_NOT_EXPORT_PACKAGE, (err, res) => {
                 expect(err).equal(undefined);
                 expect(Messenger.getInstance().info.args[0][0]).equal(
-                    `\nSkill schema and interactionModels for ${TEST_SKILL_NAME} created at\n\t./skill-package\n`
+                    `\nImported Skill schema and interactionModels for ${TEST_SKILL_NAME} created at\n\t./skill-package\n`
                 );
                 done();
             });
@@ -262,7 +262,7 @@ describe('Controller test - hosted skill controller test', () => {
             hostedSkillController.clone(TEST_SKILL_ID, TEST_SKILL_NAME, TEST_PROJECT_PATH, TEST_DO_EXPORT_PACKAGE, (err, res) => {
                 expect(err).equal(undefined);
                 expect(Messenger.getInstance().info.args[0][0]).equal(
-                    `\nSkill schema and interactionModels for ${TEST_SKILL_NAME} created at\n\t./skill-package\n`
+                    `\nImported Skill schema and interactionModels for ${TEST_SKILL_NAME} created at\n\t./skill-package\n`
                 );
                 done();
             });
@@ -280,7 +280,7 @@ describe('Controller test - hosted skill controller test', () => {
             hostedSkillController.clone(TEST_SKILL_ID, TEST_SKILL_NAME, TEST_PROJECT_PATH, TEST_DO_EXPORT_PACKAGE, (err, res) => {
                 expect(err).equal(undefined);
                 expect(Messenger.getInstance().info.args[0][0]).equal(
-                    `\nSkill schema and interactionModels for ${TEST_SKILL_NAME} created at\n\t./skill-package\n`
+                    `\nImported Skill schema and interactionModels for ${TEST_SKILL_NAME} created at\n\t./skill-package\n`
                 );
                 done();
             });

--- a/test/unit/controller/hosted-skill-controller/index-test.js
+++ b/test/unit/controller/hosted-skill-controller/index-test.js
@@ -15,6 +15,8 @@ const jsonView = require('@src/view/json-view');
 describe('Controller test - hosted skill controller test', () => {
     const TEST_PROFILE = 'default'; // test file uses 'default' profile
     const TEST_DO_DEBUG = false;
+    const TEST_DO_EXPORT_PACKAGE = true;
+    const TEST_DO_NOT_EXPORT_PACKAGE = false;
     const TEST_SKILL_ID = 'SKILL_ID';
     const TEST_SKILL_NAME = 'SKILL_NAME';
     const TEST_MANIFEST = {};
@@ -135,7 +137,7 @@ describe('Controller test - hosted skill controller test', () => {
             // setup
             sinon.stub(fs, 'existsSync').withArgs(TEST_PROJECT_PATH).returns(true);
             // call
-            hostedSkillController.clone(TEST_SKILL_ID, TEST_SKILL_NAME, TEST_PROJECT_PATH, (err, res) => {
+            hostedSkillController.clone(TEST_SKILL_ID, TEST_SKILL_NAME, TEST_PROJECT_PATH, false, (err, res) => {
                 expect(err).equal(`${TEST_PROJECT_PATH} directory already exists.`);
                 expect(res).equal(undefined);
                 done();
@@ -149,7 +151,7 @@ describe('Controller test - hosted skill controller test', () => {
             sinon.stub(fs, 'existsSync').withArgs(TEST_PROJECT_PATH).returns(false);
             sinon.stub(httpClient, 'request').callsArgWith(3, TEST_ERROR); // stub getAlexaHostedSkillMetadata smapi request
             // call
-            hostedSkillController.clone(TEST_SKILL_ID, TEST_SKILL_NAME, TEST_PROJECT_PATH, (err, res) => {
+            hostedSkillController.clone(TEST_SKILL_ID, TEST_SKILL_NAME, TEST_PROJECT_PATH, false, (err, res) => {
                 expect(err.message).equal(TEST_METADATA_ERROR);
                 expect(res).equal(undefined);
                 done();
@@ -168,7 +170,7 @@ describe('Controller test - hosted skill controller test', () => {
             sinon.stub(fs, 'existsSync').withArgs(TEST_PROJECT_PATH).returns(false);
             sinon.stub(httpClient, 'request').callsArgWith(3, null, TEST_STATUS_ERROR); // stub getAlexaHostedSkillMetadata smapi request
             // call
-            hostedSkillController.clone(TEST_SKILL_ID, TEST_SKILL_NAME, TEST_PROJECT_PATH, (err, res) => {
+            hostedSkillController.clone(TEST_SKILL_ID, TEST_SKILL_NAME, TEST_PROJECT_PATH, false, (err, res) => {
                 expect(err).equal(jsonView.toString({ error: TEST_METADATA_ERROR }));
                 expect(res).equal(undefined);
                 done();
@@ -190,7 +192,7 @@ describe('Controller test - hosted skill controller test', () => {
             sinon.stub(CloneFlow, 'cloneProjectFromGit');
             sinon.stub(CloneFlow, 'doSkillPackageExist').callsArgWith(3, TEST_SKILL_PACKAGE_ERROR);
             // call
-            hostedSkillController.clone(TEST_SKILL_ID, TEST_SKILL_NAME, TEST_PROJECT_PATH, (err, res) => {
+            hostedSkillController.clone(TEST_SKILL_ID, TEST_SKILL_NAME, TEST_PROJECT_PATH, false, (err, res) => {
                 expect(err).equal(TEST_SKILL_PACKAGE_ERROR);
                 expect(res).equal(undefined);
                 done();
@@ -205,7 +207,7 @@ describe('Controller test - hosted skill controller test', () => {
             sinon.stub(CloneFlow, 'cloneProjectFromGit');
             sinon.stub(CloneFlow, 'doSkillPackageExist').callsArgWith(3, null, true);
             // call
-            hostedSkillController.clone(TEST_SKILL_ID, TEST_SKILL_NAME, TEST_PROJECT_PATH, (err) => {
+            hostedSkillController.clone(TEST_SKILL_ID, TEST_SKILL_NAME, TEST_PROJECT_PATH, false, (err) => {
                 expect(err).equal(undefined);
                 expect(Messenger.getInstance().info.args[0][0]).equal(
                     `\nSkill schema and interactionModels for ${TEST_SKILL_NAME} created at\n\t./skill-package\n`
@@ -222,9 +224,9 @@ describe('Controller test - hosted skill controller test', () => {
             sinon.stub(CloneFlow, 'generateProject');
             sinon.stub(CloneFlow, 'cloneProjectFromGit');
             sinon.stub(CloneFlow, 'doSkillPackageExist').callsArgWith(3, null, false);
-            sinon.stub(SkillMetadataController.prototype, 'getSkillPackage').callsArgWith(3, TEST_EXPORT_ERROR);
+            sinon.stub(SkillMetadataController.prototype, 'getSkillPackage').callsArgWith(4, TEST_EXPORT_ERROR);
             // call
-            hostedSkillController.clone(TEST_SKILL_ID, TEST_SKILL_NAME, TEST_PROJECT_PATH, (err) => {
+            hostedSkillController.clone(TEST_SKILL_ID, TEST_SKILL_NAME, TEST_PROJECT_PATH, false, (err, res) => {
                 expect(err).equal(TEST_EXPORT_ERROR);
                 done();
             });
@@ -237,9 +239,45 @@ describe('Controller test - hosted skill controller test', () => {
             sinon.stub(CloneFlow, 'generateProject');
             sinon.stub(CloneFlow, 'cloneProjectFromGit');
             sinon.stub(CloneFlow, 'doSkillPackageExist').callsArgWith(3, null);
-            sinon.stub(SkillMetadataController.prototype, 'getSkillPackage').callsArgWith(3, null);
+            sinon.stub(SkillMetadataController.prototype, 'getSkillPackage').callsArgWith(4, null);
             // call
-            hostedSkillController.clone(TEST_SKILL_ID, TEST_SKILL_NAME, TEST_PROJECT_PATH, (err) => {
+            hostedSkillController.clone(TEST_SKILL_ID, TEST_SKILL_NAME, TEST_PROJECT_PATH, false, (err, res) => {
+                expect(err).equal(undefined);
+                expect(Messenger.getInstance().info.args[0][0]).equal(
+                    `\nSkill schema and interactionModels for ${TEST_SKILL_NAME} created at\n\t./skill-package\n`
+                );
+                done();
+            });
+        });
+
+        it('| export-package option used, clone project models dont exist, expect skill-package generated ', (done) => {
+            // setup
+            sinon.stub(fs, 'existsSync').withArgs(TEST_PROJECT_PATH).returns(false);
+            sinon.stub(HostedSkillController.prototype, 'getHostedSkillMetadata').yields(null, { repository: { url: 'test' } });
+            sinon.stub(CloneFlow, 'generateProject');
+            sinon.stub(CloneFlow, 'cloneProjectFromGit');
+            sinon.stub(CloneFlow, 'doSkillPackageExist').callsArgWith(3, null, false);
+            sinon.stub(SkillMetadataController.prototype, 'getSkillPackage').callsArgWith(4, null);
+            // call
+            hostedSkillController.clone(TEST_SKILL_ID, TEST_SKILL_NAME, TEST_PROJECT_PATH, TEST_DO_EXPORT_PACKAGE, (err, res) => {
+                expect(err).equal(undefined);
+                expect(Messenger.getInstance().info.args[0][0]).equal(
+                    `\nSkill schema and interactionModels for ${TEST_SKILL_NAME} created at\n\t./skill-package\n`
+                );
+                done();
+            });
+        });
+
+        it('| export-package option used, clone project models exist, expect skill-package overwritten ', (done) => {
+            // setup
+            sinon.stub(fs, 'existsSync').withArgs(TEST_PROJECT_PATH).returns(false);
+            sinon.stub(HostedSkillController.prototype, 'getHostedSkillMetadata').yields(null, { repository: { url: 'test' } });
+            sinon.stub(CloneFlow, 'generateProject');
+            sinon.stub(CloneFlow, 'cloneProjectFromGit');
+            sinon.stub(CloneFlow, 'doSkillPackageExist').callsArgWith(3, null, true);
+            sinon.stub(SkillMetadataController.prototype, 'getSkillPackage').callsArgWith(4, null);
+            // call
+            hostedSkillController.clone(TEST_SKILL_ID, TEST_SKILL_NAME, TEST_PROJECT_PATH, TEST_DO_EXPORT_PACKAGE, (err, res) => {
                 expect(err).equal(undefined);
                 expect(Messenger.getInstance().info.args[0][0]).equal(
                     `\nSkill schema and interactionModels for ${TEST_SKILL_NAME} created at\n\t./skill-package\n`

--- a/test/unit/controller/skill-metadata-controller-test.js
+++ b/test/unit/controller/skill-metadata-controller-test.js
@@ -494,7 +494,7 @@ describe('Controller test - skill metadata controller test', () => {
             // setup
             sinon.stub(SkillMetadataController.prototype, '_exportPackage').callsArgWith(2, 'exportErr');
             // call
-            skillMetaController.getSkillPackage(TEST_ROOT_PATH, TEST_SKILL_ID, TEST_STAGE, (err, res) => {
+            skillMetaController.getSkillPackage(TEST_ROOT_PATH, TEST_SKILL_ID, TEST_STAGE, false, (err, res) => {
                 // verify
                 expect(SkillMetadataController.prototype._exportPackage.args[0][0]).equal(TEST_SKILL_ID);
                 expect(SkillMetadataController.prototype._exportPackage.args[0][1]).equal(TEST_STAGE);
@@ -514,7 +514,7 @@ describe('Controller test - skill metadata controller test', () => {
             });
             sinon.stub(SkillMetadataController.prototype, '_pollExportStatus').callsArgWith(1, 'polling error');
             // call
-            skillMetaController.getSkillPackage(TEST_ROOT_PATH, TEST_SKILL_ID, TEST_STAGE, (err, res) => {
+            skillMetaController.getSkillPackage(TEST_ROOT_PATH, TEST_SKILL_ID, TEST_STAGE, false, (err, res) => {
                 // verify
                 expect(SkillMetadataController.prototype._pollExportStatus.args[0][0]).equal(TEST_EXPORT_ID);
                 expect(res).equal(undefined);
@@ -539,9 +539,9 @@ describe('Controller test - skill metadata controller test', () => {
                     }
                 }
             });
-            sinon.stub(zipUtils, 'unzipRemoteZipFile').callsArgWith(3, 'unzip error');
+            sinon.stub(zipUtils, 'unzipRemoteZipFile').callsArgWith(4, 'unzip error');
             // call
-            skillMetaController.getSkillPackage(TEST_ROOT_PATH, TEST_SKILL_ID, TEST_STAGE, (err, res) => {
+            skillMetaController.getSkillPackage(TEST_ROOT_PATH, TEST_SKILL_ID, TEST_STAGE, false, (err, res) => {
                 // verify
                 expect(SkillMetadataController.prototype._pollExportStatus.args[0][0]).equal(TEST_EXPORT_ID);
                 expect(res).equal(undefined);
@@ -566,9 +566,9 @@ describe('Controller test - skill metadata controller test', () => {
                     }
                 }
             });
-            sinon.stub(zipUtils, 'unzipRemoteZipFile').callsArgWith(3, null);
+            sinon.stub(zipUtils, 'unzipRemoteZipFile').callsArgWith(4, null);
             // call
-            skillMetaController.getSkillPackage(TEST_ROOT_PATH, TEST_SKILL_ID, TEST_STAGE, (err, res) => {
+            skillMetaController.getSkillPackage(TEST_ROOT_PATH, TEST_SKILL_ID, TEST_STAGE, false, (err, res) => {
                 // verify
                 expect(SkillMetadataController.prototype._pollExportStatus.args[0][0]).equal(TEST_EXPORT_ID);
                 expect(res).equal(undefined);

--- a/test/unit/utils/zip-utils-test.js
+++ b/test/unit/utils/zip-utils-test.js
@@ -207,7 +207,7 @@ describe('Utils test - zip utility', () => {
             // setup
             sinon.stub(httpClient, 'request').callsArgWith(3, 'get error');
             // test
-            zipUtils.unzipRemoteZipFile(TEST_REMOTE_ZIP_URL, TEST_ZIP_FILE_PATH, false, (err) => {
+            zipUtils.unzipRemoteZipFile(TEST_REMOTE_ZIP_URL, TEST_ZIP_FILE_PATH, false, false, (err) => {
                 // verify
                 expect(httpClient.request.args[0][0].url).equal(TEST_REMOTE_ZIP_URL);
                 expect(httpClient.request.args[0][0].method).equal(CONSTANTS.HTTP_REQUEST.VERB.GET);
@@ -224,7 +224,7 @@ describe('Utils test - zip utility', () => {
             sinon.stub(httpClient, 'request').callsArgWith(3, null, TEST_REMOTE_ZIP_RESPONSE);
             stubRequest.throws('extract error');
             // test
-            proxyZipUtil.unzipRemoteZipFile(TEST_REMOTE_ZIP_URL, TEST_ZIP_FILE_PATH, false, (err) => {
+            proxyZipUtil.unzipRemoteZipFile(TEST_REMOTE_ZIP_URL, TEST_ZIP_FILE_PATH, false, false, (err) => {
                 // verify
                 expect(httpClient.request.args[0][0].url).equal(TEST_REMOTE_ZIP_URL);
                 expect(httpClient.request.args[0][0].method).equal(CONSTANTS.HTTP_REQUEST.VERB.GET);
@@ -242,7 +242,7 @@ describe('Utils test - zip utility', () => {
             sinon.stub(httpClient, 'request').callsArgWith(3, null, TEST_REMOTE_ZIP_RESPONSE);
             stubRequest.returns(null);
             // test
-            proxyZipUtil.unzipRemoteZipFile(TEST_REMOTE_ZIP_URL, TEST_ZIP_FILE_PATH, false, (err) => {
+            proxyZipUtil.unzipRemoteZipFile(TEST_REMOTE_ZIP_URL, TEST_ZIP_FILE_PATH, false, false, (err) => {
                 // verify
                 expect(stubRequest.args[0][0]).deep.equal(TEST_ZIP_FILE_PATH);
                 expect(err).equal(undefined);


### PR DESCRIPTION
*Description of changes:*

Adding a simple `export-package` option to the `ask init` command.

I have recently been working with a team creating widgets for alexa skills and they are heavy users of `ask init`. But after they use `ask init` and commit changes, they also update the skill via the developer console.

This causes an issue because those changes aren't stored in `git`. So I've added an `export-package` option that will update `ask init` to download files from smapi alongside cloning the git repo.

Before this option, the `ask init` command would only download skill-package assets from smapi if a `skill-package` folder didn't exist in git. So if a developer does commit the skill-package folder, it will no longer use `smapi export-package`. Now when `ask init --hosted-skill-id <id> --export-package` is used, it will always download the skill schema from smapi so developers can recommit these files if wanted.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
