### PR TITLE
Hosted Skills default python version upgrade to Python3.8

### DIFF
--- a/docs/concepts/Alexa-Hosted-Skill-Commands.md
+++ b/docs/concepts/Alexa-Hosted-Skill-Commands.md
@@ -20,7 +20,7 @@ Users will be asked the following questions to create a new skill:
 
 * Prompts user for `programming language`
   * Select programming language
-    * AHS supports Python3.7 and Node12.x
+    * AHS supports Python3.8 and Node16.x
 * Prompts user for a method to host your skill's backend resources
   * Select `Alexa-hosted skills`
 * Prompts user for `skill name`

--- a/lib/utils/constants.js
+++ b/lib/utils/constants.js
@@ -63,7 +63,7 @@ module.exports.HOSTED_SKILL = {
   },
   DEFAULT_RUNTIME: {
     NodeJS: "NODE_16_X",
-    Python: "PYTHON_3_7",
+    Python: "PYTHON_3_8",
   },
   SIGNIN_PATH: "/ap/signin",
   PERMISSION_ENUM: {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Change default Python version for hosted skills to 3.8


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
