### PR TITLE
fix: display warning object message correctly

### DIFF
--- a/lib/view/messenger.js
+++ b/lib/view/messenger.js
@@ -152,14 +152,15 @@ class Messenger {
    * @param {*} data the message to display
    */
   warn(data) {
+    const msg = data.constructor.name === "Error" ? data.message : jsonViewer.toString(data);
     const operation = "WARN";
     this.buffer({
       time: Messenger.getTime(),
       operation,
       level: MESSAGE_CATEGORY_MAPPING[operation].level,
-      msg: data,
+      msg,
     });
-    this.displayMessage(operation, data);
+    this.displayMessage(operation, msg);
   }
 
   /**
@@ -186,7 +187,6 @@ class Messenger {
    */
   fatal(data) {
     const msg = data.constructor.name === "Error" ? data.stack.substring(7) : data;
-
     const operation = "FATAL";
     this.buffer({
       time: Messenger.getTime(),

--- a/test/unit/view/messenger-test.js
+++ b/test/unit/view/messenger-test.js
@@ -137,6 +137,42 @@ describe("View test - messenger file test", () => {
       expect(stub.args[0][0]).equal(chalk`{bold.yellow [Warn]: ${TEST_MESSAGE}}`);
     });
 
+    it("| warn function correctly push error objects to buffer and display", () => {
+      const stub = sinon.stub(console, "warn");
+      const expectedMessage = jsonView.toString(TEST_ERROR_WITH_STACK);
+      const expectedItem = {
+        time: TEST_TIME,
+        operation: "WARN",
+        level: 40,
+        msg: expectedMessage,
+      };
+
+      // call
+      Messenger.getInstance().warn(TEST_ERROR_WITH_STACK);
+
+      // verify
+      expect(Messenger.getInstance()._buffer[0]).deep.equal(expectedItem);
+      expect(stub.args[0][0]).equal(chalk`{bold.yellow [Warn]: ${expectedMessage}}`);
+    });
+
+    it("| warn function correctly push error message to buffer and display", () => {
+      const stub = sinon.stub(console, "warn");
+      const expectedMessage = TEST_ERROR_OBJ.message;
+      const expectedItem = {
+        time: TEST_TIME,
+        operation: "WARN",
+        level: 40,
+        msg: expectedMessage,
+      };
+
+      // call
+      Messenger.getInstance().warn(TEST_ERROR_OBJ);
+
+      // verify
+      expect(Messenger.getInstance()._buffer[0]).deep.equal(expectedItem);
+      expect(stub.args[0][0]).equal(chalk`{bold.yellow [Warn]: ${expectedMessage}}`);
+    });
+
     it("| error function correctly push message to buffer and display", () => {
       const stub = sinon.stub(console, "error");
       const expectedItem = {
@@ -156,12 +192,12 @@ describe("View test - messenger file test", () => {
 
     it("| error function correctly push error objects to buffer and display", () => {
       const stub = sinon.stub(console, "error");
-      const expectedError = jsonView.toString(TEST_ERROR_WITH_STACK);
+      const expectedMessage = jsonView.toString(TEST_ERROR_WITH_STACK);
       const expectedItem = {
         time: TEST_TIME,
         operation: "ERROR",
         level: 50,
-        msg: expectedError,
+        msg: expectedMessage,
       };
 
       // call
@@ -169,7 +205,25 @@ describe("View test - messenger file test", () => {
 
       // verify
       expect(Messenger.getInstance()._buffer[0]).deep.equal(expectedItem);
-      expect(stub.args[0][0]).equal(chalk`{bold.red [Error]: ${expectedError}}`);
+      expect(stub.args[0][0]).equal(chalk`{bold.red [Error]: ${expectedMessage}}`);
+    });
+
+    it("| error function correctly push error message to buffer and display", () => {
+      const stub = sinon.stub(console, "error");
+      const expectedMessage = TEST_ERROR_OBJ.message;
+      const expectedItem = {
+        time: TEST_TIME,
+        operation: "ERROR",
+        level: 50,
+        msg: expectedMessage,
+      };
+
+      // call
+      Messenger.getInstance().error(TEST_ERROR_OBJ);
+
+      // verify
+      expect(Messenger.getInstance()._buffer[0]).deep.equal(expectedItem);
+      expect(stub.args[0][0]).equal(chalk`{bold.red [Error]: ${expectedMessage}}`);
     });
 
     it("| fatal function correctly push message to buffer and display", () => {
@@ -191,11 +245,12 @@ describe("View test - messenger file test", () => {
 
     it("| fatal function correctly push error stack to buffer and display", () => {
       const stub = sinon.stub(console, "error");
+      const expectedMessage = TEST_ERROR_OBJ.stack.substring(7);
       const expectedItem = {
         time: TEST_TIME,
         operation: "FATAL",
         level: 60,
-        msg: TEST_ERROR_OBJ.stack.substring(7),
+        msg: expectedMessage,
       };
 
       // call
@@ -203,7 +258,7 @@ describe("View test - messenger file test", () => {
 
       // verify
       expect(Messenger.getInstance()._buffer[0]).deep.equal(expectedItem);
-      expect(stub.args[0][0]).equal(chalk`{bold.rgb(128, 0, 0) [Fatal]: ${TEST_ERROR_OBJ.stack.substring(7)}}`);
+      expect(stub.args[0][0]).equal(chalk`{bold.rgb(128, 0, 0) [Fatal]: ${expectedMessage}}`);
     });
 
     it("| trace function correctly push message to buffer and write to file with complete message", () => {
@@ -229,7 +284,7 @@ describe("View test - messenger file test", () => {
           statusMessage: TEST_STATUS_MESSAGE,
           headers: TEST_HEADERS,
         },
-        error: "TEST_ERROR",
+        error: TEST_ERROR,
         "request-id": TEST_REQUEST_ID,
         body: TEST_BODY,
       };


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Similar to #478, some of the warning messages can be objects, such as the SMAPI import status warnings.

This change applies the same fix to the warning channel.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
