### PR TITLE
fix: get skill status should only poll when in progress

### DIFF
--- a/lib/controllers/hosted-skill-controller/helper.js
+++ b/lib/controllers/hosted-skill-controller/helper.js
@@ -67,15 +67,18 @@ function pollingSkillStatus(smapiClient, skillId, callback) {
         response,
       );
     }
+    
+    const empty = (data) => !data || R.isEmpty(data);
+    
     return (
-      !statusTracker.manifest ||
-      !statusTracker.interactionModel ||
-      !statusTracker.hostedSkillProvisioning ||
-      !(
-        statusTracker.manifest === CONSTANTS.HOSTED_SKILL.MANIFEST_STATUS.SUCCESS &&
-        statusTracker.interactionModel === CONSTANTS.HOSTED_SKILL.INTERACTION_MODEL_STATUS.SUCCESS &&
-        statusTracker.hostedSkillProvisioning === CONSTANTS.HOSTED_SKILL.PROVISIONING_STATUS.SUCCESS
-      )
+      // retry if one of manifest, interaction model, provisioning don't exist
+      empty(statusTracker.manifest) ||
+      empty(statusTracker.interactionModel) ||
+      empty(statusTracker.hostedSkillProvisioning) ||
+      // retry if one of manifest, interaction model, provisioning are in progress
+      statusTracker.manifest === CONSTANTS.HOSTED_SKILL.MANIFEST_STATUS.IN_PROGRESS ||
+      statusTracker.interactionModel === CONSTANTS.HOSTED_SKILL.INTERACTION_MODEL_STATUS.IN_PROGRESS ||
+      statusTracker.hostedSkillProvisioning === CONSTANTS.HOSTED_SKILL.PROVISIONING_STATUS.IN_PROGRESS
     );
   };
   retryUtils.retry(retryConfig, retryCall, shouldRetryCondition, (err) => callback(err, err ? null : statusTracker));


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Currently, `ask new` continues polling for >15 minutes when one of the steps has failed, instead of displaying the error message. This CR will ensure polling occurs when a step is in progress.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
