### PR TITLE
fix: prevent errors to be displayed as [Error]: [object Object]

### DIFF
--- a/lib/view/json-view.js
+++ b/lib/view/json-view.js
@@ -11,6 +11,9 @@ module.exports = {
  */
 function toString(jsonObject) {
   try {
+    if (typeof jsonObject === 'string') {
+      return jsonObject;
+    }
     // handle issue when Error object serialized to {}
     if (jsonObject instanceof Error) {
       jsonObject = {message: jsonObject.message, stack: jsonObject.stack, detail: jsonObject};

--- a/lib/view/messenger.js
+++ b/lib/view/messenger.js
@@ -1,6 +1,7 @@
 const chalk = require("chalk");
 const path = require("path");
 const fs = require("fs");
+const jsonViewer = require("./json-view");
 
 // A map used to define message levels
 // and set their display styles
@@ -167,8 +168,7 @@ class Messenger {
    * @param {*} data the message to display
    */
   error(data) {
-    const msg = data.constructor.name === "Error" ? data.message : data;
-
+    const msg = data.constructor.name === "Error" ? data.message : jsonViewer.toString(data);
     const operation = "ERROR";
     this.buffer({
       time: Messenger.getTime(),

--- a/test/unit/view/messenger-test.js
+++ b/test/unit/view/messenger-test.js
@@ -4,9 +4,16 @@ const chalk = require("chalk");
 const fs = require("fs");
 const path = require("path");
 const Messenger = require("../../../lib/view/messenger");
+const jsonView = require("../../../lib/view/json-view");
 
 describe("View test - messenger file test", () => {
   const TEST_MESSAGE = "TEST_MESSAGE";
+  const TEST_STACK = "TEST_STACK";
+  const TEST_ERROR_WITH_STACK = {
+    message: TEST_MESSAGE,
+    stack: TEST_STACK,
+    foo: 2,
+  }
   const TEST_TIME = "TEST_TIME";
   const TEST_ERROR_OBJ = new Error("TEST_ERROR");
 
@@ -145,6 +152,24 @@ describe("View test - messenger file test", () => {
       // verify
       expect(Messenger.getInstance()._buffer[0]).deep.equal(expectedItem);
       expect(stub.args[0][0]).equal(chalk`{bold.red [Error]: ${TEST_MESSAGE}}`);
+    });
+
+    it("| error function correctly push error objects to buffer and display", () => {
+      const stub = sinon.stub(console, "error");
+      const expectedError = jsonView.toString(TEST_ERROR_WITH_STACK);
+      const expectedItem = {
+        time: TEST_TIME,
+        operation: "ERROR",
+        level: 50,
+        msg: expectedError,
+      };
+
+      // call
+      Messenger.getInstance().error(TEST_ERROR_WITH_STACK);
+
+      // verify
+      expect(Messenger.getInstance()._buffer[0]).deep.equal(expectedItem);
+      expect(stub.args[0][0]).equal(chalk`{bold.red [Error]: ${expectedError}}`);
     });
 
     it("| fatal function correctly push message to buffer and display", () => {


### PR DESCRIPTION
some reports of failures deploying were displaying error outputs on the terminal as 
```
[Error]: [object Object]
```

this PR resolves this issue by updating the Messenger class directly to call jsonview.toString() which internally calls JSON.stringify on the object.  Confirmed that it now prints the error but it's also unfortunately stringified.  However now we can see the error messages and stack. 

```
[Error]: "{\n  \"message\": \"TEST_MESSAGE\",\n  \"stack\": \"TEST_STACK\"}"
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
