### PR TITLE
feat: updating Alexa Hosted Skills runtime to Node.js 16

### DIFF
--- a/lib/utils/constants.js
+++ b/lib/utils/constants.js
@@ -40,7 +40,7 @@ module.exports.HOSTED_SKILL = {
         'eu-west-1': 'EU_WEST_1'
     },
     DEFAULT_RUNTIME: {
-        NodeJS: 'NODE_12_X',
+        NodeJS: 'NODE_16_X',
         Python: 'PYTHON_3_7',
     },
     SIGNIN_PATH: '/ap/signin',

--- a/test/integration/fixtures/skill-manifest.json
+++ b/test/integration/fixtures/skill-manifest.json
@@ -15,7 +15,7 @@
     },
     "hosting":{
        "alexaHosted":{
-          "runtime":"NODE_12_X"
+          "runtime":"NODE_16_X"
        }
     }
  }

--- a/test/unit/clients/smapi-client-test/resources/alexa-hosted.js
+++ b/test/unit/clients/smapi-client-test/resources/alexa-hosted.js
@@ -16,7 +16,7 @@ module.exports = (smapiClient) => {
         const TEST_PROFILE = 'testProfile';
         const TEST_ACCESS_TOKEN = 'access_token';
         const TEST_RUNTIME_FIELD = 'NodeJS';
-        const TEST_RUNTIME_VALUE = 'NODE_12_X';
+        const TEST_RUNTIME_VALUE = 'NODE_16_X';
         const TEST_REGION_VALUE = 'US_EAST_1';
         const TEST_MANIFEST = {
             runtime: TEST_RUNTIME_FIELD,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This change is to update Alexa Hosted Skills node runtime to Node.js 16.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
