### PR TITLE
feat: add ASK_SKIP_DOMAIN_VALIDATION to allow skipping manifest api v…

### DIFF
--- a/lib/controllers/skill-metadata-controller/index.js
+++ b/lib/controllers/skill-metadata-controller/index.js
@@ -111,6 +111,11 @@ module.exports = class SkillMetadataController {
    * Validates domain info
    */
   validateDomain() {
+    if (process.env.ASK_FORCE_ENABLE) {
+      Messenger.getInstance().warn("The ASK_FORCE_ENABLE environment variable is set. Skipping domain validation.\n");
+      return;
+    }
+
     const domainInfo = Manifest.getInstance().getApis();
     if (!domainInfo || R.isEmpty(domainInfo)) {
       throw new CLiError('Skill information is not valid. Please make sure "apis" field in the skill.json is not empty.');


### PR DESCRIPTION
…alidation prior to skill enablement

*Issue #, if available:*

*Description of changes:*

if attempting to deploy a skill that is anything other than custom or music the domain validation will fail and prevent skill enablement from being attempted.  By setting the following env variable, the cli will ignore your manifest domain apis and attempt to enable the skill without any prior checks.

```ASK_FORCE_ENABLE```


example usage: 

```
ASK_FORCE_ENABLE=1 ask deploy
```

you'll see a warning show up on the terminal stating that the env variable was detected and validation was skipped 

```
==================== Enable Skill ====================
[Warn]: The ASK_FORCE_ENABLE environment variable is set. Skipping domain validation.

The skill has been enabled.
```


**Note:** You should not set this env variable, if you have a smartHome skill or any other skill types known to fail skill enablement. It will just make extra service api calls that will end up failing.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
