### PR TITLE
chore(release): 2.30.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [2.30.2](https://github.com/alexa/ask-cli/compare/v2.30.1...v2.30.2) (2023-06-22)
+
+
+### Bug Fixes
+
+* prevent errors to be displayed as [Error]: [object Object] ([767e104](https://github.com/alexa/ask-cli/commit/767e10481fb7230c6748f784c6d5e6a483508950))
+
 ## [2.30.0](https://github.com/alexa/ask-cli/compare/v2.29.1...v2.30.0) (2023-05-22)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ask-cli",
-  "version": "2.30.0",
+  "version": "2.30.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ask-cli",
-      "version": "2.30.0",
+      "version": "2.30.2",
       "hasInstallScript": true,
       "license": "Apache 2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ask-cli",
-  "version": "2.30.1",
+  "version": "2.30.2",
   "description": "Alexa Skills Kit (ASK) Command Line Interfaces",
   "bin": {
     "ask": "dist/bin/ask.js"


### PR DESCRIPTION
bump version to 2.30.2 to release the bug fix where the errors were printed as [object, object].



full delta between the latest release: https://github.com/alexa/ask-cli/compare/v2.30.1...release_2-30-2



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
