### PR TITLE
fix: default region not getting set correctly

### DIFF
--- a/lib/builtins/deploy-delegates/cfn-deployer/index.js
+++ b/lib/builtins/deploy-delegates/cfn-deployer/index.js
@@ -20,7 +20,7 @@ module.exports = {
  * @param {Object} options
  * @param {Function} callback
  */
-function bootstrap(options, callback) {
+async function bootstrap(options, callback) {
   const {profile, workspacePath} = options;
   const userConfig = options.userConfig || {};
   const templateLocation = path.join(workspacePath, SKILL_STACK_PUBLIC_FILE_NAME);
@@ -28,7 +28,7 @@ function bootstrap(options, callback) {
   try {
     const templateContent = fs.readFileSync(path.join(__dirname, "assets", SKILL_STACK_ASSET_FILE_NAME), "utf-8");
     const awsProfile = awsUtil.getAWSProfile(profile);
-    const awsDefaultRegion = awsUtil.getCLICompatibleDefaultRegion(awsProfile);
+    const awsDefaultRegion = await awsUtil.getCLICompatibleDefaultRegion(awsProfile);
     fs.writeFileSync(templateLocation, templateContent);
     userConfig.templatePath = `./${path.posix.join("infrastructure", path.basename(workspacePath), SKILL_STACK_PUBLIC_FILE_NAME)}`;
     updatedUserConfig = R.set(R.lensPath(["awsRegion"]), awsDefaultRegion, userConfig);

--- a/lib/builtins/deploy-delegates/lambda-deployer/index.js
+++ b/lib/builtins/deploy-delegates/lambda-deployer/index.js
@@ -14,10 +14,10 @@ module.exports = {
  * @param {Object} options
  * @param {Function} callback
  */
-function bootstrap(options, callback) {
+async function bootstrap(options, callback) {
   const {profile, userConfig} = options;
   const awsProfile = awsUtil.getAWSProfile(profile);
-  const awsDefaultRegion = awsUtil.getCLICompatibleDefaultRegion(awsProfile);
+  const awsDefaultRegion = await awsUtil.getCLICompatibleDefaultRegion(awsProfile);
   const updatedUserConfig = R.set(R.lensPath(["awsRegion"]), awsDefaultRegion, userConfig);
   callback(null, {userConfig: updatedUserConfig});
 }


### PR DESCRIPTION
*Issue #, if available:*

Fixing some functional tests that were showing an issue picking up the default AWS regions. the latest changes migrating to aws-sdk v3 converted an awsutil function to a promise and the callers were not updated to await for the promise to complete.   fix is simply to wait for the promise to resolve by calling await.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
