### PR TITLE
chore(release): 2.30.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [2.30.6](https://github.com/alexa/ask-cli/compare/v2.30.5...v2.30.6) (2023-12-09)
+
+### Features
+
+* add ASK_FORCE_ENABLE to allow skipping domain validation during enablement ([487f8db](https://github.com/alexa/ask-cli/commit/487f8dbcdc9429d04b6fd475aa4a2a8430831f1f))
+
+### Bug Fixes
+
+* display message property for all error instance types ([a0d2f19](https://github.com/alexa/ask-cli/commit/a0d2f19faeee36523be701522585272cff2a2d6d))
+* use npm registry https url ([9e92ee5](https://github.com/alexa/ask-cli/commit/9e92ee5bf9aedcba1f683c1db877d0a9c1442cae))
+
 ### [2.30.5](https://github.com/alexa/ask-cli/compare/v2.30.4...v2.30.5) (2023-08-09)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ask-cli",
-  "version": "2.30.5",
+  "version": "2.30.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ask-cli",
-      "version": "2.30.5",
+      "version": "2.30.6",
       "hasInstallScript": true,
       "license": "Apache 2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ask-cli",
-  "version": "2.30.5",
+  "version": "2.30.6",
   "description": "Alexa Skills Kit (ASK) Command Line Interfaces",
   "bin": {
     "ask": "dist/bin/ask.js"


### PR DESCRIPTION
## Notes

### [2.30.6](https://github.com/alexa/ask-cli/compare/v2.30.4...v2.30.6) (2023-12-09)

### Features
* ASK State Updates ([#498](https://github.com/alexa/ask-cli/pull/408)) 

### Bug Fixes

* deploy skill package when icon uri path relative to its asset files ([#487](https://github.com/alexa/ask-cli/issues/487)) ([4b6ac2f](https://github.com/alexa/ask-cli/commit/4b6ac2ff8cd8b6511bdcf42938f05518ecf31361))
* display message property for all error instance types ([a0d2f19](https://github.com/alexa/ask-cli/commit/a0d2f19faeee36523be701522585272cff2a2d6d))
* display warning object message correctly ([#488](https://github.com/alexa/ask-cli/issues/488)) ([abbdc57](https://github.com/alexa/ask-cli/commit/abbdc574df25757990d2101d931cc6d063f64af2))
* use npm registry https url ([9e92ee5](https://github.com/alexa/ask-cli/commit/9e92ee5bf9aedcba1f683c1db877d0a9c1442cae))