### PR TITLE
fix: Local Credential Hijacking fix

### DIFF
--- a/lib/controllers/authorization-controller/index.js
+++ b/lib/controllers/authorization-controller/index.js
@@ -11,6 +11,7 @@ const Messenger = require("../../view/messenger");
 const SpinnerView = require("../../view/spinner-view");
 
 const messages = require("./messages");
+const ui = require("./ui");
 
 module.exports = class AuthorizationController {
   /**
@@ -147,11 +148,29 @@ module.exports = class AuthorizationController {
       listenSpinner.terminate();
       const requestUrl = request.url;
       const requestQuery = url.parse(requestUrl, true).query;
-      server.destroy();
+
       if (requestUrl.startsWith("/cb?code")) {
         response.end(messages.ASK_SIGN_IN_SUCCESS_MESSAGE);
-        callback(null, requestQuery.code);
+        ui.confirmAllowSignIn((error, confirmSignInChoice) => {
+          // After confirmed or not browser sign in, closes the socket/port 
+          // with server.destroy().
+          // We need to keep the port open so a local hacker is not be able to 
+          // open that port until we get an answer in confirmAllowSignIn
+          server.destroy();
+
+          if (error) {
+            return callback(error);
+          }
+
+          if (!confirmSignInChoice) {
+            return callback(messages.STOP_UNCONFIRMED_BROWSER_SIGNIN);
+          }
+          
+          callback(null, requestQuery.code);
+        });
+        return;
       }
+      server.destroy();
       if (requestUrl.startsWith("/cb?error")) {
         response.statusCode = 403;
         const errorMessage = `Error: ${requestQuery.error}\nReason: ${requestQuery.error_description}`;

--- a/lib/controllers/authorization-controller/messages.js
+++ b/lib/controllers/authorization-controller/messages.js
@@ -56,3 +56,5 @@ module.exports.ASK_SIGN_IN_FAILURE_MESSAGE = (error) => `
 `;
 
 module.exports.ASK_ENV_VARIABLES_ERROR_MESSAGE = "Could not find either of the environment variables: ASK_ACCESS_TOKEN, ASK_REFRESH_TOKEN";
+
+module.exports.STOP_UNCONFIRMED_BROWSER_SIGNIN = "Stopping configuration due to unconfirmed browser sign in.";

--- a/lib/controllers/authorization-controller/questions.js
+++ b/lib/controllers/authorization-controller/questions.js
@@ -1,0 +1,10 @@
+module.exports = {
+  CONFIRM_ALLOW_BROWSER_SIGN_IN: [
+    {
+      message: "Do you confirm that you used the browser to sign in to Alexa Skills Kit Tools?",
+      type: "confirm",
+      name: "choice",
+      default: true,
+    },
+  ],
+};

--- a/lib/controllers/authorization-controller/ui.js
+++ b/lib/controllers/authorization-controller/ui.js
@@ -1,0 +1,16 @@
+const inquirer = require("inquirer");
+const questions = require("./questions");
+
+module.exports = {
+  confirmAllowSignIn,
+};
+export function confirmAllowSignIn(callback) {
+  inquirer
+    .prompt(questions.CONFIRM_ALLOW_BROWSER_SIGN_IN)
+    .then((answer) => {
+      callback(null, answer.choice);
+    })
+    .catch((error) => {
+      callback(error);
+    });
+}


### PR DESCRIPTION
Added a confirmation the browser has been used to sign in to alexa before closing the port.

DX for no:
```
% ask configure
This command will configure the ASK CLI with a profile associated with your Amazon developer credentials.
------------------------- Step 1 of 2 : ASK CLI Configuration -------------------------
? Please create a new profile or overwrite the existing profile.
 [x]                       ** NULL **
[Warn]: ASK CLI uses authorization code to fetch LWA tokens. Do not share neither your authorization code nor access tokens.
Switch to "Login with Amazon" page and sign-in with your Amazon developer credentials.
If your browser did not open the page, try to run the command again with "--no-browser" option.

? Do you confirm using the browser to sign in to Alexa Skills Kit Tools? No
[Error]: Stopping configuration with unconfirmed browser sign in.
``` 

DX for yes:
```
 % ask configure
This command will configure the ASK CLI with a profile associated with your Amazon developer credentials.
------------------------- Step 1 of 2 : ASK CLI Configuration -------------------------
? Please create a new profile or overwrite the existing profile.
 [x]                       ** NULL **
[Warn]: ASK CLI uses authorization code to fetch LWA tokens. Do not share neither your authorization code nor access tokens.
Switch to "Login with Amazon" page and sign-in with your Amazon developer credentials.
If your browser did not open the page, try to run the command again with "--no-browser" option.

? Do you confirm using the browser to sign in to Alexa Skills Kit Tools? Yes
ASK Profile "x" was successfully created. The details are recorded in ask-cli config file (.ask/cli_config) located at your **HOME** folder.
Vendor ID set as M1UCNFO4KV3AAA.

------------------------- Step 2 of 2 : Associate an AWS Profile with ASK CLI -------------------------
...
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
