### PR TITLE
fix: update functional-tests to not prompt for modeling stack anymore

### DIFF
--- a/test/functional/commands/high-level-commands-test.js
+++ b/test/functional/commands/high-level-commands-test.js
@@ -52,7 +52,6 @@ parallel("high level commands test", () => {
     // new
     let args = ["new"];
     let inputs = [
-      {match: "? Choose a modeling stack for your skill"},
       {match: "? Choose the programming language you will use to code your skill"},
       {match: "? Choose a method to host your skill"},
       {match: "? Choose the default region for your skill"},
@@ -96,7 +95,6 @@ parallel("high level commands test", () => {
     // new
     let args = ["new"];
     const inputs = [
-      {match: "? Choose a modeling stack for your skill"},
       {match: "? Choose the programming language you will use to code your skill"},
       {match: "? Choose a method to host your skill", input: KeySymbol.DOWN},
       {match: "? Choose a template to start with"},
@@ -123,7 +121,6 @@ parallel("high level commands test", () => {
     // new
     let args = ["new"];
     const inputs = [
-      {match: "? Choose a modeling stack for your skill"},
       {match: "? Choose the programming language you will use to code your skill"},
       {match: "? Choose a method to host your skill", input: `${KeySymbol.DOWN}${KeySymbol.DOWN}`},
       {match: "? Choose a template to start with"},
@@ -150,7 +147,6 @@ parallel("high level commands test", () => {
     // new
     let args = ["new"];
     const inputs = [
-      {match: "? Choose a modeling stack for your skill"},
       {match: "? Choose the programming language you will use to code your skill"},
       {match: "? Choose a method to host your skill", input: `${KeySymbol.DOWN}${KeySymbol.DOWN}`},
       {match: "? Choose a template to start with", input: `${KeySymbol.DOWN}${KeySymbol.DOWN}${KeySymbol.DOWN}`},


### PR DESCRIPTION
*Issue #, if available:*

after the --ac flag was introduced the functional tests were failing.  

fixing the tests by removing the prompt for modeling stack. 

new tests to validate the --ac flag are in the backlog and will be part of another PR


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
