### PR TITLE
Askstate updates

### DIFF
--- a/.github/auto-assign-config.yml
+++ b/.github/auto-assign-config.yml
@@ -3,6 +3,5 @@ addReviewers: true
 addAssignees: author
 
 reviewers:
-  - doiron
   - tydonelson
-  - LucioMS
+  - CamdenFoucht

--- a/docs/concepts/Alexa-Hosted-Skill-Commands.md
+++ b/docs/concepts/Alexa-Hosted-Skill-Commands.md
@@ -14,32 +14,27 @@ Using `ask new`, the Alexa hosted skill service will create a new AWS account, w
 
 **debug**: Optional. Show debug messages.
 
-
-
-## WORKFLOW:
+## WORKFLOW
 
 Users will be asked the following questions to create a new skill:
 
 * Prompts user for `programming language`
-	* Select programming language
-	* AHS supports Python3.7 and Node12.x
+  * Select programming language
+    * AHS supports Python3.7 and Node12.x
 * Prompts user for a method to host your skill's backend resources
-	* Select `Alexa-hosted skills`
+  * Select `Alexa-hosted skills`
 * Prompts user for `skill name`
- 	 * Leave empty to use the default skill name  `Hello World Skill`
+  * Leave empty to use the default skill name  `hosted hello world`
 * Prompts user for a `folder name` for the skill project
- 	 * Leave empty to use the default folder name  `HelloWorldSkill`
+  * Leave empty to use the default folder name  `HelloWorldSkill`
 
 The user is not prompted for a `skill template`. The [Hello World Skill](https://github.com/alexa/skill-sample-nodejs-hello-world) is the only option for now.
-
-
 
 # DOWNLOAD SKILL - INIT COMMAND
 
 `ask init --hosted-skill-id <hosted-skill-id>` -- download an existing Alexa-Hosted Skill to their local environment.
 
 This command initializes Alexa Hosted Skills by cloning the project from the hosted skill service, downloading the latest Alexa skill package, and provide a git-ready environment. Developers can then checkout, pull from, and push to a remote Git repository from their local machines.
-
 
 **STRUCTURE OF INIT COMMAND:**
 
@@ -53,15 +48,11 @@ This command initializes Alexa Hosted Skills by cloning the project from the hos
 
 **debug**: Optional. Show debug messages.
 
-
-
 ## GIT CREDENTIALS
 
 To access the CodeCommit repository, the Alexa hosted service uses git-credential along with ASK-CLI and SMAPI to automatically pass down temporary Git credentials.
 
 Using `ask util git-credentials-helper` in the skill root directory can retrieve the username and password of the Git credentials.
-
-
 
 # UPGRADE PROJECT - UPGRADE COMMANDS
 
@@ -78,22 +69,21 @@ Skills created with CLI 1.x will need to update their project structure in order
 
 **debug**: Optional. Show debug messages.
 
+## UPGRADE STEPS
 
-## UPGRADE STEPS:
 1. Using ask-cli 1.x, deploy your skill:
-	* `$ ask deploy`
+  * `$ ask deploy`
 2. Install ask-cli:
-	* `$ npm install -g ask-cli`
+  * `$ npm install -g ask-cli`
 3. Upgrade your skill project with ask-cli. From your project's root directory, run:
-	* `$ ask util upgrade-project`
+  * `$ ask util upgrade-project`
     * A hidden folder named ./legacy contains a copy of your v1 skill project.
     * The CLI v2 skill-package directory is downloaded to the working directory.
     * The CLI v2 ask-resources.json will be generated.
     * The dev branch is merged into the master branch. The dev branch is then removed.
 4. Commit upgrade changes:
-  * `$ git commit -m "upgrade project for CLI v2"`
 
-
+* `$ git commit -m "upgrade project for CLI v2"`
 
 # DEPLOY SKILL - GIT PUSH
 
@@ -101,25 +91,25 @@ Skills created with CLI 1.x will need to update their project structure in order
 Unlike in CLI v1, running `ask deploy` on hosted skills will no longer trigger skill deployment in CLI v2.
 Instead, `$ git push` sends the latest source code to Lambda.  It also deploys skill-package changes such as the interaction model, skill manifest and in-skill products.
 
-## DEPLOYMENT STEPS:
+## DEPLOYMENT STEPS
+
 * Push to deploy skill code and resources:
-	* `$ git push`
+  * `$ git push`
   * Pushing to `master` branch deploys "lambda" folder to user's `development` stage AWS Lambda function, and deploys "skill-package" folder as skill's JSON files
   * Pushing to `prod` branch deploys "lambda" folder to user's `live` stage AWS Lambda function, and deploys "skill-package" folder as skill's JSON files
-
 
 Note: dev branch is only used to be displayed in the web console. You only need to push to dev branch if you want to sync version that is displayed in the web console.
 
 When you receive the following warning: "The master branch of your skill is ahead of the dev version. To re-enable the code editor, you need to use the ASK CLI to merge the remote master branch to dev and push.", you need to use following steps to sync your master branch back to dev:
 
-```
+```shell
 git checkout dev
 git pull --rebase
 git merge master
 # fix any merge conflicts if you have
 git push --no-verify
 ```
-  
+
 ## DEVELOPMENT CONSOLE, BRANCHES AND STAGES
 
 * dev branch corresponds to the code you see in the web console editor.
@@ -129,5 +119,3 @@ git push --no-verify
 ## Git Pre-push Hook
 
 CLI v2 supports Alexa Hosted skill, a git-native service, to track deployment states using the pre-push hook. When $ git push executes, the pre-push hook prints the skill portal URL to allow users to track deployment states.
-
-

--- a/lib/commands/deploy/index.ts
+++ b/lib/commands/deploy/index.ts
@@ -38,6 +38,8 @@ export default class DeployCommand extends AbstractCommand {
     try {
       profile = profileHelper.runtimeProfile(cmd.profile);
       new ResourcesConfig(path.join(process.cwd(), CONSTANTS.FILE_PATH.ASK_RESOURCES_JSON_CONFIG));
+      ResourcesConfig.getInstance().setDeploymentStatus(profile, "IN_PROGRESS");
+      ResourcesConfig.getInstance().write();
       Messenger.getInstance().info(`Deploy configuration loaded from ${CONSTANTS.FILE_PATH.ASK_RESOURCES_JSON_CONFIG}`);
       helper.confirmProfile(profile);
       this._filterAlexaHostedSkill(profile);
@@ -80,7 +82,7 @@ export default class DeployCommand extends AbstractCommand {
 
             // Save the deployment type to ask states
             ResourcesConfig.getInstance().setSkillMetaLastDeployType(profile, deploymentType);
-
+            ResourcesConfig.getInstance().setDeploymentStatus(profile, "COMPLETE");
             // Write updates back to resources file
             ResourcesConfig.getInstance().write();
             Manifest.getInstance().write();
@@ -105,6 +107,9 @@ export default class DeployCommand extends AbstractCommand {
             });
           })
           .catch((err) => {
+            ResourcesConfig.getInstance().setDeploymentStatus(profile, "COMPLETE");
+            // Write updates back to resources file
+            ResourcesConfig.getInstance().write();
             Messenger.getInstance().error(err);
             return reject(err);
           });

--- a/lib/controllers/skill-infrastructure-controller/index.js
+++ b/lib/controllers/skill-infrastructure-controller/index.js
@@ -148,7 +148,7 @@ module.exports = class SkillInfrastructureController {
       if (error) {
         // update partial successful deploy results to resources config
         if (result && !R.isEmpty(R.keys(result))) {
-          this._updateResourcesConfig(regionsList, result);
+          this._updateResourcesConfig(regionsList, result, error);
         }
         return callback(error);
       }
@@ -296,7 +296,7 @@ module.exports = class SkillInfrastructureController {
    *
    * @param {Object} rawDeployResult deploy result from invoke: { $region: deploy-delegate's response }
    */
-  _updateResourcesConfig(regionsList, rawDeployResult) {
+  _updateResourcesConfig(regionsList, rawDeployResult, error) {
     const curDeployState = ResourcesConfig.getInstance().getSkillInfraDeployState(this.profile) || {};
     const newDeployState = {};
     regionsList.forEach((alexaRegion) => {
@@ -307,6 +307,9 @@ module.exports = class SkillInfrastructureController {
       }
     });
     ResourcesConfig.getInstance().setSkillInfraDeployState(this.profile, newDeployState);
+    if (!error) {
+      ResourcesConfig.getInstance().setCodeLastDeployTimestamp(this.profile, `${(new Date()).toISOString()}`);
+    }
     ResourcesConfig.getInstance().write();
   }
 

--- a/lib/controllers/skill-metadata-controller/index.js
+++ b/lib/controllers/skill-metadata-controller/index.js
@@ -188,6 +188,9 @@ module.exports = class SkillMetadataController {
         const importId = path.basename(importResponse.headers.location);
         if (importId) {
           this.getImportStatusPollView().displayImportId(importId);
+          ResourcesConfig.getInstance().setLastImportId(this.profile, importId);
+          ResourcesConfig.getInstance().setLastImportTimestamp(this.profile, `${(new Date()).toISOString()}`);
+          ResourcesConfig.getInstance().write();
         }
         // 3.poll for the skill package import status
         this._pollImportStatus(importId, (pollErr, pollResponse) => {

--- a/lib/model/resources-config/ask-states.js
+++ b/lib/model/resources-config/ask-states.js
@@ -52,6 +52,30 @@ module.exports = class AskStates extends ConfigFile {
     this.setProperty(["profiles", profile, "skillId"], skillId);
   }
 
+  getDeploymentStatus(profile) {
+    return this.getProperty(["profiles", profile, "deploymentStatus"]);
+  }
+
+  setDeploymentStatus(profile, status) {
+    this.setProperty(["profiles", profile, "deploymentStatus"], status);
+  }
+
+  getLastImportId(profile) {
+    return this.getProperty(["profiles", profile, "skillMetadata", "lastImportId"]);
+  }
+
+  setLastImportId(profile, lastImportId) {
+    this.setProperty(["profiles", profile, "skillMetadata", "lastImportId"], lastImportId);
+  }
+
+  getLastImportTimestamp(profile) {
+    return this.getProperty(["profiles", profile, "skillMetadata", "lastImportTimestamp"]);
+  }
+
+  setLastImportTimestamp(profile, dateTimeStamp) {
+    this.setProperty(["profiles", profile, "skillMetadata", "lastImportTimestamp"], dateTimeStamp);
+  }
+
   // Group for the "skillMetadata"
   getSkillMetaLastDeployHash(profile) {
     return this.getProperty(["profiles", profile, "skillMetadata", "lastDeployHash"]);
@@ -90,6 +114,14 @@ module.exports = class AskStates extends ConfigFile {
 
   setCodeLastDeployHashByRegion(profile, region, hash) {
     this.setProperty(["profiles", profile, "code", region, "lastDeployHash"], hash);
+  }
+
+  getCodeLastDeployTimestamp(profile) {
+    return this.getProperty(["profiles", profile, "code", "lastDeployTimestamp"]);
+  }
+
+  setCodeLastDeployTimestamp(profile, dateTimestamp) {
+    this.setProperty(["profiles", profile, "code", "lastDeployTimestamp"], dateTimestamp);
   }
 
   getCodeBuildByRegion(projRoot, codeSrc) {

--- a/lib/model/resources-config/index.js
+++ b/lib/model/resources-config/index.js
@@ -68,6 +68,30 @@ module.exports = class ResourcesConfig {
     AskStates.getInstance().setSkillId(profile, skillId);
   }
 
+  getDeploymentStatus(profile) {
+    return AskStates.getInstance().getDeploymentStatus(profile);
+  }
+
+  setDeploymentStatus(profile, status) {
+    AskStates.getInstance().setDeploymentStatus(profile, status);
+  }
+
+  getLastImportId(profile) {
+    return AskStates.getInstance().getLastImportId(profile);
+  }
+
+  setLastImportId(profile, importId) {
+    AskStates.getInstance().setLastImportId(profile, importId);
+  }
+
+  getLastImportTimestamp(profile) {
+    return AskStates.getInstance().getLastImportTimestamp(profile);
+  }
+
+  setLastImportTimestamp(profile, dateTimestamp) {
+    AskStates.getInstance().setLastImportTimestamp(profile, dateTimestamp);
+  }
+
   // Group for the "skillMetadata"
   getSkillMetaSrc(profile) {
     return AskResources.getInstance().getSkillMetaSrc(profile);
@@ -121,6 +145,14 @@ module.exports = class ResourcesConfig {
 
   setCodeLastDeployHashByRegion(profile, region, hash) {
     AskStates.getInstance().setCodeLastDeployHashByRegion(profile, region, hash);
+  }
+
+  getCodeLastDeployTimestamp(profile) {
+    return AskStates.getInstance().getCodeLastDeployTimestamp(profile);
+  }
+
+  setCodeLastDeployTimestamp(profile, dateTimestamp) {
+    AskStates.getInstance().setCodeLastDeployTimestamp(profile, dateTimestamp);
   }
 
   getCodeRegions(profile) {

--- a/lib/model/sample-template.ts
+++ b/lib/model/sample-template.ts
@@ -18,7 +18,7 @@ export type SampleTemplateFilterValues = IM | AC | ALEXA_HOSTED | CLOUDFORMATION
  *     "stack": "ac",
  *     "deploy": "lambda",
  *     "lang": "node",
- *     "name": "Hello world",
+ *     "name": "hello world",
  *     "url": "https://github.com/alexa/skill-sample-nodejs-hello-world.git",
  *     "desc": "Alexa's hello world skill to send the greetings to the world!"
  * }

--- a/lib/utils/constants.js
+++ b/lib/utils/constants.js
@@ -37,7 +37,7 @@ module.exports.DEPLOY_TARGET = {
 };
 
 module.exports.HOSTED_SKILL = {
-  DEFAULT_SKILL_NAME: "Hello World Skill",
+  DEFAULT_SKILL_NAME: "hosted hello world",
   DEFAULT_LOCALE: "en-US",
   LOCALES: [
     "de-DE",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3954,22 +3954,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/JSONStream": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
-      "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
-      "dev": true,
-      "dependencies": {
-        "jsonparse": "^1.2.0",
-        "through": ">=2.2.7 <3"
-      },
-      "bin": {
-        "JSONStream": "bin.js"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -5977,8 +5961,8 @@
       "integrity": "sha512-nK7sAtfi+QXbxHCYfhpZsfRtaitZLIA6889kFIouLvz6repszQDgxBu7wf2WbU+Dco7sAnNCJYERCwt54WPC2Q==",
       "dev": true,
       "dependencies": {
-        "JSONStream": "^1.0.4",
         "is-text-path": "^1.0.1",
+        "JSONStream": "^1.0.4",
         "lodash": "^4.17.15",
         "meow": "^8.0.0",
         "split2": "^3.0.0",
@@ -9131,6 +9115,22 @@
       "resolved": "https://registry.npmjs.org/jsonpointer.js/-/jsonpointer.js-0.4.0.tgz",
       "integrity": "sha512-2bf/1crAmPpsmj1I6rDT6W0SOErkrNBpb555xNWcMVWYrX6VnXpG0GRMQ2shvOHwafpfse8q0gnzPFYVH6Tqdg==",
       "dev": true
+    },
+    "node_modules/JSONStream": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
+      "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
+      "dev": true,
+      "dependencies": {
+        "jsonparse": "^1.2.0",
+        "through": ">=2.2.7 <3"
+      },
+      "bin": {
+        "JSONStream": "bin.js"
+      },
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/just-extend": {
       "version": "4.2.1",
@@ -14426,6 +14426,14 @@
         "node": ">=10"
       }
     },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/string-argv": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
@@ -14477,14 +14485,6 @@
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/stringify-package": {

--- a/test/unit/controller/skill-metadata-controller-test.js
+++ b/test/unit/controller/skill-metadata-controller-test.js
@@ -377,6 +377,7 @@ describe("Controller test - skill metadata controller test", () => {
 
     beforeEach(() => {
       skillMetaController = new SkillMetadataController(TEST_CONFIGURATION);
+      sinon.stub(ResourcesConfig.prototype, "write").returns("");
     });
 
 

--- a/test/unit/fixture/model/regular-proj/.ask/ask-states.json
+++ b/test/unit/fixture/model/regular-proj/.ask/ask-states.json
@@ -5,7 +5,9 @@
       "skillId": "amzn1.ask.skill.1234567890",
       "skillMetadata": {
         "lastDeployHash": "hash==",
-        "lastDeployType": "interaction-model"
+        "lastDeployType": "interaction-model",
+        "lastImportId": "amzn1.ask-package.import.123abc",
+        "lastImportTimestamp": "2023-11-21T04:01:31.047Z"
       },
       "code": {
         "default": {
@@ -16,7 +18,8 @@
         },
         "NA": {
           "lastDeployHash": "hash=="
-        }
+        },
+        "lastDeployTimestamp": "2023-11-21T03:07:07.820Z"
       },
       "skillInfrastructure": {
         "@ask-cli/cfn-deployer": {
@@ -47,7 +50,8 @@
             }
           }
         }
-      }
+      },
+      "deploymentStatus": "COMPLETE"
     }
   }
 }

--- a/test/unit/model/resources-config/resources-config-test.js
+++ b/test/unit/model/resources-config/resources-config-test.js
@@ -156,6 +156,18 @@ describe("Model test - resources config test", () => {
           oldValue: TEST_ASK_STATES.profiles[TEST_PROFILE].skillId,
         },
         {
+          field: "LastImportId",
+          params: [TEST_PROFILE],
+          newValue: "LastImportId new",
+          oldValue: TEST_ASK_STATES.profiles[TEST_PROFILE].skillMetadata.lastImportId,
+        },
+        {
+          field: "LastImportTimestamp",
+          params: [TEST_PROFILE],
+          newValue: "LastImportTimestamp new",
+          oldValue: TEST_ASK_STATES.profiles[TEST_PROFILE].skillMetadata.lastImportTimestamp,
+        },
+        {
           field: "SkillMetaSrc",
           params: [TEST_PROFILE],
           newValue: "new skillMetadata src",
@@ -166,6 +178,18 @@ describe("Model test - resources config test", () => {
           params: [TEST_PROFILE],
           newValue: "==hash",
           oldValue: TEST_ASK_STATES.profiles[TEST_PROFILE].skillMetadata.lastDeployHash,
+        },
+        {
+          field: "CodeLastDeployTimestamp",
+          params: [TEST_PROFILE],
+          newValue: "CodeLastDeployTimestamp new",
+          oldValue: TEST_ASK_STATES.profiles[TEST_PROFILE].code.lastDeployTimestamp,
+        },
+        {
+          field: "DeploymentStatus",
+          params: [TEST_PROFILE],
+          newValue: "deploymentStatus new",
+          oldValue: TEST_ASK_STATES.profiles[TEST_PROFILE].deploymentStatus,
         },
       ].forEach(({field, params, newValue, oldValue}) => {
         it(`| test get${field} function successfully`, () => {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

with this change the ask-state file preserves a bit more deployment metadata. 

* **Last Import Id**: The SMAPI import-id during the skill metadata was previously printed on the terminal, but if the terminal was closed it was impossible to fetch import status.  By saving this to file you we can work on ask-cli features that would fetch previous imports status. 
* **Skill Metadata Last Import Timestamp**:  A timestamp at which the last successful import took place. 
* **Code Last Deploy Timestamp**: A timestamp at which the last code endpoint successful deployment.
* **Deployment Status**: shows if the ask-cli has an active deployment. it has two states: IN_PROGRESS | COMPLETE.


Other commits in this change: 

1. npm audit fix a few dependencies in ```package-lock.json``` file
2. Hosted skill ```ask new``` workflow was broken due to invalid invocation name ```Hello World Skill```.  This was failing to build the model due to Upper casing and the word ```Skill``` in the name. Fixed by changing the Default Skill Name which is what the template was using to use as a Invocation name as well. 
3. updating the auto assign reviewers list to include CamdenFoucht and tydonelson only.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
