### PR TITLE
Revert ac flag

### DIFF
--- a/lib/commands/new/index.ts
+++ b/lib/commands/new/index.ts
@@ -21,8 +21,13 @@ export type NewSkillDeployerTypeInfo = {
   NAME: string;
   DESCRIPTION: string;
 };
-export const MODELING_STACK_IM = "im";
-export const MODELING_STACK_AC = "ac";
+export type NewSkillModelingStackTypes = "Interaction Model" | "Alexa Conversations";
+export const MODELING_STACK_IM: NewSkillModelingStackTypes = "Interaction Model";
+export const MODELING_STACK_IM_DESCRIPTION: string =
+  "The Interaction Model stack enables you to define the user interactions with a combination of utterances, intents, and slots.";
+export const MODELING_STACK_AC: NewSkillModelingStackTypes = "Alexa Conversations";
+export const MODELING_STACK_AC_DESCRIPTION: string =
+  "Alexa Conversations (AC) uses deep learning to manage the dialog flow. User utterances, APL, and APLA documents train the skill model to create natural, human-like Alexa voice experiences.";
 export type NewSkillTemplateInfo = {
   templateUrl?: string;
   templateName?: string;
@@ -37,6 +42,7 @@ export type NewSkillUserInput = {
   templateInfo?: NewSkillTemplateInfo;
   skillName?: string;
   projectFolderName?: string;
+  modelingStack?: NewSkillModelingStackTypes;
 };
 
 export default class NewCommand extends AbstractCommand {
@@ -53,7 +59,7 @@ export default class NewCommand extends AbstractCommand {
   }
 
   optionalOptions() {
-    return ["templateUrl", "templateBranch", "profile", "debug", "ac"];
+    return ["templateUrl", "templateBranch", "profile", "debug"];
   }
 
   async handle(cmd: Record<string, any>): Promise<void> {

--- a/lib/commands/new/template-helper.ts
+++ b/lib/commands/new/template-helper.ts
@@ -2,7 +2,7 @@ import httpClient from "../../clients/http-client";
 import R from "ramda";
 import {TEMPLATES, HTTP_REQUEST, DEPLOYER_TYPE} from "../../utils/constants";
 import {SampleTemplate, SampleTemplateFilterValues} from "../../model/sample-template";
-import {CODE_LANGUAGE_JAVA, CODE_LANGUAGE_NODEJS, CODE_LANGUAGE_PYTHON} from ".";
+import {CODE_LANGUAGE_JAVA, CODE_LANGUAGE_NODEJS, CODE_LANGUAGE_PYTHON, MODELING_STACK_AC, MODELING_STACK_IM} from ".";
 
 export function getSampleTemplatesFromS3(doDebug: boolean): Promise<SampleTemplate[]> {
   return new Promise<SampleTemplate[]>((resolve, reject) => {
@@ -24,6 +24,10 @@ export function getSampleTemplatesFromS3(doDebug: boolean): Promise<SampleTempla
 
 export function convertUserInputToFilterValue(inputValue: string): SampleTemplateFilterValues {
   switch (inputValue.toLowerCase()) {
+    case MODELING_STACK_IM.toLowerCase():
+      return "im";
+    case MODELING_STACK_AC.toLowerCase():
+      return "ac";
     case CODE_LANGUAGE_NODEJS.toLowerCase():
       return "node";
     case CODE_LANGUAGE_PYTHON.toLowerCase():

--- a/lib/commands/new/ui.ts
+++ b/lib/commands/new/ui.ts
@@ -7,7 +7,11 @@ import {callbackError, uiCallback} from "../../model/callback";
 import {isNonBlankString} from "../../utils/string-utils";
 import {
   NewSkillDeployerTypeInfo,
+  MODELING_STACK_IM,
+  MODELING_STACK_AC,
   NewSkillCodeLanguage,
+  MODELING_STACK_IM_DESCRIPTION,
+  MODELING_STACK_AC_DESCRIPTION,
 } from ".";
 import {SampleTemplate} from "../../model/sample-template";
 
@@ -195,6 +199,37 @@ export function getDeploymentType(deployType: NewSkillDeployerTypeInfo[], callba
     .then((answer) => {
       const selectedDeployDelegate = find(propEq("OPTION_NAME", answer.deployDelegate))(deployType);
       callback(null, view(lensPath(["NAME"]), selectedDeployDelegate));
+    })
+    .catch((error) => {
+      callback(error);
+    });
+}
+
+/**
+ * Prompts the user to select the modeling stack type they want the samples to use
+ * i.e. Interaction Model vs Alexa Conversations
+ *
+ * @param {uiCallback} callback function that will be called with the resulting value or error
+ */
+export function getModelingStackType(callback: uiCallback): void {
+  const modelingStackChoices = [
+    `${MODELING_STACK_IM}\n  ${gray(MODELING_STACK_IM_DESCRIPTION)}`,
+    `${MODELING_STACK_AC}\n  ${gray(MODELING_STACK_AC_DESCRIPTION)}`,
+  ];
+  inquirer
+    .prompt([
+      {
+        message: "Choose a modeling stack for your skill: ",
+        type: "list",
+        name: "modelingStack",
+        choices: modelingStackChoices,
+        default: MODELING_STACK_IM,
+        pageSize: 5,
+        filter: (input) => input.replace(/\n.*/g, ""),
+      },
+    ])
+    .then((answer) => {
+      callback(null, answer.modelingStack);
     })
     .catch((error) => {
       callback(error);

--- a/lib/commands/new/wizard-helper.ts
+++ b/lib/commands/new/wizard-helper.ts
@@ -13,8 +13,8 @@ import {
   NewSkillRegion,
   NewSkillTemplateInfo,
   NewSkillUserInput,
+  NewSkillModelingStackTypes,
   MODELING_STACK_IM,
-  MODELING_STACK_AC,
   CODE_LANGUAGE_NODEJS,
   CODE_LANGUAGE_PYTHON,
   CODE_LANGUAGE_JAVA,
@@ -48,7 +48,8 @@ export async function collectUserCreationProjectInfo(
     const sampleTemplateFilter: SampleTemplatesFilter = new SampleTemplatesFilter(sampleTemplates);
 
     // MODELING STACK TYPE
-    sampleTemplateFilter.filter("stack", cmd.ac ? MODELING_STACK_AC : MODELING_STACK_IM);
+    await promptForModelingStackType().then((modelingStack) => (userInput.modelingStack = modelingStack));
+    sampleTemplateFilter.filter("stack", convertUserInputToFilterValue(userInput.modelingStack || MODELING_STACK_IM));
 
     // CODE LANGUAGE
     // ignore when template url supplied
@@ -140,6 +141,18 @@ function promptForDeployerType(samples: SampleTemplate[]): Promise<NewSkillDeplo
     );
 
     ui.getDeploymentType(Array.from(remainingDeployerTypes), (error, deploymentType) => (error ? reject(error) : resolve(deploymentType)));
+  });
+}
+
+/**
+ * A Promise that fetches and returns the NewSkillModelingStackTypes the user wants the samples to use.
+ * i.e. interaction-model vs alexa-conversations
+ *
+ * @returns {Promise<NewSkillModelingStackTypes>} a Promise that will provide a Modeling Stack
+ */
+function promptForModelingStackType(): Promise<NewSkillModelingStackTypes> {
+  return new Promise((resolve, reject) => {
+    ui.getModelingStackType((error, modelingStack) => (error ? reject(error) : resolve(modelingStack)));
   });
 }
 

--- a/lib/commands/option-model.json
+++ b/lib/commands/option-model.json
@@ -234,10 +234,5 @@
     "name": "watch",
     "description": "Uses nodemon to monitor changes and automatically restart the run session.",
     "stringInput": "NONE"
-  },
-  "ac": {
-    "name": "ac",
-    "description": "Displays Alexa skill templates that use the Alexa Conversations modeling stack.",
-    "stringInput": "NONE"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3997,22 +3997,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/JSONStream": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
-      "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
-      "dev": true,
-      "dependencies": {
-        "jsonparse": "^1.2.0",
-        "through": ">=2.2.7 <3"
-      },
-      "bin": {
-        "JSONStream": "bin.js"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -5989,8 +5973,8 @@
       "integrity": "sha512-nK7sAtfi+QXbxHCYfhpZsfRtaitZLIA6889kFIouLvz6repszQDgxBu7wf2WbU+Dco7sAnNCJYERCwt54WPC2Q==",
       "dev": true,
       "dependencies": {
-        "JSONStream": "^1.0.4",
         "is-text-path": "^1.0.1",
+        "JSONStream": "^1.0.4",
         "lodash": "^4.17.15",
         "meow": "^8.0.0",
         "split2": "^3.0.0",
@@ -9093,6 +9077,22 @@
       "resolved": "https://registry.npmjs.org/jsonpointer.js/-/jsonpointer.js-0.4.0.tgz",
       "integrity": "sha512-2bf/1crAmPpsmj1I6rDT6W0SOErkrNBpb555xNWcMVWYrX6VnXpG0GRMQ2shvOHwafpfse8q0gnzPFYVH6Tqdg==",
       "dev": true
+    },
+    "node_modules/JSONStream": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
+      "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
+      "dev": true,
+      "dependencies": {
+        "jsonparse": "^1.2.0",
+        "through": ">=2.2.7 <3"
+      },
+      "bin": {
+        "JSONStream": "bin.js"
+      },
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/jsprim": {
       "version": "1.4.2",
@@ -14333,6 +14333,14 @@
         "node": ">=10"
       }
     },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/string-argv": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.1.tgz",
@@ -14352,14 +14360,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/stringify-package": {

--- a/test/functional/commands/high-level-commands-test.js
+++ b/test/functional/commands/high-level-commands-test.js
@@ -52,6 +52,7 @@ parallel("high level commands test", () => {
     // new
     let args = ["new"];
     let inputs = [
+      {match: "? Choose a modeling stack for your skill"},
       {match: "? Choose the programming language you will use to code your skill"},
       {match: "? Choose a method to host your skill"},
       {match: "? Choose the default region for your skill"},
@@ -95,6 +96,7 @@ parallel("high level commands test", () => {
     // new
     let args = ["new"];
     const inputs = [
+      {match: "? Choose a modeling stack for your skill"},
       {match: "? Choose the programming language you will use to code your skill"},
       {match: "? Choose a method to host your skill", input: KeySymbol.DOWN},
       {match: "? Choose a template to start with"},
@@ -121,6 +123,7 @@ parallel("high level commands test", () => {
     // new
     let args = ["new"];
     const inputs = [
+      {match: "? Choose a modeling stack for your skill"},
       {match: "? Choose the programming language you will use to code your skill"},
       {match: "? Choose a method to host your skill", input: `${KeySymbol.DOWN}${KeySymbol.DOWN}`},
       {match: "? Choose a template to start with"},
@@ -147,6 +150,7 @@ parallel("high level commands test", () => {
     // new
     let args = ["new"];
     const inputs = [
+      {match: "? Choose a modeling stack for your skill"},
       {match: "? Choose the programming language you will use to code your skill"},
       {match: "? Choose a method to host your skill", input: `${KeySymbol.DOWN}${KeySymbol.DOWN}`},
       {match: "? Choose a template to start with", input: `${KeySymbol.DOWN}${KeySymbol.DOWN}${KeySymbol.DOWN}`},

--- a/test/integration/commands/smapi-commands-test.js
+++ b/test/integration/commands/smapi-commands-test.js
@@ -687,7 +687,6 @@ describe('smapi command test', () => {
   });
 
   it("| should get interaction model catalog update status", async () => {
-    console.log("here");
     const args = [subCmd, "get-interaction-model-catalog-update-status", "-c", catalogId, "--update-request-id", updateRequestId];
     addCoveredCommand(args);
     const result = await run(askCmd, args, options);
@@ -1508,12 +1507,8 @@ describe('smapi command test', () => {
   });
 
   after(() => {
-    console.log("killing smapi server mock");
     mockSmapiServer.kill();
-    console.log("killing lwa server mock");
     mockLwaServer.kill();
-    console.log("checking expects");
     expect(Array.from(untestedCommands), 'should not have untested commands').eql([]);
-    console.log("all done");
   });
 });

--- a/test/unit/commands/new/index-test.ts
+++ b/test/unit/commands/new/index-test.ts
@@ -54,7 +54,7 @@ describe("Commands new test - command class test", () => {
     expect(instance.name()).equal("new");
     expect(instance.description()).equal("create a new skill project from Alexa skill templates");
     expect(instance.requiredOptions()).deep.equal([]);
-    expect(instance.optionalOptions()).deep.equal(["templateUrl", "templateBranch", "profile", "debug", "ac"]);
+    expect(instance.optionalOptions()).deep.equal(["templateUrl", "templateBranch", "profile", "debug"]);
   });
 
   describe("validate command handle", () => {

--- a/test/unit/commands/new/template-helper-test.ts
+++ b/test/unit/commands/new/template-helper-test.ts
@@ -6,6 +6,8 @@ import {
   CODE_LANGUAGE_JAVA,
   CODE_LANGUAGE_NODEJS,
   CODE_LANGUAGE_PYTHON,
+  MODELING_STACK_AC,
+  MODELING_STACK_IM,
 } from "../../../../lib/commands/new";
 import {getSampleTemplatesFromS3, convertUserInputToFilterValue} from "../../../../lib/commands/new/template-helper";
 import {SampleTemplate} from "../../../../lib/model/sample-template";
@@ -121,6 +123,8 @@ describe("Commands new test - template helper test", () => {
 
   describe("convertUserInputToFilterValue", () => {
     it("should convert values to correct mapping", () => {
+      expect(convertUserInputToFilterValue(MODELING_STACK_IM)).to.equal("im");
+      expect(convertUserInputToFilterValue(MODELING_STACK_AC)).to.equal("ac");
       expect(convertUserInputToFilterValue(CODE_LANGUAGE_NODEJS)).to.equal("node");
       expect(convertUserInputToFilterValue(CODE_LANGUAGE_PYTHON)).to.equal("python");
       expect(convertUserInputToFilterValue(CODE_LANGUAGE_JAVA)).to.equal("java");
@@ -131,9 +135,9 @@ describe("Commands new test - template helper test", () => {
     });
 
     it("should be case insensitive", () => {
-      expect(convertUserInputToFilterValue(CODE_LANGUAGE_NODEJS)).to.equal("node");
-      expect(convertUserInputToFilterValue(CODE_LANGUAGE_NODEJS.toLowerCase())).to.equal("node");
-      expect(convertUserInputToFilterValue(CODE_LANGUAGE_NODEJS.toUpperCase())).to.equal("node");
+      expect(convertUserInputToFilterValue(MODELING_STACK_IM)).to.equal("im");
+      expect(convertUserInputToFilterValue(MODELING_STACK_IM.toLowerCase())).to.equal("im");
+      expect(convertUserInputToFilterValue(MODELING_STACK_IM.toUpperCase())).to.equal("im");
     });
 
     it("should fail fast and throw and error if not identified", (done) => {

--- a/test/unit/commands/new/ui-test.ts
+++ b/test/unit/commands/new/ui-test.ts
@@ -11,6 +11,7 @@ import {
   getTargetTemplateName,
   confirmUsingUnofficialTemplate,
   getDeploymentType,
+  getModelingStackType,
 } from "../../../../lib/commands/new/ui";
 import {SampleTemplate} from "../../../../lib/model/sample-template";
 import { CODE_LANGUAGE_JAVA, CODE_LANGUAGE_NODEJS, CODE_LANGUAGE_PYTHON } from "../../../../lib/commands/new";
@@ -423,6 +424,50 @@ describe("Commands new - UI test", () => {
           choices: TEST_DEPLOYMENT_CHOICES_WITH_SEP,
         });
         expect(inquirerPrompt.args[0][0][0].filter("a \n \n b")).equal("a ");
+        expect(err?.message).equal(TEST_ERROR);
+        expect(response).equal(undefined);
+        done();
+      });
+    });
+  });
+
+  describe("| getModelingStackType", () => {
+    let inquirerPrompt: SinonStub;
+
+    beforeEach(() => {
+      inquirerPrompt = sinon.stub(inquirer, "prompt");
+    });
+
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it("| getModelingStackType selected by user is retrieved correctly", (done) => {
+      // setup
+      inquirerPrompt.resolves({modelingStack: "Alexa Conversations"});
+      // call
+      getModelingStackType((err, response) => {
+        // verify
+        validateInquirerConfig(inquirerPrompt.args[0][0][0], {
+          message: "Choose a modeling stack for your skill: ",
+          type: "list",
+        });
+        expect(err).equal(null);
+        expect(response).equal("Alexa Conversations");
+        done();
+      });
+    });
+
+    it("| getModelingStackType inquirer throws exception", (done) => {
+      // setup
+      inquirerPrompt.rejects(new Error(TEST_ERROR));
+      // call
+      getModelingStackType((err, response) => {
+        // verify
+        validateInquirerConfig(inquirerPrompt.args[0][0][0], {
+          message: "Choose a modeling stack for your skill: ",
+          type: "list",
+        });
         expect(err?.message).equal(TEST_ERROR);
         expect(response).equal(undefined);
         done();

--- a/test/unit/commands/new/wizard-helper-test.ts
+++ b/test/unit/commands/new/wizard-helper-test.ts
@@ -7,6 +7,7 @@ import urlUtils from "../../../../lib/utils/url-utils";
 import * as wizardHelper from "../../../../lib/commands/new/wizard-helper";
 import Messenger from "../../../../lib/view/messenger";
 import {TEST_SAMPLE_1_IM_HOSTED_NODE, TEST_SAMPLE_2_AC_CFN_PYTHON} from "./template-helper-test";
+import { MODELING_STACK_IM } from "../../../../lib/commands/new";
 
 describe("Commands new test - wizard helper test", () => {
   const TEST_ERROR = "TEST_ERROR";
@@ -37,6 +38,7 @@ describe("Commands new test - wizard helper test", () => {
   let getSkillDefaultRegionStub: SinonStub;
   let getSkillLocaleStub: SinonStub;
   let getInstanceStub: SinonStub;
+  let getModelingStackTypeStub: SinonStub;
   let getSampleTemplatesFromS3Stub: SinonStub;
 
   beforeEach(() => {
@@ -61,6 +63,8 @@ describe("Commands new test - wizard helper test", () => {
     getSkillLocaleStub = sinon.stub(ui, "getSkillLocale");
     getSkillLocaleStub.yields(null, "en-US");
     getSkillLocaleStub.yields(null, "us-east-1");
+    getModelingStackTypeStub = sinon.stub(ui, "getModelingStackType");
+    getModelingStackTypeStub.callsArgWith(0, null, MODELING_STACK_IM);
     getSampleTemplatesFromS3Stub = sinon.stub(templateHelper, "getSampleTemplatesFromS3");
     getSampleTemplatesFromS3Stub.resolves(TEST_TEMPLATE_SAMPLES);
   });


### PR DESCRIPTION
*Issue #, if available:*

rolling back the --ac flag changes to the ask new temporarily to publish an important fix for ask new 

3 commits in this PR: 
* reverts the addition of --ac flag
* reverts the functional tests related to --ac flag
* minor change that removes some console.log entries in the integration tests that were added given the tests were failing and we needed to understand a bit why and where but these have been since fixed. therefore not needed anymore. 



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
