### PR TITLE
fix: update npm build command

### DIFF
--- a/lib/builtins/build-flows/abstract-build-flow.js
+++ b/lib/builtins/build-flows/abstract-build-flow.js
@@ -17,6 +17,7 @@ class AbstractBuildFlow {
         this.cwd = cwd;
         this.src = src;
         this.buildFile = buildFile;
+        this.env = process.env;
         this.stdio = 'inherit';
         this.doDebug = !!doDebug;
         this.isWindows = process.platform === 'win32';
@@ -76,7 +77,7 @@ class AbstractBuildFlow {
      * @param {String} cmd command
      */
     execCommand(cmd) {
-        childProcess.execSync(cmd, { cwd: this.cwd, stdio: this.stdio });
+        childProcess.execSync(cmd, { cwd: this.cwd, env: this.env, stdio: this.stdio });
     }
 
     /**

--- a/lib/builtins/build-flows/nodejs-npm.js
+++ b/lib/builtins/build-flows/nodejs-npm.js
@@ -9,6 +9,8 @@ class NodeJsNpmBuildFlow extends AbstractBuildFlow {
      */
     static get manifest() { return 'package.json'; }
 
+    static get _lockFiles() { return ['package-lock.json', 'npm-shrinkwrap.json']; }
+
     /**
      * Returns true if the build flow can handle the build
      */
@@ -33,10 +35,16 @@ class NodeJsNpmBuildFlow extends AbstractBuildFlow {
      * @param {Function} callback
      */
     execute(callback) {
+        const installCmd = this._hasLockFile() ? 'ci' : 'install';
         const quietFlag = this.doDebug ? '' : ' --quiet';
+        this.env.NODE_ENV = 'production';
         this.debug(`Installing NodeJS dependencies based on the ${NodeJsNpmBuildFlow.manifest}.`);
-        this.execCommand(`npm install --production${quietFlag}`);
+        this.execCommand(`npm ${installCmd}${quietFlag}`);
         this.createZip(callback);
+    }
+
+    _hasLockFile() {
+        return NodeJsNpmBuildFlow._lockFiles.some(file => fs.existsSync(path.join(this.src, file)));
     }
 }
 


### PR DESCRIPTION
*Description of changes:*

This change updates the npm build command setting the environment variable `NODE_ENV` to `production` instead of using the deprecated `production` config flag. This will prevent the below warning from being generated using npm v7 and later.

```
npm WARN config production Use `--omit=dev` instead.
```

It also includes a change favoring the [`npm ci`](https://docs.npmjs.com/cli/commands/npm-ci) command over `npm install` when a package lock file is present.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
