### PR TITLE
fix: display message property for all error instance types

### DIFF
--- a/lib/controllers/skill-metadata-controller/index.js
+++ b/lib/controllers/skill-metadata-controller/index.js
@@ -463,7 +463,7 @@ module.exports = class SkillMetadataController {
 
         if (shouldPrintWarning && importStatusResponse.warnings.length > 0) {
           importStatusResponse.warnings.forEach((warning) => {
-            Messenger.getInstance().warn(warning);
+            Messenger.getInstance().warn(warning.message);
           });
           shouldPrintWarning = false;
         }

--- a/lib/view/messenger.js
+++ b/lib/view/messenger.js
@@ -152,7 +152,7 @@ class Messenger {
    * @param {*} data the message to display
    */
   warn(data) {
-    const msg = data.constructor.name === "Error" ? data.message : jsonViewer.toString(data);
+    const msg = data instanceof Error ? data.message : jsonViewer.toString(data);
     const operation = "WARN";
     this.buffer({
       time: Messenger.getTime(),
@@ -169,7 +169,7 @@ class Messenger {
    * @param {*} data the message to display
    */
   error(data) {
-    const msg = data.constructor.name === "Error" ? data.message : jsonViewer.toString(data);
+    const msg = data instanceof Error ? data.message : jsonViewer.toString(data);
     const operation = "ERROR";
     this.buffer({
       time: Messenger.getTime(),
@@ -186,7 +186,7 @@ class Messenger {
    * @param {*} data the message to display
    */
   fatal(data) {
-    const msg = data.constructor.name === "Error" ? data.stack.substring(7) : data;
+    const msg = data instanceof Error ? data.stack.substring(7) : data;
     const operation = "FATAL";
     this.buffer({
       time: Messenger.getTime(),

--- a/test/unit/view/messenger-test.js
+++ b/test/unit/view/messenger-test.js
@@ -8,14 +8,9 @@ const jsonView = require("../../../lib/view/json-view");
 
 describe("View test - messenger file test", () => {
   const TEST_MESSAGE = "TEST_MESSAGE";
-  const TEST_STACK = "TEST_STACK";
-  const TEST_ERROR_WITH_STACK = {
-    message: TEST_MESSAGE,
-    stack: TEST_STACK,
-    foo: 2,
-  }
+  const TEST_OBJECT = { foo: 1, bar: 2 };
+  const TEST_ERROR = new Error("TEST_ERROR");
   const TEST_TIME = "TEST_TIME";
-  const TEST_ERROR_OBJ = new Error("TEST_ERROR");
 
   describe("# inspect correctness for constructor, getInstance and dispose", () => {
     beforeEach(() => {
@@ -137,9 +132,9 @@ describe("View test - messenger file test", () => {
       expect(stub.args[0][0]).equal(chalk`{bold.yellow [Warn]: ${TEST_MESSAGE}}`);
     });
 
-    it("| warn function correctly push error objects to buffer and display", () => {
+    it("| warn function correctly push stringify object to buffer and display", () => {
       const stub = sinon.stub(console, "warn");
-      const expectedMessage = jsonView.toString(TEST_ERROR_WITH_STACK);
+      const expectedMessage = jsonView.toString(TEST_OBJECT);
       const expectedItem = {
         time: TEST_TIME,
         operation: "WARN",
@@ -148,7 +143,7 @@ describe("View test - messenger file test", () => {
       };
 
       // call
-      Messenger.getInstance().warn(TEST_ERROR_WITH_STACK);
+      Messenger.getInstance().warn(TEST_OBJECT);
 
       // verify
       expect(Messenger.getInstance()._buffer[0]).deep.equal(expectedItem);
@@ -157,7 +152,7 @@ describe("View test - messenger file test", () => {
 
     it("| warn function correctly push error message to buffer and display", () => {
       const stub = sinon.stub(console, "warn");
-      const expectedMessage = TEST_ERROR_OBJ.message;
+      const expectedMessage = TEST_ERROR.message;
       const expectedItem = {
         time: TEST_TIME,
         operation: "WARN",
@@ -166,7 +161,7 @@ describe("View test - messenger file test", () => {
       };
 
       // call
-      Messenger.getInstance().warn(TEST_ERROR_OBJ);
+      Messenger.getInstance().warn(TEST_ERROR);
 
       // verify
       expect(Messenger.getInstance()._buffer[0]).deep.equal(expectedItem);
@@ -190,9 +185,9 @@ describe("View test - messenger file test", () => {
       expect(stub.args[0][0]).equal(chalk`{bold.red [Error]: ${TEST_MESSAGE}}`);
     });
 
-    it("| error function correctly push error objects to buffer and display", () => {
+    it("| error function correctly push stringify object to buffer and display", () => {
       const stub = sinon.stub(console, "error");
-      const expectedMessage = jsonView.toString(TEST_ERROR_WITH_STACK);
+      const expectedMessage = jsonView.toString(TEST_OBJECT);
       const expectedItem = {
         time: TEST_TIME,
         operation: "ERROR",
@@ -201,7 +196,7 @@ describe("View test - messenger file test", () => {
       };
 
       // call
-      Messenger.getInstance().error(TEST_ERROR_WITH_STACK);
+      Messenger.getInstance().error(TEST_OBJECT);
 
       // verify
       expect(Messenger.getInstance()._buffer[0]).deep.equal(expectedItem);
@@ -210,7 +205,7 @@ describe("View test - messenger file test", () => {
 
     it("| error function correctly push error message to buffer and display", () => {
       const stub = sinon.stub(console, "error");
-      const expectedMessage = TEST_ERROR_OBJ.message;
+      const expectedMessage = TEST_ERROR.message;
       const expectedItem = {
         time: TEST_TIME,
         operation: "ERROR",
@@ -219,7 +214,7 @@ describe("View test - messenger file test", () => {
       };
 
       // call
-      Messenger.getInstance().error(TEST_ERROR_OBJ);
+      Messenger.getInstance().error(TEST_ERROR);
 
       // verify
       expect(Messenger.getInstance()._buffer[0]).deep.equal(expectedItem);
@@ -245,7 +240,7 @@ describe("View test - messenger file test", () => {
 
     it("| fatal function correctly push error stack to buffer and display", () => {
       const stub = sinon.stub(console, "error");
-      const expectedMessage = TEST_ERROR_OBJ.stack.substring(7);
+      const expectedMessage = TEST_ERROR.stack.substring(7);
       const expectedItem = {
         time: TEST_TIME,
         operation: "FATAL",
@@ -254,7 +249,7 @@ describe("View test - messenger file test", () => {
       };
 
       // call
-      Messenger.getInstance().fatal(TEST_ERROR_OBJ);
+      Messenger.getInstance().fatal(TEST_ERROR);
 
       // verify
       expect(Messenger.getInstance()._buffer[0]).deep.equal(expectedItem);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Related to #488, I should have included this change as well.

Non-standard `Error` objects, such as `CliWarn` and `CliError`, are being display as stringified object instead of their message property.

```
[Warn]: {
  "message": "Skill api domain \"smartHome\" cannot be enabled. Skipping the enable process.\n",
  "stack": "CliWarn: Skill api domain \"smartHome\" cannot be enabled. Skipping the enable process.\n\n    at SkillMetadataController.validateDomain (/opt/hostedtoolcache/node/18.17.0/x64/lib/node_modules/ask-cli/dist/lib/controllers/skill-metadata-controller/index.js:106:19)\n    at Object.enableSkill (/opt/hostedtoolcache/node/18.17.0/x64/lib/node_modules/ask-cli/dist/lib/commands/deploy/helper.js:[101](https://github.com/openhab/openhab-alexa/actions/runs/5800707395/job/15759328693#step:6:102):29)\n    at /opt/hostedtoolcache/node/18.17.0/x64/lib/node_modules/ask-cli/dist/lib/commands/deploy/index.js:93:38\n    at processTicksAndRejections (node:internal/process/task_queues:95:5)",
  "detail": {
    "name": "CliWarn"
  }
}
```

Likewise, SMAPI import status warnings seem to only include a message property. It makes sense to only display that property in that case.

```
[Warn]: {
  "message": "No interaction model definitions found in the import package for following locales declared in 'publishingInformation' of skill manifest: [\"ar-SA\",\"de-DE\",\"en-US\",\"en-CA\",\"pt-BR\",\"en-IN\",\"es-ES\",\"es-MX\",\"fr-CA\",\"it-IT\",\"hi-IN\",\"en-AU\",\"es-US\",\"fr-FR\",\"en-GB\",\"ja-JP\"]. These locales will not have voice interfaces after successful import."
}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
