### PR TITLE
feat: remove modeling stack prompt from `ask new`, add `--ac` flag to view ac templates

### DIFF
--- a/lib/commands/new/index.ts
+++ b/lib/commands/new/index.ts
@@ -21,13 +21,8 @@ export type NewSkillDeployerTypeInfo = {
   NAME: string;
   DESCRIPTION: string;
 };
-export type NewSkillModelingStackTypes = "Interaction Model" | "Alexa Conversations";
-export const MODELING_STACK_IM: NewSkillModelingStackTypes = "Interaction Model";
-export const MODELING_STACK_IM_DESCRIPTION: string =
-  "The Interaction Model stack enables you to define the user interactions with a combination of utterances, intents, and slots.";
-export const MODELING_STACK_AC: NewSkillModelingStackTypes = "Alexa Conversations";
-export const MODELING_STACK_AC_DESCRIPTION: string =
-  "Alexa Conversations (AC) uses deep learning to manage the dialog flow. User utterances, APL, and APLA documents train the skill model to create natural, human-like Alexa voice experiences.";
+export const MODELING_STACK_IM = "im";
+export const MODELING_STACK_AC = "ac";
 export type NewSkillTemplateInfo = {
   templateUrl?: string;
   templateName?: string;
@@ -42,7 +37,6 @@ export type NewSkillUserInput = {
   templateInfo?: NewSkillTemplateInfo;
   skillName?: string;
   projectFolderName?: string;
-  modelingStack?: NewSkillModelingStackTypes;
 };
 
 export default class NewCommand extends AbstractCommand {
@@ -59,7 +53,7 @@ export default class NewCommand extends AbstractCommand {
   }
 
   optionalOptions() {
-    return ["templateUrl", "templateBranch", "profile", "debug"];
+    return ["templateUrl", "templateBranch", "profile", "debug", "ac"];
   }
 
   async handle(cmd: Record<string, any>): Promise<void> {

--- a/lib/commands/new/template-helper.ts
+++ b/lib/commands/new/template-helper.ts
@@ -2,7 +2,7 @@ import httpClient from "../../clients/http-client";
 import R from "ramda";
 import {TEMPLATES, HTTP_REQUEST, DEPLOYER_TYPE} from "../../utils/constants";
 import {SampleTemplate, SampleTemplateFilterValues} from "../../model/sample-template";
-import {CODE_LANGUAGE_JAVA, CODE_LANGUAGE_NODEJS, CODE_LANGUAGE_PYTHON, MODELING_STACK_AC, MODELING_STACK_IM} from ".";
+import {CODE_LANGUAGE_JAVA, CODE_LANGUAGE_NODEJS, CODE_LANGUAGE_PYTHON} from ".";
 
 export function getSampleTemplatesFromS3(doDebug: boolean): Promise<SampleTemplate[]> {
   return new Promise<SampleTemplate[]>((resolve, reject) => {
@@ -24,10 +24,6 @@ export function getSampleTemplatesFromS3(doDebug: boolean): Promise<SampleTempla
 
 export function convertUserInputToFilterValue(inputValue: string): SampleTemplateFilterValues {
   switch (inputValue.toLowerCase()) {
-    case MODELING_STACK_IM.toLowerCase():
-      return "im";
-    case MODELING_STACK_AC.toLowerCase():
-      return "ac";
     case CODE_LANGUAGE_NODEJS.toLowerCase():
       return "node";
     case CODE_LANGUAGE_PYTHON.toLowerCase():

--- a/lib/commands/new/ui.ts
+++ b/lib/commands/new/ui.ts
@@ -7,11 +7,7 @@ import {callbackError, uiCallback} from "../../model/callback";
 import {isNonBlankString} from "../../utils/string-utils";
 import {
   NewSkillDeployerTypeInfo,
-  MODELING_STACK_IM,
-  MODELING_STACK_AC,
   NewSkillCodeLanguage,
-  MODELING_STACK_IM_DESCRIPTION,
-  MODELING_STACK_AC_DESCRIPTION,
 } from ".";
 import {SampleTemplate} from "../../model/sample-template";
 
@@ -199,37 +195,6 @@ export function getDeploymentType(deployType: NewSkillDeployerTypeInfo[], callba
     .then((answer) => {
       const selectedDeployDelegate = find(propEq("OPTION_NAME", answer.deployDelegate))(deployType);
       callback(null, view(lensPath(["NAME"]), selectedDeployDelegate));
-    })
-    .catch((error) => {
-      callback(error);
-    });
-}
-
-/**
- * Prompts the user to select the modeling stack type they want the samples to use
- * i.e. Interaction Model vs Alexa Conversations
- *
- * @param {uiCallback} callback function that will be called with the resulting value or error
- */
-export function getModelingStackType(callback: uiCallback): void {
-  const modelingStackChoices = [
-    `${MODELING_STACK_IM}\n  ${gray(MODELING_STACK_IM_DESCRIPTION)}`,
-    `${MODELING_STACK_AC}\n  ${gray(MODELING_STACK_AC_DESCRIPTION)}`,
-  ];
-  inquirer
-    .prompt([
-      {
-        message: "Choose a modeling stack for your skill: ",
-        type: "list",
-        name: "modelingStack",
-        choices: modelingStackChoices,
-        default: MODELING_STACK_IM,
-        pageSize: 5,
-        filter: (input) => input.replace(/\n.*/g, ""),
-      },
-    ])
-    .then((answer) => {
-      callback(null, answer.modelingStack);
     })
     .catch((error) => {
       callback(error);

--- a/lib/commands/new/wizard-helper.ts
+++ b/lib/commands/new/wizard-helper.ts
@@ -13,8 +13,8 @@ import {
   NewSkillRegion,
   NewSkillTemplateInfo,
   NewSkillUserInput,
-  NewSkillModelingStackTypes,
   MODELING_STACK_IM,
+  MODELING_STACK_AC,
   CODE_LANGUAGE_NODEJS,
   CODE_LANGUAGE_PYTHON,
   CODE_LANGUAGE_JAVA,
@@ -48,8 +48,7 @@ export async function collectUserCreationProjectInfo(
     const sampleTemplateFilter: SampleTemplatesFilter = new SampleTemplatesFilter(sampleTemplates);
 
     // MODELING STACK TYPE
-    await promptForModelingStackType().then((modelingStack) => (userInput.modelingStack = modelingStack));
-    sampleTemplateFilter.filter("stack", convertUserInputToFilterValue(userInput.modelingStack || MODELING_STACK_IM));
+    sampleTemplateFilter.filter("stack", cmd.ac ? MODELING_STACK_AC : MODELING_STACK_IM);
 
     // CODE LANGUAGE
     // ignore when template url supplied
@@ -141,18 +140,6 @@ function promptForDeployerType(samples: SampleTemplate[]): Promise<NewSkillDeplo
     );
 
     ui.getDeploymentType(Array.from(remainingDeployerTypes), (error, deploymentType) => (error ? reject(error) : resolve(deploymentType)));
-  });
-}
-
-/**
- * A Promise that fetches and returns the NewSkillModelingStackTypes the user wants the samples to use.
- * i.e. interaction-model vs alexa-conversations
- *
- * @returns {Promise<NewSkillModelingStackTypes>} a Promise that will provide a Modeling Stack
- */
-function promptForModelingStackType(): Promise<NewSkillModelingStackTypes> {
-  return new Promise((resolve, reject) => {
-    ui.getModelingStackType((error, modelingStack) => (error ? reject(error) : resolve(modelingStack)));
   });
 }
 

--- a/lib/commands/option-model.json
+++ b/lib/commands/option-model.json
@@ -234,5 +234,10 @@
     "name": "watch",
     "description": "Uses nodemon to monitor changes and automatically restart the run session.",
     "stringInput": "NONE"
+  },
+  "ac": {
+    "name": "ac",
+    "description": "Displays Alexa skill templates that use the Alexa Conversations modeling stack.",
+    "stringInput": "NONE"
   }
 }

--- a/lib/commands/smapi/smapi-commander.ts
+++ b/lib/commands/smapi/smapi-commander.ts
@@ -190,7 +190,7 @@ export const makeSmapiCommander = () => {
   );
 
   program.on("command:*", () => {
-    console.error(`Command not recognized. Please run "${program.name}" to check the user instructions.`);
+    console.error(`Command not recognized. Please run "ask smapi" to check the user instructions.`);
     process.exit(1);
   });
 

--- a/test/unit/commands/new/index-test.ts
+++ b/test/unit/commands/new/index-test.ts
@@ -54,7 +54,7 @@ describe("Commands new test - command class test", () => {
     expect(instance.name()).equal("new");
     expect(instance.description()).equal("create a new skill project from Alexa skill templates");
     expect(instance.requiredOptions()).deep.equal([]);
-    expect(instance.optionalOptions()).deep.equal(["templateUrl", "templateBranch", "profile", "debug"]);
+    expect(instance.optionalOptions()).deep.equal(["templateUrl", "templateBranch", "profile", "debug", "ac"]);
   });
 
   describe("validate command handle", () => {

--- a/test/unit/commands/new/template-helper-test.ts
+++ b/test/unit/commands/new/template-helper-test.ts
@@ -6,8 +6,6 @@ import {
   CODE_LANGUAGE_JAVA,
   CODE_LANGUAGE_NODEJS,
   CODE_LANGUAGE_PYTHON,
-  MODELING_STACK_AC,
-  MODELING_STACK_IM,
 } from "../../../../lib/commands/new";
 import {getSampleTemplatesFromS3, convertUserInputToFilterValue} from "../../../../lib/commands/new/template-helper";
 import {SampleTemplate} from "../../../../lib/model/sample-template";
@@ -123,8 +121,6 @@ describe("Commands new test - template helper test", () => {
 
   describe("convertUserInputToFilterValue", () => {
     it("should convert values to correct mapping", () => {
-      expect(convertUserInputToFilterValue(MODELING_STACK_IM)).to.equal("im");
-      expect(convertUserInputToFilterValue(MODELING_STACK_AC)).to.equal("ac");
       expect(convertUserInputToFilterValue(CODE_LANGUAGE_NODEJS)).to.equal("node");
       expect(convertUserInputToFilterValue(CODE_LANGUAGE_PYTHON)).to.equal("python");
       expect(convertUserInputToFilterValue(CODE_LANGUAGE_JAVA)).to.equal("java");
@@ -135,9 +131,9 @@ describe("Commands new test - template helper test", () => {
     });
 
     it("should be case insensitive", () => {
-      expect(convertUserInputToFilterValue(MODELING_STACK_IM)).to.equal("im");
-      expect(convertUserInputToFilterValue(MODELING_STACK_IM.toLowerCase())).to.equal("im");
-      expect(convertUserInputToFilterValue(MODELING_STACK_IM.toUpperCase())).to.equal("im");
+      expect(convertUserInputToFilterValue(CODE_LANGUAGE_NODEJS)).to.equal("node");
+      expect(convertUserInputToFilterValue(CODE_LANGUAGE_NODEJS.toLowerCase())).to.equal("node");
+      expect(convertUserInputToFilterValue(CODE_LANGUAGE_NODEJS.toUpperCase())).to.equal("node");
     });
 
     it("should fail fast and throw and error if not identified", (done) => {

--- a/test/unit/commands/new/ui-test.ts
+++ b/test/unit/commands/new/ui-test.ts
@@ -11,7 +11,6 @@ import {
   getTargetTemplateName,
   confirmUsingUnofficialTemplate,
   getDeploymentType,
-  getModelingStackType,
 } from "../../../../lib/commands/new/ui";
 import {SampleTemplate} from "../../../../lib/model/sample-template";
 import { CODE_LANGUAGE_JAVA, CODE_LANGUAGE_NODEJS, CODE_LANGUAGE_PYTHON } from "../../../../lib/commands/new";
@@ -424,50 +423,6 @@ describe("Commands new - UI test", () => {
           choices: TEST_DEPLOYMENT_CHOICES_WITH_SEP,
         });
         expect(inquirerPrompt.args[0][0][0].filter("a \n \n b")).equal("a ");
-        expect(err?.message).equal(TEST_ERROR);
-        expect(response).equal(undefined);
-        done();
-      });
-    });
-  });
-
-  describe("| getModelingStackType", () => {
-    let inquirerPrompt: SinonStub;
-
-    beforeEach(() => {
-      inquirerPrompt = sinon.stub(inquirer, "prompt");
-    });
-
-    afterEach(() => {
-      sinon.restore();
-    });
-
-    it("| getModelingStackType selected by user is retrieved correctly", (done) => {
-      // setup
-      inquirerPrompt.resolves({modelingStack: "Alexa Conversations"});
-      // call
-      getModelingStackType((err, response) => {
-        // verify
-        validateInquirerConfig(inquirerPrompt.args[0][0][0], {
-          message: "Choose a modeling stack for your skill: ",
-          type: "list",
-        });
-        expect(err).equal(null);
-        expect(response).equal("Alexa Conversations");
-        done();
-      });
-    });
-
-    it("| getModelingStackType inquirer throws exception", (done) => {
-      // setup
-      inquirerPrompt.rejects(new Error(TEST_ERROR));
-      // call
-      getModelingStackType((err, response) => {
-        // verify
-        validateInquirerConfig(inquirerPrompt.args[0][0][0], {
-          message: "Choose a modeling stack for your skill: ",
-          type: "list",
-        });
         expect(err?.message).equal(TEST_ERROR);
         expect(response).equal(undefined);
         done();

--- a/test/unit/commands/new/wizard-helper-test.ts
+++ b/test/unit/commands/new/wizard-helper-test.ts
@@ -7,7 +7,6 @@ import urlUtils from "../../../../lib/utils/url-utils";
 import * as wizardHelper from "../../../../lib/commands/new/wizard-helper";
 import Messenger from "../../../../lib/view/messenger";
 import {TEST_SAMPLE_1_IM_HOSTED_NODE, TEST_SAMPLE_2_AC_CFN_PYTHON} from "./template-helper-test";
-import { MODELING_STACK_IM } from "../../../../lib/commands/new";
 
 describe("Commands new test - wizard helper test", () => {
   const TEST_ERROR = "TEST_ERROR";
@@ -38,7 +37,6 @@ describe("Commands new test - wizard helper test", () => {
   let getSkillDefaultRegionStub: SinonStub;
   let getSkillLocaleStub: SinonStub;
   let getInstanceStub: SinonStub;
-  let getModelingStackTypeStub: SinonStub;
   let getSampleTemplatesFromS3Stub: SinonStub;
 
   beforeEach(() => {
@@ -63,8 +61,6 @@ describe("Commands new test - wizard helper test", () => {
     getSkillLocaleStub = sinon.stub(ui, "getSkillLocale");
     getSkillLocaleStub.yields(null, "en-US");
     getSkillLocaleStub.yields(null, "us-east-1");
-    getModelingStackTypeStub = sinon.stub(ui, "getModelingStackType");
-    getModelingStackTypeStub.callsArgWith(0, null, MODELING_STACK_IM);
     getSampleTemplatesFromS3Stub = sinon.stub(templateHelper, "getSampleTemplatesFromS3");
     getSampleTemplatesFromS3Stub.resolves(TEST_TEMPLATE_SAMPLES);
   });


### PR DESCRIPTION
### Description of changes
Removes the "Interaction Model" vs "Alexa Conversations" modeling stack prompt during the `ask new` wizard. To access the Alexa Conversations templates, you can now pass in a new 'ac' flag, like `ask new --ac`.

### Tests/ Screenshots
All unit tests passing:
<img width="715" alt="image" src="https://user-images.githubusercontent.com/56455637/231618682-2a49af02-fe1a-4407-90ed-acbd773b014b.png">

Without `--ac` flag: 
<img width="996" alt="image" src="https://user-images.githubusercontent.com/56455637/231618826-84a46e3a-6983-4278-ab93-c558ace50646.png">

With `--ac` flag:
<img width="586" alt="image" src="https://user-images.githubusercontent.com/56455637/231618886-30a608fc-79f6-4571-9637-b4dae5a12be2.png">

`ask new --help`: 
<img width="1138" alt="image" src="https://user-images.githubusercontent.com/56455637/231618990-a0de9f4d-dd40-4bde-85d6-a71f5f22de1a.png">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
